### PR TITLE
Auto-compute max_quads from HEALPix geometry

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,9 +66,9 @@ enum Commands {
         #[arg(long, default_value = "10")]
         max_stars_per_cell: usize,
 
-        /// Maximum number of quads to generate.
-        #[arg(long, default_value = "100000")]
-        max_quads: usize,
+        /// Maximum number of quads to generate (auto-computed if omitted).
+        #[arg(long)]
+        max_quads: Option<usize>,
 
         /// HEALPix depth for star uniformization (auto if omitted).
         #[arg(long)]
@@ -323,6 +323,17 @@ fn cmd_solve(
 
 fn cmd_build_index(catalog_path: &Path, output_path: &Path, config: &CatalogBuilderConfig) {
     use starfield::catalogs::MinimalCatalog;
+
+    let quad_depth = config.effective_quad_depth();
+    let n_cells = zodiacal::healpix::npix(quad_depth);
+    let max_quads = config.effective_max_quads();
+    eprintln!(
+        "Index params: depth={}, cells={}, quads_per_cell={}, max_quads={}",
+        quad_depth,
+        n_cells,
+        max_quads / n_cells as usize,
+        max_quads
+    );
 
     let catalog = MinimalCatalog::load(catalog_path).unwrap_or_else(|e| {
         eprintln!("Failed to load catalog {}: {e}", catalog_path.display());


### PR DESCRIPTION
## Summary
- `--max-quads` is now optional; when omitted, it auto-computes as `passes * npix(quad_depth)`
- Default: 16 passes * 786,432 cells = **12,582,912 quads** (vs old hardcoded 100K)
- Prints resolved index parameters at build start for visibility
- Explicit `--max-quads N` still works as an override

## Why
The old default of 100K quads spread across 786K HEALPix cells gave <1 quad per cell, making the solver unable to find matches anywhere. The heuristic ensures every cell gets `passes` quads, matching astrometry.net's approach.

## Test plan
- [x] All 112 tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] Auto mode: `build-index --scale-lower 10 --scale-upper 600` prints `depth=8, cells=786432, quads_per_cell=16, max_quads=12582912`
- [x] Override mode: `build-index --max-quads 500000` uses explicit value