### PR TITLE
Add SpatialCatalog trait and Gaia streaming reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1260,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,6 +1943,17 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3237,7 +3278,9 @@ version = "0.1.0"
 dependencies = [
  "cdshealpix",
  "clap",
+ "dirs-next",
  "fitsio-pure",
+ "flate2",
  "glob",
  "image 0.25.10",
  "indicatif 0.18.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ image = { version = "0.25.9", optional = true }
 indicatif = { version = "0.18.3", optional = true }
 ndarray = { version = "0.17.2", optional = true }
 cdshealpix = "0.9.1"
+dirs-next = "2"
+flate2 = "1"
 rayon = "1.11.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/examples/build_gaia_index.rs
+++ b/examples/build_gaia_index.rs
@@ -1,0 +1,118 @@
+//! Build a zodiacal index from the local Gaia DR1 catalog.
+//!
+//! Processes all Gaia CSV files in parallel using rayon for fast index building.
+//!
+//! Usage:
+//!   cargo run --example build_gaia_index --release -- [options]
+//!
+//! Options:
+//!   --output PATH       Output index file (default: gaia_index.zdcl)
+//!   --mag-limit MAG     Magnitude limit (default: 18.0)
+//!   --scale-lo ARCSEC   Min quad scale in arcsec (default: 10.0)
+//!   --scale-hi ARCSEC   Max quad scale in arcsec (default: 1800.0)
+//!   --stars-per-cell N  Max stars per HEALPix cell (default: 20)
+//!   --passes N          Quad building passes per cell (default: 16)
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use zodiacal::index::builder::CatalogBuilderConfig;
+use zodiacal::index::gaia::{GaiaSpatialCatalog, build_index_from_gaia};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let mut output = PathBuf::from("gaia_index.zdcl");
+    let mut mag_limit = 18.0_f64;
+    let mut scale_lo = 10.0_f64;
+    let mut scale_hi = 1800.0_f64;
+    let mut stars_per_cell = 20_usize;
+    let mut passes = 16_usize;
+    let mut uni_depth: Option<u8> = None;
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--output" => {
+                i += 1;
+                output = PathBuf::from(&args[i]);
+            }
+            "--mag-limit" => {
+                i += 1;
+                mag_limit = args[i].parse().expect("invalid --mag-limit");
+            }
+            "--scale-lo" => {
+                i += 1;
+                scale_lo = args[i].parse().expect("invalid --scale-lo");
+            }
+            "--scale-hi" => {
+                i += 1;
+                scale_hi = args[i].parse().expect("invalid --scale-hi");
+            }
+            "--stars-per-cell" => {
+                i += 1;
+                stars_per_cell = args[i].parse().expect("invalid --stars-per-cell");
+            }
+            "--passes" => {
+                i += 1;
+                passes = args[i].parse().expect("invalid --passes");
+            }
+            "--depth" => {
+                i += 1;
+                uni_depth = Some(args[i].parse().expect("invalid --depth"));
+            }
+            _ => {
+                eprintln!("Unknown arg: {}", args[i]);
+                std::process::exit(1);
+            }
+        }
+        i += 1;
+    }
+
+    eprintln!("=== Gaia Index Builder (parallel) ===");
+    eprintln!("  mag_limit:      {mag_limit}");
+    eprintln!("  scale range:    {scale_lo}\" - {scale_hi}\"");
+    eprintln!("  stars/cell:     {stars_per_cell}");
+    eprintln!("  passes:         {passes}");
+    eprintln!("  output:         {}", output.display());
+    eprintln!();
+
+    let t0 = Instant::now();
+
+    let gaia_dir = GaiaSpatialCatalog::default_dir().unwrap_or_else(|| {
+        eprintln!("No cache directory found");
+        std::process::exit(1);
+    });
+
+    let config = CatalogBuilderConfig {
+        scale_lower: (scale_lo / 3600.0_f64).to_radians(),
+        scale_upper: (scale_hi / 3600.0_f64).to_radians(),
+        max_stars_per_cell: stars_per_cell,
+        passes,
+        uniformize_depth: uni_depth,
+        ..CatalogBuilderConfig::default()
+    };
+
+    let index = build_index_from_gaia(&gaia_dir, mag_limit, &config).unwrap_or_else(|e| {
+        eprintln!("Failed to build index: {e}");
+        std::process::exit(1);
+    });
+
+    eprintln!(
+        "\nIndex built in {:.1}s: {} stars, {} quads",
+        t0.elapsed().as_secs_f64(),
+        index.stars.len(),
+        index.quads.len(),
+    );
+
+    index.save(&output).unwrap_or_else(|e| {
+        eprintln!("Failed to save index: {e}");
+        std::process::exit(1);
+    });
+
+    eprintln!(
+        "Saved to {} ({:.1}MB)",
+        output.display(),
+        std::fs::metadata(&output).map(|m| m.len()).unwrap_or(0) as f64 / 1e6
+    );
+    eprintln!("Total time: {:.1}s", t0.elapsed().as_secs_f64());
+}

