### PR TITLE
Add CI and fix clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -38,7 +38,7 @@ fn median(values: &[f32]) -> f32 {
     let mut sorted: Vec<f32> = values.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let n = sorted.len();
-    if n % 2 == 0 {
+    if n.is_multiple_of(2) {
         (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
     } else {
         sorted[n / 2]

--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -55,7 +55,7 @@ impl<const DIM: usize> KdTree<DIM> {
         };
 
         let mut order: Vec<usize> = (0..n).collect();
-        tree.build_recursive(&mut order, 0, n, 0);
+        tree.build_recursive(&mut order, 0, n);
 
         let old_points = tree.points.clone();
         let old_indices = tree.indices.clone();
@@ -67,13 +67,7 @@ impl<const DIM: usize> KdTree<DIM> {
         tree
     }
 
-    fn build_recursive(
-        &mut self,
-        order: &mut [usize],
-        start: usize,
-        end: usize,
-        depth: usize,
-    ) -> usize {
+    fn build_recursive(&mut self, order: &mut [usize], start: usize, end: usize) -> usize {
         let count = end - start;
 
         if count <= LEAF_SIZE {
@@ -91,8 +85,8 @@ impl<const DIM: usize> KdTree<DIM> {
         let node_idx = self.nodes.len();
         self.nodes.push(Node::Leaf { start: 0, end: 0 });
 
-        let left = self.build_recursive(order, start, median_pos, depth + 1);
-        let right = self.build_recursive(order, median_pos, end, depth + 1);
+        let left = self.build_recursive(order, start, median_pos);
+        let right = self.build_recursive(order, median_pos, end);
 
         self.nodes[node_idx] = Node::Split {
             dim: split_dim,


### PR DESCRIPTION
## Summary

- Adds GitHub Actions CI workflow with three parallel jobs: `fmt` (cargo fmt --check), `clippy` (cargo clippy -- -D warnings), and `test` (cargo test)
- Runs on pushes to main and PRs targeting main
- Uses rust-cache for faster builds
- Fixes two clippy warnings: `n % 2 == 0` → `n.is_multiple_of(2)` in extraction.rs, unused `depth` parameter in kdtree.rs

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (55 tests)