### PR TITLE
Add extract CLI and JSON source format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3116,6 +3116,8 @@ dependencies = [
  "indicatif 0.18.3",
  "ndarray 0.17.2",
  "rayon",
+ "serde",
+ "serde_json",
  "starfield",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,6 @@ image = "0.25.9"
 indicatif = "0.18.3"
 ndarray = "0.17.2"
 rayon = "1.11.0"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
 starfield = "0.9.1"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # zodiacal
-A blind astrometry library!
+A blind astrometry library written in Rust.
+
+## Sources JSON Format
+
+Zodiacal uses a JSON format for exchanging detected source lists between tools. The `extract` command produces this format, and the solver can consume it.
+
+### Schema
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `image_width` | number | yes | Image width in pixels |
+| `image_height` | number | yes | Image height in pixels |
+| `ra_deg` | number | no | Known RA of field center (degrees) |
+| `dec_deg` | number | no | Known Dec of field center (degrees) |
+| `plate_scale_arcsec` | number | no | Known plate scale (arcsec/pixel) |
+| `sources` | array | yes | Detected sources |
+| `sources[].x` | number | yes | Source x position (pixels) |
+| `sources[].y` | number | yes | Source y position (pixels) |
+| `sources[].flux` | number | yes | Source brightness (ADU) |
+
+### Example
+
+```json
+{
+  "image_width": 9568,
+  "image_height": 6380,
+  "ra_deg": 265.47,
+  "dec_deg": 44.31,
+  "plate_scale_arcsec": 0.1296,
+  "sources": [
+    { "x": 4821.3, "y": 3190.7, "flux": 54210.0 },
+    { "x": 1023.5, "y": 892.1, "flux": 38450.0 }
+  ]
+}
+```
+
+The `ra_deg`, `dec_deg`, and `plate_scale_arcsec` fields are optional hints. When present they can speed up solving by constraining the search space. When absent they are omitted from the JSON entirely.


### PR DESCRIPTION
## Summary
- Adds `extract` CLI command to convert images/FITS to a JSON source list
- Replaces CSV source I/O with JSON using serde/serde_json
- JSON format includes optional `ra_deg`, `dec_deg`, `plate_scale_arcsec` hint fields
- Documents the Sources JSON schema in README

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 112 tests pass