--- a/examples/solve_test_cases.rs
+++ b/examples/solve_test_cases.rs
@@ -1,0 +1,139 @@
+//! Solve test_cases/*.json against a prebuilt index.
+//!
+//! Usage:
+//!   cargo run --example solve_test_cases --release -- --index scratch/gaia_d8_index.zdcl
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use zodiacal::extraction::read_sources_json;
+use zodiacal::index::Index;
+use zodiacal::solver::{SolverConfig, solve};
+use zodiacal::verify::VerifyConfig;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let mut index_path = PathBuf::from("scratch/gaia_d8_index.zdcl");
+    let mut test_dir = PathBuf::from("test_cases");
+    let mut max_cases: Option<usize> = None;
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--index" => {
+                i += 1;
+                index_path = PathBuf::from(&args[i]);
+            }
+            "--dir" => {
+                i += 1;
+                test_dir = PathBuf::from(&args[i]);
+            }
+            "--max" => {
+                i += 1;
+                max_cases = Some(args[i].parse().expect("invalid --max"));
+            }
+            _ => {
+                eprintln!("Unknown arg: {}", args[i]);
+                std::process::exit(1);
+            }
+        }
+        i += 1;
+    }
+
+    eprintln!("Loading index from {}...", index_path.display());
+    let t0 = Instant::now();
+    let index = Index::load(&index_path).unwrap_or_else(|e| {
+        eprintln!("Failed to load index: {e}");
+        std::process::exit(1);
+    });
+    eprintln!(
+        "Loaded index in {:.1}s: {} stars, {} quads",
+        t0.elapsed().as_secs_f64(),
+        index.stars.len(),
+        index.quads.len()
+    );
+
+    let mut files: Vec<PathBuf> = std::fs::read_dir(&test_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|e| e == "json"))
+        .collect();
+    files.sort();
+    if let Some(max) = max_cases {
+        files.truncate(max);
+    }
+
+    eprintln!("Solving {} test cases...\n", files.len());
+
+    let mut config = SolverConfig::default();
+    config.code_tolerance = 0.01;
+    config.timeout = Some(std::time::Duration::from_secs(5));
+    config.verify = VerifyConfig {
+        match_radius_pix: 10.0,
+        log_odds_accept: 15.0,
+        min_matches: 6,
+        ..VerifyConfig::default()
+    };
+
+    let mut n_solved = 0;
+    let mut n_failed = 0;
+    let mut solve_times = Vec::new();
+
+    for (i, file) in files.iter().enumerate() {
+        let name = file.file_name().unwrap().to_string_lossy();
+        let reader = std::fs::File::open(file).unwrap();
+        let sj = read_sources_json(reader).unwrap();
+
+        let t1 = Instant::now();
+        let (result, stats) = solve(
+            &sj.sources,
+            &[&index],
+            (sj.image_width, sj.image_height),
+            &config,
+        );
+        let elapsed = t1.elapsed().as_secs_f64();
+
+        match result {
+            Some(solution) => {
+                let (ra, dec) = solution.wcs.field_center();
+                n_solved += 1;
+                solve_times.push(elapsed);
+                eprintln!(
+                    "[{:3}/{}] {} SOLVED {:.2}s  RA={:.4}° Dec={:+.4}°  matched={}  verified={}",
+                    i + 1,
+                    files.len(),
+                    name,
+                    elapsed,
+                    ra.to_degrees(),
+                    dec.to_degrees(),
+                    solution.verify_result.n_matched,
+                    stats.n_verified,
+                );
+            }
+            None => {
+                n_failed += 1;
+                eprintln!(
+                    "[{:3}/{}] {} FAILED {:.2}s  verified={}  best_rejected={:?}",
+                    i + 1,
+                    files.len(),
+                    name,
+                    elapsed,
+                    stats.n_verified,
+                    stats.best_rejected,
+                );
+            }
+        }
+    }
+
+    eprintln!("\n=== Results ===");
+    eprintln!("Solved: {n_solved}/{}", files.len());
+    eprintln!("Failed: {n_failed}/{}", files.len());
+    if !solve_times.is_empty() {
+        solve_times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let median = solve_times[solve_times.len() / 2];
+        let mean: f64 = solve_times.iter().sum::<f64>() / solve_times.len() as f64;
+        let p95 = solve_times[(solve_times.len() as f64 * 0.95) as usize];
+        eprintln!("Solve times: median={median:.3}s, mean={mean:.3}s, p95={p95:.3}s");
+    }
+}

--- a/src/index/builder.rs
+++ b/src/index/builder.rs
@@ -768,6 +768,109 @@ pub fn build_index_from_star_data(stars: &[StarData], config: &IndexBuilderConfi
     build_index(&tuples, config)
 }
 
