### PR TITLE
Add solve_with_callback() for progress visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,9 +1669,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]

--- a/src/index/builder.rs
+++ b/src/index/builder.rs
@@ -382,7 +382,7 @@ fn build_index_from_stars(
     let total_raw = all_candidates.len();
 
     // Sort by key for deterministic output regardless of parallel scheduling.
-    all_candidates.sort_by(|a, b| a.0.cmp(&b.0));
+    all_candidates.sort_by_key(|a| a.0);
 
     let mut seen: HashSet<[usize; DIMQUADS]> = HashSet::with_capacity(total_raw);
     let mut quads: Vec<Quad> = Vec::with_capacity(total_raw.min(max_quads));

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -648,20 +648,21 @@ mod tests {
         let mut call_count = 0usize;
         let mut last_verified = 0usize;
 
-        let (solution, _stats) = solve_with_callback(
-            &sources,
-            &[&index],
-            (512.0, 512.0),
-            &config,
-            |stats| {
+        let (solution, _stats) =
+            solve_with_callback(&sources, &[&index], (512.0, 512.0), &config, |stats| {
                 call_count += 1;
                 last_verified = stats.n_verified;
-            },
-        );
+            });
 
         assert!(solution.is_some());
-        assert!(call_count > 0, "callback should have been called at least once");
-        assert!(last_verified > 0, "should have verified at least one candidate");
+        assert!(
+            call_count > 0,
+            "callback should have been called at least once"
+        );
+        assert!(
+            last_verified > 0,
+            "should have verified at least one candidate"
+        );
     }
 
     #[test]

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -295,6 +295,25 @@ pub fn solve(
     image_size: (f64, f64),
     config: &SolverConfig,
 ) -> (Option<Solution>, SolveStats) {
+    solve_with_callback(sources, indexes, image_size, config, |_| {})
+}
+
+/// Like [`solve`], but calls `on_progress` after each candidate verification.
+///
+/// The callback receives a snapshot of the current [`SolveStats`], which includes
+/// the number of candidates verified, best rejected log-odds, and whether a
+/// timeout has occurred. This can be used for progress bars, logging, or
+/// adaptive termination.
+///
+/// The no-op callback `|_| {}` is optimized away by the compiler, so
+/// [`solve`] has zero overhead from this mechanism.
+pub fn solve_with_callback(
+    sources: &[DetectedSource],
+    indexes: &[&Index],
+    image_size: (f64, f64),
+    config: &SolverConfig,
+    mut on_progress: impl FnMut(&SolveStats),
+) -> (Option<Solution>, SolveStats) {
     let mut stats = SolveStats {
         n_verified: 0,
         best_rejected: None,
@@ -402,8 +421,10 @@ pub fn solve(
                         &sorted, a, b, c, d, indexes, sources, image_size, config, &mut stats,
                         dist, scale_rad,
                     ) {
+                        on_progress(&stats);
                         return (Some(sol), stats);
                     }
+                    on_progress(&stats);
                 }
             }
         }
@@ -453,8 +474,10 @@ pub fn solve(
                         &sorted, a, b, c, d, indexes, sources, image_size, config, &mut stats,
                         dist, scale_rad,
                     ) {
+                        on_progress(&stats);
                         return (Some(sol), stats);
                     }
+                    on_progress(&stats);
                 }
             }
         }
@@ -604,6 +627,41 @@ mod tests {
 
         // Verify the solution was accepted.
         assert!(solution.verify_result.is_accepted(&config.verify));
+    }
+
+    #[test]
+    fn callback_fires_on_solve() {
+        let (sources, index, _) = make_synthetic_scenario();
+
+        let config = SolverConfig {
+            max_field_stars: 25,
+            code_tolerance: 0.002,
+            verify: VerifyConfig {
+                match_radius_pix: 3.0,
+                log_odds_accept: 10.0,
+                min_matches: 3,
+                ..VerifyConfig::default()
+            },
+            ..SolverConfig::default()
+        };
+
+        let mut call_count = 0usize;
+        let mut last_verified = 0usize;
+
+        let (solution, _stats) = solve_with_callback(
+            &sources,
+            &[&index],
+            (512.0, 512.0),
+            &config,
+            |stats| {
+                call_count += 1;
+                last_verified = stats.n_verified;
+            },
+        );
+
+        assert!(solution.is_some());
+        assert!(call_count > 0, "callback should have been called at least once");
+        assert!(last_verified > 0, "should have verified at least one candidate");
     }
 
     #[test]


### PR DESCRIPTION
Closes #38.

## Summary
- `solve_with_callback(sources, indexes, image_size, config, on_progress)` — calls `on_progress(&SolveStats)` after each quad attempt
- `solve()` delegates to it with `|_| {}`, which the compiler eliminates — zero overhead
- Callback receives live `SolveStats`: verified count, best rejected log-odds, etc.

## Test plan
- [x] New `callback_fires_on_solve` test verifies callback is invoked and receives valid stats
- [x] All 110 lib tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)