### PR TITLE
Add SIP distortion and iterative refinement

### DIFF
--- a/src/geom/mod.rs
+++ b/src/geom/mod.rs
@@ -1,2 +1,3 @@
+pub mod sip;
 pub mod sphere;
 pub mod tan;

--- a/src/geom/sip.rs
+++ b/src/geom/sip.rs
@@ -1,0 +1,313 @@
+use super::sphere;
+use super::tan::TanWcs;
+
+/// SIP (Simple Imaging Polynomial) WCS distortion model.
+///
+/// Extends the standard TAN projection with polynomial distortion terms
+/// that model optical aberrations such as barrel/pincushion distortion.
+///
+/// Forward direction (pixel -> sky):
+///   u, v = pixel offset from crpix
+///   U = u + sum(A[p][q] * u^p * v^q)  for p+q >= 2
+///   V = v + sum(B[p][q] * u^p * v^q)  for p+q >= 2
+///   Then CD * (U, V) -> intermediate world coordinates -> sphere
+///
+/// Inverse direction (sky -> pixel):
+///   Get (U, V) from TAN inverse projection
+///   u = U + sum(AP[p][q] * U^p * V^q)  for p+q >= 2
+///   v = V + sum(BP[p][q] * U^p * V^q)  for p+q >= 2
+///   pixel = (u + crpix[0], v + crpix[1])
+#[derive(Debug, Clone)]
+pub struct SipWcs {
+    /// Underlying TAN WCS.
+    pub tan: TanWcs,
+    /// Forward distortion coefficients for U.
+    pub a: Vec<Vec<f64>>,
+    /// Forward distortion coefficients for V.
+    pub b: Vec<Vec<f64>>,
+    /// Order of forward A polynomial.
+    pub a_order: usize,
+    /// Order of forward B polynomial.
+    pub b_order: usize,
+    /// Inverse distortion coefficients for u.
+    pub ap: Vec<Vec<f64>>,
+    /// Inverse distortion coefficients for v.
+    pub bp: Vec<Vec<f64>>,
+    /// Order of inverse AP polynomial.
+    pub ap_order: usize,
+    /// Order of inverse BP polynomial.
+    pub bp_order: usize,
+}
+
+/// Evaluate a SIP polynomial: sum(coeffs[p][q] * u^p * v^q) for p+q >= 2.
+fn eval_polynomial(coeffs: &[Vec<f64>], order: usize, u: f64, v: f64) -> f64 {
+    let mut result = 0.0;
+    let mut u_pow = 1.0; // u^p
+    for p in 0..=order {
+        let mut v_pow = 1.0; // v^q
+        for q in 0..=order {
+            if p + q >= 2 && p < coeffs.len() && q < coeffs[p].len() {
+                result += coeffs[p][q] * u_pow * v_pow;
+            }
+            v_pow *= v;
+        }
+        u_pow *= u;
+    }
+    result
+}
+
+/// Create a zero-filled 2D coefficient array of size (order+1) x (order+1).
+pub fn zero_coeffs(order: usize) -> Vec<Vec<f64>> {
+    vec![vec![0.0; order + 1]; order + 1]
+}
+
+impl SipWcs {
+    /// Create an identity SIP WCS (zero distortion coefficients) from a TAN WCS.
+    pub fn from_tan(tan: TanWcs, order: usize) -> Self {
+        SipWcs {
+            a: zero_coeffs(order),
+            b: zero_coeffs(order),
+            a_order: order,
+            b_order: order,
+            ap: zero_coeffs(order),
+            bp: zero_coeffs(order),
+            ap_order: order,
+            bp_order: order,
+            tan,
+        }
+    }
+
+    /// Convert pixel coordinates to a unit vector on the celestial sphere.
+    pub fn pixel_to_xyz(&self, px: f64, py: f64) -> [f64; 3] {
+        let u = px - self.tan.crpix[0];
+        let v = py - self.tan.crpix[1];
+
+        // Apply forward SIP distortion.
+        let u_dist = u + eval_polynomial(&self.a, self.a_order, u, v);
+        let v_dist = v + eval_polynomial(&self.b, self.b_order, u, v);
+
+        // Apply CD matrix to get intermediate world coordinates.
+        let x = self.tan.cd[0][0] * u_dist + self.tan.cd[0][1] * v_dist;
+        let y = self.tan.cd[1][0] * u_dist + self.tan.cd[1][1] * v_dist;
+
+        self.tan.iwc_to_xyz(x, y)
+    }
+
+    /// Convert a unit vector on the celestial sphere to pixel coordinates.
+    ///
+    /// Returns `None` if the point is behind the tangent plane.
+    pub fn xyz_to_pixel(&self, xyz: [f64; 3]) -> Option<(f64, f64)> {
+        let reference = sphere::radec_to_xyz(self.tan.crval[0], self.tan.crval[1]);
+        let (x, y) = sphere::star_coords(xyz, reference)?;
+
+        // Invert CD matrix to get undistorted pixel offsets (U, V).
+        let det = self.tan.cd[0][0] * self.tan.cd[1][1] - self.tan.cd[0][1] * self.tan.cd[1][0];
+        let inv_det = 1.0 / det;
+        let u_big = inv_det * (self.tan.cd[1][1] * x - self.tan.cd[0][1] * y);
+        let v_big = inv_det * (-self.tan.cd[1][0] * x + self.tan.cd[0][0] * y);
+
+        // Apply inverse SIP polynomial to recover original pixel offsets.
+        let u = u_big + eval_polynomial(&self.ap, self.ap_order, u_big, v_big);
+        let v = v_big + eval_polynomial(&self.bp, self.bp_order, u_big, v_big);
+
+        Some((u + self.tan.crpix[0], v + self.tan.crpix[1]))
+    }
+
+    /// Convert pixel coordinates to (RA, Dec) in radians.
+    pub fn pixel_to_radec(&self, px: f64, py: f64) -> (f64, f64) {
+        sphere::xyz_to_radec(self.pixel_to_xyz(px, py))
+    }
+
+    /// Convert (RA, Dec) in radians to pixel coordinates.
+    ///
+    /// Returns `None` if the position is behind the tangent plane.
+    pub fn radec_to_pixel(&self, ra: f64, dec: f64) -> Option<(f64, f64)> {
+        self.xyz_to_pixel(sphere::radec_to_xyz(ra, dec))
+    }
+
+    /// Approximate pixel scale in degrees per pixel from the CD matrix determinant.
+    pub fn pixel_scale(&self) -> f64 {
+        self.tan.pixel_scale()
+    }
+
+    /// RA, Dec (radians) of the image center pixel.
+    pub fn field_center(&self) -> (f64, f64) {
+        self.pixel_to_radec(self.tan.image_size[0] / 2.0, self.tan.image_size[1] / 2.0)
+    }
+
+    /// Angular radius (radians) of the smallest circle centered on the image
+    /// center that encloses all four corners.
+    pub fn field_radius(&self) -> f64 {
+        let (cx, cy) = (self.tan.image_size[0] / 2.0, self.tan.image_size[1] / 2.0);
+        let center = self.pixel_to_xyz(cx, cy);
+        let w = self.tan.image_size[0];
+        let h = self.tan.image_size[1];
+
+        [
+            self.pixel_to_xyz(0.0, 0.0),
+            self.pixel_to_xyz(w, 0.0),
+            self.pixel_to_xyz(0.0, h),
+            self.pixel_to_xyz(w, h),
+        ]
+        .iter()
+        .map(|c| sphere::angular_distance(center, *c))
+        .fold(0.0_f64, f64::max)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::PI;
+
+    const EPS: f64 = 1e-10;
+
+    fn assert_close(a: f64, b: f64, tol: f64) {
+        assert!(
+            (a - b).abs() < tol,
+            "expected {a} ~= {b} (diff = {})",
+            (a - b).abs()
+        );
+    }
+
+    fn test_tan_wcs() -> TanWcs {
+        let arcsec_rad = (1.0_f64 / 3600.0).to_radians();
+        TanWcs {
+            crval: [PI, 0.25],
+            crpix: [512.0, 512.0],
+            cd: [[arcsec_rad, 0.0], [0.0, arcsec_rad]],
+            image_size: [1024.0, 1024.0],
+        }
+    }
+
+    #[test]
+    fn identity_sip_matches_tan() {
+        let tan = test_tan_wcs();
+        let sip = SipWcs::from_tan(tan.clone(), 3);
+
+        for &(px, py) in &[
+            (512.0, 512.0),
+            (0.0, 0.0),
+            (1024.0, 1024.0),
+            (256.0, 768.0),
+            (100.0, 900.0),
+        ] {
+            let tan_xyz = tan.pixel_to_xyz(px, py);
+            let sip_xyz = sip.pixel_to_xyz(px, py);
+            for i in 0..3 {
+                assert_close(tan_xyz[i], sip_xyz[i], EPS);
+            }
+
+            let (tan_ra, tan_dec) = tan.pixel_to_radec(px, py);
+            let (sip_ra, sip_dec) = sip.pixel_to_radec(px, py);
+            assert_close(tan_ra, sip_ra, EPS);
+            assert_close(tan_dec, sip_dec, EPS);
+
+            let (tan_px, tan_py) = tan.xyz_to_pixel(tan_xyz).unwrap();
+            let (sip_px, sip_py) = sip.xyz_to_pixel(tan_xyz).unwrap();
+            assert_close(tan_px, sip_px, 1e-6);
+            assert_close(tan_py, sip_py, 1e-6);
+        }
+    }
+
+    #[test]
+    fn barrel_distortion_round_trip() {
+        let tan = test_tan_wcs();
+        let mut sip = SipWcs::from_tan(tan, 3);
+
+        // Apply known barrel distortion: A[2][0] and B[0][2] coefficients.
+        let k = 1e-6;
+        sip.a[2][0] = k;
+        sip.b[0][2] = k;
+
+        // Compute matching inverse coefficients.
+        // For small distortion, AP ~ -A and BP ~ -B to first order.
+        sip.ap[2][0] = -k;
+        sip.bp[0][2] = -k;
+
+        // Test round-trip at various positions.
+        for &(px, py) in &[
+            (512.0, 512.0),
+            (256.0, 256.0),
+            (768.0, 768.0),
+            (100.0, 512.0),
+            (512.0, 100.0),
+            (200.0, 800.0),
+        ] {
+            let (ra, dec) = sip.pixel_to_radec(px, py);
+            let (px2, py2) = sip.radec_to_pixel(ra, dec).unwrap();
+            assert_close(px, px2, 0.1);
+            assert_close(py, py2, 0.1);
+        }
+    }
+
+    #[test]
+    fn pixel_scale_at_center_matches_tan() {
+        let tan = test_tan_wcs();
+        let sip = SipWcs::from_tan(tan.clone(), 3);
+
+        assert_close(sip.pixel_scale(), tan.pixel_scale(), 1e-15);
+    }
+
+    #[test]
+    fn distortion_moves_edge_pixels() {
+        let tan = test_tan_wcs();
+        let mut sip = SipWcs::from_tan(tan.clone(), 3);
+
+        let k = 1e-6;
+        sip.a[2][0] = k;
+        sip.b[0][2] = k;
+
+        // At crpix, distortion should be zero since u=v=0.
+        let sip_center = sip.pixel_to_xyz(512.0, 512.0);
+        let tan_center = tan.pixel_to_xyz(512.0, 512.0);
+        for i in 0..3 {
+            assert_close(sip_center[i], tan_center[i], EPS);
+        }
+
+        // At corner, distortion should shift the result.
+        let sip_corner = sip.pixel_to_xyz(0.0, 0.0);
+        let tan_corner = tan.pixel_to_xyz(0.0, 0.0);
+        let dist = sphere::angular_distance(sip_corner, tan_corner);
+        assert!(
+            dist > 1e-8,
+            "expected distortion to move corner, got dist = {dist}"
+        );
+    }
+
+    #[test]
+    fn eval_polynomial_zero_coeffs() {
+        let coeffs = zero_coeffs(3);
+        let val = eval_polynomial(&coeffs, 3, 100.0, 200.0);
+        assert_close(val, 0.0, EPS);
+    }
+
+    #[test]
+    fn eval_polynomial_known_value() {
+        // Set A[2][0] = 1.0 => result should be u^2.
+        let mut coeffs = zero_coeffs(3);
+        coeffs[2][0] = 1.0;
+        let val = eval_polynomial(&coeffs, 3, 5.0, 3.0);
+        assert_close(val, 25.0, EPS);
+
+        // Set A[1][1] = 2.0 additionally => result = u^2 + 2*u*v.
+        coeffs[1][1] = 2.0;
+        let val = eval_polynomial(&coeffs, 3, 5.0, 3.0);
+        assert_close(val, 25.0 + 30.0, EPS);
+    }
+
+    #[test]
+    fn field_center_and_radius() {
+        let tan = test_tan_wcs();
+        let sip = SipWcs::from_tan(tan.clone(), 3);
+
+        let (sip_ra, sip_dec) = sip.field_center();
+        let (tan_ra, tan_dec) = tan.field_center();
+        assert_close(sip_ra, tan_ra, EPS);
+        assert_close(sip_dec, tan_dec, EPS);
+
+        let sip_r = sip.field_radius();
+        let tan_r = tan.field_radius();
+        assert_close(sip_r, tan_r, 1e-8);
+    }
+}

--- a/src/geom/tan.rs
+++ b/src/geom/tan.rs
@@ -89,7 +89,7 @@ impl TanWcs {
     /// to a unit vector on the sphere.
     ///
     /// Follows the astrometry.net `tan_iwc2xyzarr` algorithm.
-    fn iwc_to_xyz(&self, x: f64, y: f64) -> [f64; 3] {
+    pub(crate) fn iwc_to_xyz(&self, x: f64, y: f64) -> [f64; 3] {
         let x = -x;
 
         let r = sphere::radec_to_xyz(self.crval[0], self.crval[1]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,4 +12,5 @@ pub mod index;
 pub mod kdtree;
 pub mod quads;
 pub mod solver;
+pub mod tweak;
 pub mod verify;

--- a/src/tweak.rs
+++ b/src/tweak.rs
@@ -1,0 +1,547 @@
+//! Iterative SIP distortion refinement.
+//!
+//! Given an initial TAN WCS and matched field/index sources, fits SIP
+//! polynomial distortion coefficients to reduce systematic residuals.
+
+use crate::extraction::DetectedSource;
+use crate::fitting::FitError;
+use crate::geom::sip::{SipWcs, zero_coeffs};
+use crate::geom::sphere::radec_to_xyz;
+use crate::geom::tan::TanWcs;
+use crate::index::Index;
+use crate::kdtree::KdTree;
+
+/// Refine an initial TAN WCS by fitting SIP distortion polynomials.
+///
+/// Algorithm per iteration:
+/// 1. Project index stars in the field of view to pixels using the current WCS
+/// 2. Match field sources to nearest projected reference star (using KdTree<2>)
+/// 3. Compute residuals between TAN-predicted pixel and actual field pixel
+/// 4. Build a Vandermonde matrix with u^p * v^q terms (p+q >= 2, p+q <= order)
+/// 5. Solve normal equations for A, B coefficients
+/// 6. Compute inverse AP, BP by fitting the reverse direction
+/// 7. Update SipWcs and repeat
+pub fn tweak_solution(
+    initial_wcs: &TanWcs,
+    field_sources: &[DetectedSource],
+    index: &Index,
+    sip_order: usize,
+    iterations: usize,
+) -> Result<SipWcs, FitError> {
+    if field_sources.len() < 3 {
+        return Err(FitError::TooFewCorrespondences);
+    }
+
+    let mut sip = SipWcs::from_tan(initial_wcs.clone(), sip_order);
+
+    // Build a 2D KD-tree of field source positions for matching.
+    let field_points: Vec<[f64; 2]> = field_sources.iter().map(|s| [s.x, s.y]).collect();
+    let field_indices: Vec<usize> = (0..field_sources.len()).collect();
+    let field_tree = KdTree::<2>::build(field_points, field_indices);
+
+    // Enumerate the (p, q) terms where p+q >= 2 and p+q <= order.
+    let terms = sip_terms(sip_order);
+    let n_terms = terms.len();
+
+    if n_terms == 0 {
+        return Ok(sip);
+    }
+
+    for _iter in 0..iterations {
+        // Step 1: Find reference stars in field of view.
+        let (center_ra, center_dec) = sip.field_center();
+        let center_xyz = radec_to_xyz(center_ra, center_dec);
+        let field_radius = sip.field_radius();
+        let radius_sq = 2.0 * (1.0 - field_radius.cos());
+        let nearby = index.star_tree.range_search(&center_xyz, radius_sq);
+
+        // Step 2: Project reference stars to pixels, match to field sources.
+        let match_radius_sq = 25.0; // 5 pixel match radius
+        let mut matched_ref_px = Vec::new();
+        let mut matched_field_px = Vec::new();
+
+        for result in &nearby {
+            let star = &index.stars[result.index];
+            let xyz = radec_to_xyz(star.ra, star.dec);
+
+            // Use TAN projection to get undistorted predicted pixel position.
+            let tan_pixel = sip.tan.xyz_to_pixel(xyz);
+            let (tan_px, tan_py) = match tan_pixel {
+                Some(p) => p,
+                None => continue,
+            };
+
+            // Skip if outside image bounds with margin.
+            let margin = 10.0;
+            if tan_px < -margin
+                || tan_px > sip.tan.image_size[0] + margin
+                || tan_py < -margin
+                || tan_py > sip.tan.image_size[1] + margin
+            {
+                continue;
+            }
+
+            // Find nearest field source.
+            let query = [tan_px, tan_py];
+            if let Some(nearest) = field_tree.nearest(&query)
+                && nearest.dist_sq <= match_radius_sq
+            {
+                let fs = &field_sources[nearest.index];
+                matched_ref_px.push((tan_px, tan_py));
+                matched_field_px.push((fs.x, fs.y));
+            }
+        }
+
+        let n_matches = matched_ref_px.len();
+        if n_matches < n_terms + 1 {
+            break;
+        }
+
+        // Step 3-5: Compute residuals and fit A, B polynomials.
+        // Residuals: the TAN projection predicts tan_px, but the actual field source
+        // is at field_px. The SIP forward distortion maps:
+        //   U = u + SIP_A(u,v)
+        // where u = field_px - crpix (the actual pixel offset), and U is what
+        // the CD matrix converts to IWC. The TAN inverse gives us U = tan_px - crpix.
+        // So: delta_u = (tan_px - crpix) - (field_px - crpix) = tan_px - field_px
+        // and we want: SIP_A(u,v) = delta_u, i.e., the correction to add to u
+        // so that the distorted position matches the TAN predicted position.
+
+        let crpix = sip.tan.crpix;
+
+        // For the forward coefficients A, B:
+        // u, v = field pixel offset from crpix.
+        // We want A(u,v) such that u + A(u,v) = U_tan = tan_px - crpix.
+        // So A(u,v) = (tan_px - crpix) - u = tan_px - field_px.
+        let mut delta_u_fwd = Vec::with_capacity(n_matches);
+        let mut delta_v_fwd = Vec::with_capacity(n_matches);
+        let mut u_fwd = Vec::with_capacity(n_matches);
+        let mut v_fwd = Vec::with_capacity(n_matches);
+
+        for i in 0..n_matches {
+            let u = matched_field_px[i].0 - crpix[0];
+            let v = matched_field_px[i].1 - crpix[1];
+            let du = matched_ref_px[i].0 - matched_field_px[i].0;
+            let dv = matched_ref_px[i].1 - matched_field_px[i].1;
+            u_fwd.push(u);
+            v_fwd.push(v);
+            delta_u_fwd.push(du);
+            delta_v_fwd.push(dv);
+        }
+
+        // Build Vandermonde matrix and solve.
+        let vandermonde_fwd = build_vandermonde(&u_fwd, &v_fwd, &terms);
+
+        let a_coeffs = solve_normal_equations(&vandermonde_fwd, &delta_u_fwd, n_terms);
+        let b_coeffs = solve_normal_equations(&vandermonde_fwd, &delta_v_fwd, n_terms);
+
+        if let Some(a_c) = a_coeffs {
+            sip.a = unpack_coefficients(&a_c, &terms, sip_order);
+        }
+        if let Some(b_c) = b_coeffs {
+            sip.b = unpack_coefficients(&b_c, &terms, sip_order);
+        }
+
+        // Step 6: Compute inverse AP, BP.
+        // For inverse: U, V = TAN-predicted pixel offset from crpix.
+        // We want AP(U,V) such that u = U + AP(U,V), i.e.,
+        // AP(U,V) = field_px - crpix - (tan_px - crpix) = field_px - tan_px = -delta_u.
+        let mut u_inv = Vec::with_capacity(n_matches);
+        let mut v_inv = Vec::with_capacity(n_matches);
+        let mut delta_u_inv = Vec::with_capacity(n_matches);
+        let mut delta_v_inv = Vec::with_capacity(n_matches);
+
+        for i in 0..n_matches {
+            let u_big = matched_ref_px[i].0 - crpix[0];
+            let v_big = matched_ref_px[i].1 - crpix[1];
+            u_inv.push(u_big);
+            v_inv.push(v_big);
+            delta_u_inv.push(-delta_u_fwd[i]);
+            delta_v_inv.push(-delta_v_fwd[i]);
+        }
+
+        let vandermonde_inv = build_vandermonde(&u_inv, &v_inv, &terms);
+
+        let ap_coeffs = solve_normal_equations(&vandermonde_inv, &delta_u_inv, n_terms);
+        let bp_coeffs = solve_normal_equations(&vandermonde_inv, &delta_v_inv, n_terms);
+
+        if let Some(ap_c) = ap_coeffs {
+            sip.ap = unpack_coefficients(&ap_c, &terms, sip_order);
+        }
+        if let Some(bp_c) = bp_coeffs {
+            sip.bp = unpack_coefficients(&bp_c, &terms, sip_order);
+        }
+    }
+
+    Ok(sip)
+}
+
+/// Enumerate (p, q) pairs where p+q >= 2 and p+q <= order.
+fn sip_terms(order: usize) -> Vec<(usize, usize)> {
+    let mut terms = Vec::new();
+    for total in 2..=order {
+        for p in 0..=total {
+            let q = total - p;
+            terms.push((p, q));
+        }
+    }
+    terms
+}
+
+/// Build a Vandermonde matrix for the SIP polynomial terms.
+/// Returns a flat row-major matrix of size n_points x n_terms.
+fn build_vandermonde(u: &[f64], v: &[f64], terms: &[(usize, usize)]) -> Vec<f64> {
+    let n = u.len();
+    let n_terms = terms.len();
+    let mut matrix = vec![0.0; n * n_terms];
+
+    for i in 0..n {
+        for (j, &(p, q)) in terms.iter().enumerate() {
+            matrix[i * n_terms + j] = u[i].powi(p as i32) * v[i].powi(q as i32);
+        }
+    }
+
+    matrix
+}
+
+/// Solve M^T * M * x = M^T * b via Gaussian elimination with partial pivoting.
+///
+/// M is n_rows x n_cols stored row-major. b is length n_rows.
+/// Returns the solution vector of length n_cols, or None if singular.
+fn solve_normal_equations(m: &[f64], b: &[f64], n_cols: usize) -> Option<Vec<f64>> {
+    let n_rows = b.len();
+
+    // Compute M^T * M (n_cols x n_cols, symmetric).
+    let mut mtm = vec![0.0; n_cols * n_cols];
+    for i in 0..n_cols {
+        for j in i..n_cols {
+            let mut s = 0.0;
+            for k in 0..n_rows {
+                s += m[k * n_cols + i] * m[k * n_cols + j];
+            }
+            mtm[i * n_cols + j] = s;
+            mtm[j * n_cols + i] = s;
+        }
+    }
+
+    // Compute M^T * b (length n_cols).
+    let mut mtb = vec![0.0; n_cols];
+    for i in 0..n_cols {
+        let mut s = 0.0;
+        for k in 0..n_rows {
+            s += m[k * n_cols + i] * b[k];
+        }
+        mtb[i] = s;
+    }
+
+    // Solve mtm * x = mtb via Gaussian elimination with partial pivoting.
+    solve_linear_system(&mut mtm, &mut mtb, n_cols)
+}
+
+/// Solve A * x = b in place using Gaussian elimination with partial pivoting.
+/// A is n x n stored row-major. b is length n.
+/// Returns the solution vector or None if singular.
+fn solve_linear_system(a: &mut [f64], b: &mut [f64], n: usize) -> Option<Vec<f64>> {
+    // Forward elimination with partial pivoting.
+    for col in 0..n {
+        // Find pivot.
+        let mut max_val = a[col * n + col].abs();
+        let mut max_row = col;
+        for row in (col + 1)..n {
+            let v = a[row * n + col].abs();
+            if v > max_val {
+                max_val = v;
+                max_row = row;
+            }
+        }
+
+        if max_val < 1e-30 {
+            return None;
+        }
+
+        // Swap rows.
+        if max_row != col {
+            for j in 0..n {
+                a.swap(col * n + j, max_row * n + j);
+            }
+            b.swap(col, max_row);
+        }
+
+        // Eliminate below.
+        let pivot = a[col * n + col];
+        for row in (col + 1)..n {
+            let factor = a[row * n + col] / pivot;
+            for j in col..n {
+                a[row * n + j] -= factor * a[col * n + j];
+            }
+            b[row] -= factor * b[col];
+        }
+    }
+
+    // Back substitution.
+    let mut x = vec![0.0; n];
+    for col in (0..n).rev() {
+        let mut sum = b[col];
+        for j in (col + 1)..n {
+            sum -= a[col * n + j] * x[j];
+        }
+        x[col] = sum / a[col * n + col];
+    }
+
+    Some(x)
+}
+
+/// Unpack a flat coefficient vector into a 2D array indexed by (p, q).
+fn unpack_coefficients(coeffs: &[f64], terms: &[(usize, usize)], order: usize) -> Vec<Vec<f64>> {
+    let mut result = zero_coeffs(order);
+    for (i, &(p, q)) in terms.iter().enumerate() {
+        if p <= order && q <= order {
+            result[p][q] = coeffs[i];
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extraction::DetectedSource;
+    use crate::geom::sphere::radec_to_xyz;
+    use crate::geom::tan::TanWcs;
+    use crate::index::{Index, IndexStar};
+    use crate::kdtree::KdTree;
+    use crate::quads::{DIMCODES, Quad};
+
+    fn make_test_wcs() -> TanWcs {
+        let arcsec_rad = (2.0_f64 / 3600.0).to_radians();
+        TanWcs {
+            crval: [1.0, 0.5],
+            crpix: [256.0, 256.0],
+            cd: [[arcsec_rad, 0.0], [0.0, arcsec_rad]],
+            image_size: [512.0, 512.0],
+        }
+    }
+
+    fn make_test_index(wcs: &TanWcs, n_stars: usize) -> (Vec<DetectedSource>, Index) {
+        let mut stars = Vec::new();
+        let mut sources = Vec::new();
+
+        let side = (n_stars as f64).sqrt().ceil() as usize;
+        let w = wcs.image_size[0];
+        let h = wcs.image_size[1];
+
+        let mut count = 0;
+        for iy in 0..side {
+            for ix in 0..side {
+                if count >= n_stars {
+                    break;
+                }
+                let px = w * 0.1 + w * 0.8 * (ix as f64) / (side as f64 - 1.0).max(1.0);
+                let py = h * 0.1 + h * 0.8 * (iy as f64) / (side as f64 - 1.0).max(1.0);
+                let (ra, dec) = wcs.pixel_to_radec(px, py);
+
+                stars.push(IndexStar {
+                    catalog_id: count as u64,
+                    ra,
+                    dec,
+                    mag: count as f64,
+                });
+                sources.push(DetectedSource {
+                    x: px,
+                    y: py,
+                    flux: 1000.0 - count as f64,
+                });
+                count += 1;
+            }
+        }
+
+        let points: Vec<[f64; 3]> = stars.iter().map(|s| radec_to_xyz(s.ra, s.dec)).collect();
+        let indices: Vec<usize> = (0..stars.len()).collect();
+        let star_tree = KdTree::<3>::build(points, indices);
+        let code_tree = KdTree::<{ DIMCODES }>::build(vec![], vec![]);
+        let quads: Vec<Quad> = vec![];
+
+        let index = Index {
+            star_tree,
+            stars,
+            code_tree,
+            quads,
+            scale_lower: 0.0,
+            scale_upper: 1.0,
+            metadata: None,
+        };
+
+        (sources, index)
+    }
+
+    #[test]
+    fn zero_distortion_gives_near_zero_coefficients() {
+        let wcs = make_test_wcs();
+        let (sources, index) = make_test_index(&wcs, 36);
+
+        let result = tweak_solution(&wcs, &sources, &index, 3, 3);
+        assert!(result.is_ok());
+
+        let sip = result.unwrap();
+
+        // All coefficients should be near zero since there's no distortion.
+        for p in 0..=sip.a_order {
+            for q in 0..=sip.a_order {
+                if p + q >= 2 {
+                    assert!(
+                        sip.a[p][q].abs() < 1e-10,
+                        "A[{p}][{q}] = {} should be ~0",
+                        sip.a[p][q]
+                    );
+                    assert!(
+                        sip.b[p][q].abs() < 1e-10,
+                        "B[{p}][{q}] = {} should be ~0",
+                        sip.b[p][q]
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn recovers_known_distortion() {
+        let wcs = make_test_wcs();
+        let k = 1e-7;
+
+        // Generate field sources with a known distortion applied.
+        // The "true" pixel positions are distorted from the TAN positions.
+        // u_distorted = u + k * u^2 => the field sources are at distorted positions.
+        let side = 8;
+        let w = wcs.image_size[0];
+        let h = wcs.image_size[1];
+        let mut stars = Vec::new();
+        let mut sources = Vec::new();
+
+        for iy in 0..side {
+            for ix in 0..side {
+                let px = w * 0.1 + w * 0.8 * (ix as f64) / (side as f64 - 1.0);
+                let py = h * 0.1 + h * 0.8 * (iy as f64) / (side as f64 - 1.0);
+                let (ra, dec) = wcs.pixel_to_radec(px, py);
+
+                stars.push(IndexStar {
+                    catalog_id: (iy * side + ix) as u64,
+                    ra,
+                    dec,
+                    mag: 10.0,
+                });
+
+                // The field source is at a distorted position.
+                // If the TAN WCS predicts pixel (px, py) for this star,
+                // and the actual source is displaced by the distortion,
+                // then the SIP should recover: SIP_A(u,v) = tan_px - field_px.
+                // With u = field_px - crpix, we want SIP_A ~ k*u^2 where
+                // the displacement = k*u^2.
+                let u = px - wcs.crpix[0];
+                let v = py - wcs.crpix[1];
+                let dx = k * u * u;
+                let dy = k * v * v;
+                sources.push(DetectedSource {
+                    x: px - dx,
+                    y: py - dy,
+                    flux: 1000.0,
+                });
+            }
+        }
+
+        let points: Vec<[f64; 3]> = stars.iter().map(|s| radec_to_xyz(s.ra, s.dec)).collect();
+        let indices: Vec<usize> = (0..stars.len()).collect();
+        let star_tree = KdTree::<3>::build(points, indices);
+        let code_tree = KdTree::<{ DIMCODES }>::build(vec![], vec![]);
+
+        let index = Index {
+            star_tree,
+            stars,
+            code_tree,
+            quads: vec![],
+            scale_lower: 0.0,
+            scale_upper: 1.0,
+            metadata: None,
+        };
+
+        let result = tweak_solution(&wcs, &sources, &index, 3, 5);
+        assert!(result.is_ok());
+
+        let sip = result.unwrap();
+
+        // The A[2][0] coefficient should be close to k.
+        assert!(
+            (sip.a[2][0] - k).abs() < k * 0.5,
+            "A[2][0] = {} expected ~{k}",
+            sip.a[2][0]
+        );
+        // The B[0][2] coefficient should be close to k.
+        assert!(
+            (sip.b[0][2] - k).abs() < k * 0.5,
+            "B[0][2] = {} expected ~{k}",
+            sip.b[0][2]
+        );
+    }
+
+    #[test]
+    fn too_few_sources_returns_error() {
+        let wcs = make_test_wcs();
+        let sources = vec![
+            DetectedSource {
+                x: 100.0,
+                y: 100.0,
+                flux: 1.0,
+            },
+            DetectedSource {
+                x: 200.0,
+                y: 200.0,
+                flux: 1.0,
+            },
+        ];
+
+        let (_, index) = make_test_index(&wcs, 10);
+        let result = tweak_solution(&wcs, &sources, &index, 3, 3);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn sip_terms_enumeration() {
+        let terms = sip_terms(2);
+        assert_eq!(terms, vec![(0, 2), (1, 1), (2, 0)]);
+
+        let terms = sip_terms(3);
+        assert_eq!(
+            terms,
+            vec![(0, 2), (1, 1), (2, 0), (0, 3), (1, 2), (2, 1), (3, 0)]
+        );
+    }
+
+    #[test]
+    fn linear_solver_identity() {
+        // Solve I * x = b => x = b.
+        let mut a = vec![1.0, 0.0, 0.0, 1.0];
+        let mut b = vec![3.0, 7.0];
+        let x = solve_linear_system(&mut a, &mut b, 2).unwrap();
+        assert!((x[0] - 3.0).abs() < 1e-12);
+        assert!((x[1] - 7.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn linear_solver_2x2() {
+        // [2 1] [x]   [5]
+        // [1 3] [y] = [7]
+        // x=8/5, y=9/5
+        let mut a = vec![2.0, 1.0, 1.0, 3.0];
+        let mut b = vec![5.0, 7.0];
+        let x = solve_linear_system(&mut a, &mut b, 2).unwrap();
+        assert!((x[0] - 8.0 / 5.0).abs() < 1e-12);
+        assert!((x[1] - 9.0 / 5.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn linear_solver_singular() {
+        let mut a = vec![1.0, 2.0, 2.0, 4.0];
+        let mut b = vec![3.0, 6.0];
+        let result = solve_linear_system(&mut a, &mut b, 2);
+        assert!(result.is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `src/geom/sip.rs`: SIP (Simple Imaging Polynomial) WCS distortion model with forward/inverse polynomial evaluation, pixel-to-sky and sky-to-pixel transforms
- Add `src/tweak.rs`: Iterative SIP refinement that matches field sources to index stars and fits distortion polynomials via normal equations with manual Gaussian elimination
- Make `TanWcs::iwc_to_xyz` crate-visible so SIP module can reuse the IWC deprojection

## Test plan
- [x] Identity SIP (zero coefficients) matches TAN exactly
- [x] Known barrel distortion round-trips through pixel->radec->pixel
- [x] Pixel scale at center matches TAN
- [x] Distortion moves edge pixels but not center
- [x] Zero distortion field gives near-zero SIP coefficients
- [x] Known quadratic distortion is recovered by tweak
- [x] Too few sources returns error
- [x] Linear solver handles identity, general 2x2, and singular cases
- [x] All 111 tests pass, clippy clean, formatted