+/// Build an index from a [`SpatialCatalog`](super::catalog::SpatialCatalog)
+/// using HEALPix-guided uniformization.
+///
+/// Similar to [`build_index_from_catalog`], but queries the catalog cell-by-cell
+/// instead of streaming all stars. This allows catalogs that load data on demand
+/// (e.g. [`GaiaSpatialCatalog`](super::gaia::GaiaSpatialCatalog)) to avoid
+/// loading the entire dataset into memory.
+pub fn build_index_from_spatial(
+    catalog: &impl super::catalog::SpatialCatalog,
+    config: &CatalogBuilderConfig,
+) -> Index {
+    let mp = MultiProgress::new();
+
+    let uni_depth = config.effective_uniformize_depth();
+    let max_per_cell = config.max_stars_per_cell;
+
+    // --- Phase 1: HEALPix uniformization via spatial queries ---
+    let pb_uni = mp.add(ProgressBar::new_spinner());
+    pb_uni.set_style(spinner_style());
+    pb_uni.set_prefix("✦ Uniformize");
+    pb_uni.set_message(format!(
+        "querying catalog by cell (depth {}, {} per cell)...",
+        uni_depth, max_per_cell
+    ));
+    pb_uni.enable_steady_tick(std::time::Duration::from_millis(80));
+
+    let cells = catalog.occupied_cells(uni_depth);
+    let n_cells = cells.len();
+
+    let mut stars: Vec<IndexStar> = Vec::new();
+    let mut total_streamed: u64 = 0;
+
+    for (i, &cell) in cells.iter().enumerate() {
+        let cell_stars = catalog.stars_in_cell(uni_depth, cell);
+        total_streamed += cell_stars.len() as u64;
+
+        // Keep only the brightest max_per_cell stars from this cell.
+        let mut cell_heap: BinaryHeap<HeapStar> = BinaryHeap::with_capacity(max_per_cell + 1);
+
+        for s in cell_stars {
+            let hs = HeapStar {
+                mag: s.magnitude,
+                id: s.id,
+                ra: s.position.ra,
+                dec: s.position.dec,
+            };
+            if cell_heap.len() < max_per_cell {
+                cell_heap.push(hs);
+            } else if let Some(faintest) = cell_heap.peek()
+                && hs.mag < faintest.mag
+            {
+                cell_heap.pop();
+                cell_heap.push(hs);
+            }
+        }
+
+        for hs in cell_heap {
+            stars.push(IndexStar {
+                catalog_id: hs.id,
+                ra: hs.ra,
+                dec: hs.dec,
+                mag: hs.mag,
+            });
+        }
+
+        if (i + 1) % 1000 == 0 || i + 1 == n_cells {
+            pb_uni.set_message(format!(
+                "processed {}/{} cells ({} stars from {} total)...",
+                i + 1,
+                n_cells,
+                stars.len(),
+                total_streamed,
+            ));
+        }
+    }
+
+    stars.sort_by(|a, b| {
+        a.mag
+            .partial_cmp(&b.mag)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    finish_spinner(
+        &pb_uni,
+        &format!(
+            "✓ {} stars from {} cells ({} total scanned, depth {})",
+            stars.len(),
+            n_cells,
+            total_streamed,
+            uni_depth,
+        ),
+    );
+
+    // Phases 2+ (KD-tree, quad building) reuse the shared core.
+    build_index_from_stars(
+        stars,
+        config.scale_lower,
+        config.scale_upper,
+        config.effective_max_quads(),
+        &mp,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -988,6 +1091,38 @@ mod tests {
         let index = build_index(&catalog, &config);
         assert_eq!(index.stars.len(), 5);
         assert_eq!(index.star_tree.len(), 5);
+    }
+
+    #[test]
+    fn spatial_catalog_builds_index() {
+        use crate::index::catalog::InMemorySpatialCatalog;
+        use starfield::catalogs::StarData;
+
+        let catalog = make_small_catalog();
+        // Convert to StarData for the spatial catalog
+        let star_data: Vec<StarData> = catalog
+            .iter()
+            .map(|&(id, ra, dec, mag)| {
+                StarData::new(id, ra.to_degrees(), dec.to_degrees(), mag, None)
+            })
+            .collect();
+        let spatial = InMemorySpatialCatalog::from_star_data(star_data.into_iter());
+
+        let config = CatalogBuilderConfig {
+            scale_lower: 0.001,
+            scale_upper: 0.02,
+            max_stars_per_cell: 10,
+            max_quads: Some(1000),
+            ..CatalogBuilderConfig::default()
+        };
+
+        let index = build_index_from_spatial(&spatial, &config);
+
+        assert_eq!(index.stars.len(), 10);
+        assert!(
+            !index.quads.is_empty(),
+            "expected some quads to be generated"
+        );
     }
 
     #[test]

--- a/src/index/builder.rs
+++ b/src/index/builder.rs
@@ -243,6 +243,20 @@ pub fn build_index(stars: &[(u64, f64, f64, f64)], config: &IndexBuilderConfig) 
     )
 }
 
+/// Build an index from pre-selected IndexStars (public entry point).
+///
+/// Use this when you have already performed uniformization and have
+/// a final star list ready for quad building.
+pub fn build_index_from_stars_pub(
+    index_stars: Vec<IndexStar>,
+    scale_lower: f64,
+    scale_upper: f64,
+    max_quads: usize,
+) -> Index {
+    let mp = MultiProgress::new();
+    build_index_from_stars(index_stars, scale_lower, scale_upper, max_quads, &mp)
+}
+
 /// Core index builder that takes pre-selected IndexStars.
 fn build_index_from_stars(
     index_stars: Vec<IndexStar>,

--- a/src/index/catalog.rs
+++ b/src/index/catalog.rs
@@ -1,0 +1,257 @@
+//! Spatial catalog abstraction for index building.
+//!
+//! Provides a trait for catalogs that can return stars grouped by HEALPix cell,
+//! plus implementations for in-memory catalogs and streaming Gaia CSV files.
+
+use std::collections::HashMap;
+
+use starfield::catalogs::{StarCatalog, StarData};
+
+/// A star catalog that can be queried by HEALPix cell.
+///
+/// This is the primary interface consumed by the index builder. Implementations
+/// can be backed by in-memory data or stream from disk on demand.
+pub trait SpatialCatalog {
+    /// Return stars within a single HEALPix cell at the given depth.
+    fn stars_in_cell(&self, depth: u8, cell: u64) -> Vec<StarData>;
+
+    /// Return all cells that contain at least one star at the given depth.
+    fn occupied_cells(&self, depth: u8) -> Vec<u64>;
+}
+
+/// Wraps any `StarCatalog` into a `SpatialCatalog` by binning all stars
+/// into HEALPix cells at construction time.
+pub struct InMemorySpatialCatalog {
+    /// Stars grouped by (depth, cell) → Vec<StarData>.
+    /// We store at the finest depth requested and aggregate for coarser queries.
+    stars: Vec<StarData>,
+}
+
+impl InMemorySpatialCatalog {
+    /// Build from any starfield `StarCatalog`.
+    pub fn from_catalog(catalog: &impl StarCatalog) -> Self {
+        let stars: Vec<StarData> = catalog.star_data().collect();
+        Self { stars }
+    }
+
+    /// Build from an iterator of `StarData`.
+    pub fn from_star_data(iter: impl Iterator<Item = StarData>) -> Self {
+        Self {
+            stars: iter.collect(),
+        }
+    }
+
+    /// Number of stars in the catalog.
+    pub fn len(&self) -> usize {
+        self.stars.len()
+    }
+
+    /// Whether the catalog is empty.
+    pub fn is_empty(&self) -> bool {
+        self.stars.is_empty()
+    }
+}
+
+impl SpatialCatalog for InMemorySpatialCatalog {
+    fn stars_in_cell(&self, depth: u8, cell: u64) -> Vec<StarData> {
+        self.stars
+            .iter()
+            .filter(|s| cdshealpix::nested::hash(depth, s.position.ra, s.position.dec) == cell)
+            .cloned()
+            .collect()
+    }
+
+    fn occupied_cells(&self, depth: u8) -> Vec<u64> {
+        let mut cells: Vec<u64> = self
+            .stars
+            .iter()
+            .map(|s| cdshealpix::nested::hash(depth, s.position.ra, s.position.dec))
+            .collect();
+        cells.sort_unstable();
+        cells.dedup();
+        cells
+    }
+}
+
+/// Pre-indexed in-memory spatial catalog.
+///
+/// Stars are binned into HEALPix cells at a fixed depth during construction,
+/// making cell queries O(1) lookups instead of full scans.
+pub struct IndexedSpatialCatalog {
+    depth: u8,
+    cells: HashMap<u64, Vec<StarData>>,
+}
+
+impl IndexedSpatialCatalog {
+    /// Build from any starfield `StarCatalog` at a given HEALPix depth.
+    pub fn from_catalog(catalog: &impl StarCatalog, depth: u8) -> Self {
+        let mut cells: HashMap<u64, Vec<StarData>> = HashMap::new();
+        for s in catalog.star_data() {
+            let cell = cdshealpix::nested::hash(depth, s.position.ra, s.position.dec);
+            cells.entry(cell).or_default().push(s);
+        }
+        Self { cells, depth }
+    }
+
+    /// Build from an iterator of `StarData` at a given HEALPix depth.
+    pub fn from_star_data(iter: impl Iterator<Item = StarData>, depth: u8) -> Self {
+        let mut cells: HashMap<u64, Vec<StarData>> = HashMap::new();
+        for s in iter {
+            let cell = cdshealpix::nested::hash(depth, s.position.ra, s.position.dec);
+            cells.entry(cell).or_default().push(s);
+        }
+        Self { cells, depth }
+    }
+
+    /// Number of stars across all cells.
+    pub fn len(&self) -> usize {
+        self.cells.values().map(|v| v.len()).sum()
+    }
+
+    /// Whether the catalog is empty.
+    pub fn is_empty(&self) -> bool {
+        self.cells.is_empty()
+    }
+
+    /// The HEALPix depth this catalog was indexed at.
+    pub fn depth(&self) -> u8 {
+        self.depth
+    }
+}
+
+impl SpatialCatalog for IndexedSpatialCatalog {
+    fn stars_in_cell(&self, depth: u8, cell: u64) -> Vec<StarData> {
+        if depth == self.depth {
+            // Exact match — direct lookup.
+            self.cells.get(&cell).cloned().unwrap_or_default()
+        } else if depth < self.depth {
+            // Coarser query — aggregate all child cells.
+            let shift = 2 * (self.depth - depth) as u64;
+            let child_start = cell << shift;
+            let child_end = (cell + 1) << shift;
+            let mut result = Vec::new();
+            for (&c, stars) in &self.cells {
+                if c >= child_start && c < child_end {
+                    result.extend_from_slice(stars);
+                }
+            }
+            result
+        } else {
+            // Finer query — find the parent cell and filter.
+            let shift = 2 * (depth - self.depth) as u64;
+            let parent = cell >> shift;
+            self.cells
+                .get(&parent)
+                .map(|stars| {
+                    stars
+                        .iter()
+                        .filter(|s| {
+                            cdshealpix::nested::hash(depth, s.position.ra, s.position.dec) == cell
+                        })
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_default()
+        }
+    }
+
+    fn occupied_cells(&self, depth: u8) -> Vec<u64> {
+        if depth == self.depth {
+            let mut cells: Vec<u64> = self.cells.keys().copied().collect();
+            cells.sort_unstable();
+            cells
+        } else if depth < self.depth {
+            // Coarser — map each stored cell to its parent and dedup.
+            let shift = 2 * (self.depth - depth) as u64;
+            let mut cells: Vec<u64> = self.cells.keys().map(|&c| c >> shift).collect();
+            cells.sort_unstable();
+            cells.dedup();
+            cells
+        } else {
+            // Finer — expand each stored cell to its children and filter.
+            let mut cells = Vec::new();
+            for stars in self.cells.values() {
+                for s in stars {
+                    cells.push(cdshealpix::nested::hash(
+                        depth,
+                        s.position.ra,
+                        s.position.dec,
+                    ));
+                }
+            }
+            cells.sort_unstable();
+            cells.dedup();
+            cells
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_stars() -> Vec<StarData> {
+        // Stars at known positions spread across the sky
+        vec![
+            StarData::new(1, 10.0, 20.0, 5.0, None),
+            StarData::new(2, 10.1, 20.1, 6.0, None),
+            StarData::new(3, 180.0, -30.0, 4.0, None),
+            StarData::new(4, 270.0, 60.0, 7.0, None),
+        ]
+    }
+
+    #[test]
+    fn in_memory_roundtrip() {
+        let catalog = InMemorySpatialCatalog::from_star_data(make_test_stars().into_iter());
+        assert_eq!(catalog.len(), 4);
+
+        let cells = catalog.occupied_cells(2);
+        assert!(!cells.is_empty());
+
+        // All stars should be recoverable
+        let mut total = 0;
+        for &cell in &cells {
+            total += catalog.stars_in_cell(2, cell).len();
+        }
+        assert_eq!(total, 4);
+    }
+
+    #[test]
+    fn indexed_exact_depth() {
+        let catalog = IndexedSpatialCatalog::from_star_data(make_test_stars().into_iter(), 4);
+        assert_eq!(catalog.len(), 4);
+
+        let cells = catalog.occupied_cells(4);
+        let mut total = 0;
+        for &cell in &cells {
+            total += catalog.stars_in_cell(4, cell).len();
+        }
+        assert_eq!(total, 4);
+    }
+
+    #[test]
+    fn indexed_coarser_query() {
+        let catalog = IndexedSpatialCatalog::from_star_data(make_test_stars().into_iter(), 4);
+
+        // Query at coarser depth should still return all stars
+        let cells = catalog.occupied_cells(2);
+        let mut total = 0;
+        for &cell in &cells {
+            total += catalog.stars_in_cell(2, cell).len();
+        }
+        assert_eq!(total, 4);
+    }
+
+    #[test]
+    fn indexed_finer_query() {
+        let catalog = IndexedSpatialCatalog::from_star_data(make_test_stars().into_iter(), 2);
+
+        // Query at finer depth should still return all stars
+        let cells = catalog.occupied_cells(4);
+        let mut total = 0;
+        for &cell in &cells {
+            total += catalog.stars_in_cell(4, cell).len();
+        }
+        assert_eq!(total, 4);
+    }
+}

--- a/src/index/gaia.rs
+++ b/src/index/gaia.rs
@@ -1,0 +1,269 @@
+//! Streaming Gaia DR1 catalog reader.
+//!
+//! Reads gzipped CSV files directly from the starfield cache directory,
+//! exploiting the fact that Gaia source_ids encode HEALPix level-12 pixels
+//! in their high bits, so files are spatially ordered.
+
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+use flate2::read::GzDecoder;
+use starfield::catalogs::StarData;
+
+use super::catalog::SpatialCatalog;
+
+/// Gaia HEALPix depth encoded in source_id (level 12).
+const GAIA_SOURCE_ID_DEPTH: u8 = 12;
+/// Number of bits to shift source_id right to get the HEALPix level-12 pixel.
+const GAIA_SOURCE_ID_SHIFT: u32 = 35;
+
+/// Extract the HEALPix level-12 pixel from a Gaia source_id.
+fn healpix_from_source_id(source_id: u64) -> u64 {
+    source_id >> GAIA_SOURCE_ID_SHIFT
+}
+
+/// A spatial catalog backed by Gaia DR1 gzipped CSV files on disk.
+///
+/// On construction, scans file headers to build a source_id range → file mapping.
+/// Queries decompress and parse only the files needed for the requested cells.
+pub struct GaiaSpatialCatalog {
+    /// Sorted list of (first_source_id, last_source_id, file_path).
+    file_ranges: Vec<FileRange>,
+    /// Magnitude limit — skip stars fainter than this.
+    mag_limit: f64,
+}
+
+struct FileRange {
+    /// First source_id in this file (from first data row).
+    first_source_id: u64,
+    /// Path to the gzipped CSV file.
+    path: PathBuf,
+}
+
+impl GaiaSpatialCatalog {
+    /// Build a Gaia spatial catalog from a directory of gzipped CSV files.
+    ///
+    /// Reads the first data line of each file to determine its source_id range.
+    /// This is relatively fast (~seconds for 5000 files) since it only decompresses
+    /// the first few bytes of each file.
+    pub fn open(dir: &Path, mag_limit: f64) -> std::io::Result<Self> {
+        let mut entries: Vec<PathBuf> = fs::read_dir(dir)?
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| {
+                p.extension().is_some_and(|ext| ext == "gz")
+                    && p.file_name()
+                        .is_some_and(|n| n.to_string_lossy().starts_with("GaiaSource"))
+            })
+            .collect();
+        entries.sort();
+
+        eprintln!(
+            "Scanning {} Gaia files for source_id ranges...",
+            entries.len()
+        );
+
+        let mut file_ranges = Vec::with_capacity(entries.len());
+        for path in entries {
+            if let Some(first_id) = read_first_source_id(&path) {
+                file_ranges.push(FileRange {
+                    first_source_id: first_id,
+                    path,
+                });
+            }
+        }
+
+        // Sort by first_source_id so we can binary search.
+        file_ranges.sort_by_key(|f| f.first_source_id);
+
+        eprintln!(
+            "Indexed {} Gaia files (mag_limit={:.1})",
+            file_ranges.len(),
+            mag_limit
+        );
+
+        Ok(Self {
+            file_ranges,
+            mag_limit,
+        })
+    }
+
+    /// Default Gaia cache directory (~/.cache/starfield/gaia/).
+    pub fn default_dir() -> Option<PathBuf> {
+        dirs_next::cache_dir().map(|d| d.join("starfield").join("gaia"))
+    }
+
+    /// Open from the default cache directory.
+    pub fn open_default(mag_limit: f64) -> std::io::Result<Self> {
+        let dir = Self::default_dir().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "no cache directory found")
+        })?;
+        Self::open(&dir, mag_limit)
+    }
+
+    /// Find files that might contain stars for the given HEALPix level-12 cells.
+    fn files_for_cells(&self, cells_12: &[u64]) -> Vec<&Path> {
+        if cells_12.is_empty() || self.file_ranges.is_empty() {
+            return Vec::new();
+        }
+
+        // Convert cells to source_id ranges.
+        let mut ranges: Vec<(u64, u64)> = cells_12
+            .iter()
+            .map(|&cell| {
+                let lo = cell << GAIA_SOURCE_ID_SHIFT;
+                let hi = ((cell + 1) << GAIA_SOURCE_ID_SHIFT) - 1;
+                (lo, hi)
+            })
+            .collect();
+        ranges.sort_unstable();
+
+        // Find files whose source_id range overlaps any of our target ranges.
+        let mut result = Vec::new();
+        for (i, fr) in self.file_ranges.iter().enumerate() {
+            let file_start = fr.first_source_id;
+            // File end is approximated as the start of the next file (or u64::MAX).
+            let file_end = self
+                .file_ranges
+                .get(i + 1)
+                .map(|next| next.first_source_id - 1)
+                .unwrap_or(u64::MAX);
+
+            for &(lo, hi) in &ranges {
+                if file_start <= hi && file_end >= lo {
+                    result.push(fr.path.as_path());
+                    break;
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Stream all stars from a file that fall within the given level-12 cells.
+    fn read_stars_in_cells(&self, path: &Path, cells_12: &[u64]) -> Vec<StarData> {
+        let cell_set: std::collections::HashSet<u64> = cells_12.iter().copied().collect();
+        let mut stars = Vec::new();
+
+        let file = match fs::File::open(path) {
+            Ok(f) => f,
+            Err(_) => return stars,
+        };
+
+        let reader = BufReader::new(GzDecoder::new(file));
+        let mut lines = reader.lines();
+
+        // Skip header.
+        let _ = lines.next();
+
+        for line in lines {
+            let line = match line {
+                Ok(l) => l,
+                Err(_) => continue,
+            };
+
+            if let Some(star) = parse_gaia_line(&line, self.mag_limit) {
+                let cell = healpix_from_source_id(star.id);
+                if cell_set.contains(&cell) {
+                    stars.push(star);
+                }
+            }
+        }
+
+        stars
+    }
+
+    /// Resolve a depth/cell query to HEALPix level-12 cells.
+    fn cells_at_depth_12(depth: u8, cell: u64) -> Vec<u64> {
+        if depth == GAIA_SOURCE_ID_DEPTH {
+            vec![cell]
+        } else if depth < GAIA_SOURCE_ID_DEPTH {
+            // Coarser query — enumerate all level-12 children.
+            let shift = 2 * (GAIA_SOURCE_ID_DEPTH - depth) as u64;
+            let start = cell << shift;
+            let count = 1u64 << shift;
+            (start..start + count).collect()
+        } else {
+            // Finer than level 12 — map to parent.
+            let shift = 2 * (depth - GAIA_SOURCE_ID_DEPTH) as u64;
+            vec![cell >> shift]
+        }
+    }
+}
+
+impl SpatialCatalog for GaiaSpatialCatalog {
+    fn stars_in_cell(&self, depth: u8, cell: u64) -> Vec<StarData> {
+        let cells_12 = Self::cells_at_depth_12(depth, cell);
+        let files = self.files_for_cells(&cells_12);
+
+        let mut stars = Vec::new();
+        for path in files {
+            stars.extend(self.read_stars_in_cells(path, &cells_12));
+        }
+
+        // If query is finer than level 12, filter to exact cell.
+        if depth > GAIA_SOURCE_ID_DEPTH {
+            stars
+                .retain(|s| cdshealpix::nested::hash(depth, s.position.ra, s.position.dec) == cell);
+        }
+
+        stars
+    }
+
+    fn occupied_cells(&self, depth: u8) -> Vec<u64> {
+        // Derive from the file ranges — each file's first source_id tells us
+        // which level-12 cell it starts in.
+        let mut cells: Vec<u64> = self
+            .file_ranges
+            .iter()
+            .map(|fr| {
+                let cell_12 = healpix_from_source_id(fr.first_source_id);
+                if depth <= GAIA_SOURCE_ID_DEPTH {
+                    let shift = 2 * (GAIA_SOURCE_ID_DEPTH - depth) as u64;
+                    cell_12 >> shift
+                } else {
+                    // Can't determine finer cells without reading files.
+                    let shift = 2 * (depth - GAIA_SOURCE_ID_DEPTH) as u64;
+                    cell_12 << shift
+                }
+            })
+            .collect();
+        cells.sort_unstable();
+        cells.dedup();
+        cells
+    }
+}
+
+/// Parse a single Gaia DR1 CSV line into a StarData.
+///
+/// Returns None if the magnitude exceeds the limit or the line can't be parsed.
+/// Key columns (0-indexed): source_id=1, ra=4, dec=6, phot_g_mean_mag=51.
+fn parse_gaia_line(line: &str, mag_limit: f64) -> Option<StarData> {
+    let fields: Vec<&str> = line.split(',').collect();
+    if fields.len() < 52 {
+        return None;
+    }
+
+    let source_id: u64 = fields[1].parse().ok()?;
+    let ra: f64 = fields[4].parse().ok()?;
+    let dec: f64 = fields[6].parse().ok()?;
+    let mag: f64 = fields[51].parse().ok()?;
+
+    if mag > mag_limit {
+        return None;
+    }
+
+    Some(StarData::new(source_id, ra, dec, mag, None))
+}
+
+/// Read the first source_id from a gzipped Gaia CSV file.
+fn read_first_source_id(path: &Path) -> Option<u64> {
+    let file = fs::File::open(path).ok()?;
+    let reader = BufReader::new(GzDecoder::new(file));
+    let mut lines = reader.lines();
+    let _ = lines.next()?; // skip header
+    let first_line = lines.next()?.ok()?;
+    let source_id = first_line.split(',').nth(1)?.parse::<u64>().ok()?;
+    Some(source_id)
+}

--- a/src/index/gaia.rs
+++ b/src/index/gaia.rs
@@ -267,3 +267,213 @@ fn read_first_source_id(path: &Path) -> Option<u64> {
     let source_id = first_line.split(',').nth(1)?.parse::<u64>().ok()?;
     Some(source_id)
 }
+
+/// List all Gaia CSV files in a directory.
+fn list_gaia_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut files: Vec<PathBuf> = fs::read_dir(dir)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension().is_some_and(|ext| ext == "gz")
+                && p.file_name()
+                    .is_some_and(|n| n.to_string_lossy().starts_with("GaiaSource"))
+        })
+        .collect();
+    files.sort();
+    Ok(files)
+}
+
+/// Process a single Gaia file: parse all stars under mag_limit, bin into
+/// per-cell heaps keeping only the N brightest per cell.
+fn process_file(
+    path: &Path,
+    mag_limit: f64,
+    depth: u8,
+    max_per_cell: usize,
+) -> (HashMap<u64, BinaryHeap<HeapStar>>, u64) {
+    let mut heaps: HashMap<u64, BinaryHeap<HeapStar>> = HashMap::new();
+    let mut count: u64 = 0;
+
+    let file = match fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return (heaps, 0),
+    };
+
+    let reader = BufReader::new(GzDecoder::new(file));
+    let mut lines = reader.lines();
+    let _ = lines.next(); // skip header
+
+    for line in lines {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        if let Some(star) = parse_gaia_line(&line, mag_limit) {
+            count += 1;
+            let cell = cdshealpix::nested::hash(depth, star.position.ra, star.position.dec);
+            let hs = HeapStar {
+                mag: star.magnitude,
+                id: star.id,
+                ra: star.position.ra,
+                dec: star.position.dec,
+            };
+
+            let heap = heaps
+                .entry(cell)
+                .or_insert_with(|| BinaryHeap::with_capacity(max_per_cell + 1));
+
+            if heap.len() < max_per_cell {
+                heap.push(hs);
+            } else if let Some(faintest) = heap.peek()
+                && hs.mag < faintest.mag
+            {
+                heap.pop();
+                heap.push(hs);
+            }
+        }
+    }
+
+    (heaps, count)
+}
+
+/// Merge per-file cell heaps into a single set of heaps.
+fn merge_heaps(
+    dst: &mut HashMap<u64, BinaryHeap<HeapStar>>,
+    src: HashMap<u64, BinaryHeap<HeapStar>>,
+    max_per_cell: usize,
+) {
+    for (cell, src_heap) in src {
+        let dst_heap = dst
+            .entry(cell)
+            .or_insert_with(|| BinaryHeap::with_capacity(max_per_cell + 1));
+
+        for hs in src_heap {
+            if dst_heap.len() < max_per_cell {
+                dst_heap.push(hs);
+            } else if let Some(faintest) = dst_heap.peek()
+                && hs.mag < faintest.mag
+            {
+                dst_heap.pop();
+                dst_heap.push(hs);
+            }
+        }
+    }
+}
+
+use std::collections::{BinaryHeap, HashMap};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use rayon::prelude::*;
+
+use super::builder::{CatalogBuilderConfig, build_index_from_stars_pub};
+use super::{Index, IndexStar};
+
+/// Star entry for brightness-ordered heaps (faintest at top for eviction).
+#[derive(PartialEq)]
+struct HeapStar {
+    mag: f64,
+    id: u64,
+    ra: f64,
+    dec: f64,
+}
+
+impl Eq for HeapStar {}
+
+impl PartialOrd for HeapStar {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for HeapStar {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.mag
+            .partial_cmp(&other.mag)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    }
+}
+
+/// Build a zodiacal index directly from Gaia DR1 CSV files on disk.
+///
+/// Processes all files in parallel using rayon, decompressing each file
+/// exactly once. Stars are binned into HEALPix cells with per-cell
+/// brightness heaps, then the uniformized star set is passed to the
+/// standard index builder.
+pub fn build_index_from_gaia(
+    gaia_dir: &Path,
+    mag_limit: f64,
+    config: &CatalogBuilderConfig,
+) -> std::io::Result<Index> {
+    let files = list_gaia_files(gaia_dir)?;
+    let n_files = files.len();
+    let uni_depth = config.effective_uniformize_depth();
+    let max_per_cell = config.max_stars_per_cell;
+
+    eprintln!("Processing {} Gaia files in parallel...", n_files);
+    eprintln!(
+        "  depth={}, max_per_cell={}, mag_limit={:.1}",
+        uni_depth, max_per_cell, mag_limit
+    );
+
+    let files_done = AtomicU64::new(0);
+    let stars_total = AtomicU64::new(0);
+
+    // Phase 1: parallel file processing — each file produces per-cell heaps.
+    let per_file_heaps: Vec<HashMap<u64, BinaryHeap<HeapStar>>> = files
+        .par_iter()
+        .map(|path| {
+            let (heaps, count) = process_file(path, mag_limit, uni_depth, max_per_cell);
+            let done = files_done.fetch_add(1, Ordering::Relaxed) + 1;
+            stars_total.fetch_add(count, Ordering::Relaxed);
+            if done.is_multiple_of(100) || done == n_files as u64 {
+                eprintln!("  [{}/{}] files processed...", done, n_files);
+            }
+            heaps
+        })
+        .collect();
+
+    let total = stars_total.load(Ordering::Relaxed);
+    eprintln!(
+        "Parsed {} stars from {} files, merging heaps...",
+        total, n_files
+    );
+
+    // Phase 2: merge all per-file heaps into one global set.
+    let mut global_heaps: HashMap<u64, BinaryHeap<HeapStar>> = HashMap::new();
+    for file_heaps in per_file_heaps {
+        merge_heaps(&mut global_heaps, file_heaps, max_per_cell);
+    }
+
+    // Flatten heaps into sorted star list.
+    let mut stars: Vec<IndexStar> = Vec::new();
+    for (_, heap) in global_heaps {
+        for hs in heap {
+            stars.push(IndexStar {
+                catalog_id: hs.id,
+                ra: hs.ra,
+                dec: hs.dec,
+                mag: hs.mag,
+            });
+        }
+    }
+    stars.sort_by(|a, b| {
+        a.mag
+            .partial_cmp(&b.mag)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    eprintln!(
+        "Uniformized to {} stars from {} cells",
+        stars.len(),
+        cdshealpix::nested::n_hash(uni_depth)
+    );
+
+    // Phase 3: build quads and KD-trees using the shared core.
+    Ok(build_index_from_stars_pub(
+        stars,
+        config.scale_lower,
+        config.scale_upper,
+        config.effective_max_quads(),
+    ))
+}

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1,4 +1,6 @@
 pub mod builder;
+pub mod catalog;
+pub mod gaia;
 pub mod store;
 
 use crate::kdtree::KdTree;


### PR DESCRIPTION
## Summary
- **`SpatialCatalog` trait**: query stars by HEALPix cell via `stars_in_cell(depth, cell)` and `occupied_cells(depth)`
- **`InMemorySpatialCatalog`**: wraps any `StarCatalog` with brute-force cell filtering
- **`IndexedSpatialCatalog`**: pre-bins stars at construction for O(1) cell lookups, with coarser/finer depth support
- **`GaiaSpatialCatalog`**: streams from gzipped Gaia DR1 CSVs on demand — scans file headers at construction, decompresses only needed files per query. Exploits source_id HEALPix encoding for file selection
- **`build_index_from_spatial()`**: new builder entry point alongside existing `build_index_from_catalog()` — same index output, different catalog interface

Existing `build_index_from_catalog` is unchanged.

## Test plan
- [x] 114 lib tests pass (4 new catalog tests + 1 spatial builder test)
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)