### PR TITLE
Add solver timeout and batch-solve command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3105,6 +3111,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "fitsrs",
+ "glob",
  "image 0.25.9",
  "indicatif 0.18.3",
  "ndarray 0.17.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ fits = ["dep:fitsrs"]
 [dependencies]
 clap = { version = "4.5.57", features = ["derive"] }
 fitsrs = { version = "0.4.1", optional = true }
+glob = "0.3.3"
 image = "0.25.9"
 indicatif = "0.18.3"
 ndarray = "0.17.2"


### PR DESCRIPTION
## Summary
- Add `timeout` field to `SolverConfig` with deadline-based checking in the solve loop
- Add `--timeout` flag to the `solve` command
- Add `batch-solve` subcommand for solving directories of images with statistics
- Add `glob` dependency for file pattern matching

## Batch solve results (100 images, 60s timeout, v6 index)
- **77/100 solved (77%)**
- Median solve time: 4.32s
- 75% solve in <5s, 90% in <10s
- 23 failures all timed out

## Test plan
- [x] All 112 unit tests pass
- [x] Clippy clean
- [x] Batch tested against 100 meter-sim images