### PR TITLE
Refinement module + Gaia sidecar; pre-fit solver filters; bump 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.3.0
+
+### Added
+- `refinement` module: high-precision astrometric refinement using starfield's
+  apparent-place pipeline (proper motion, parallax, light-time, stellar
+  aberration). Targets ~10 mas absolute astrometry on noise-free synthetic data.
+- `RefinementCatalog` + `GaiaAstrometry` + `ObservationContext` types for
+  feeding full Gaia astrometry through to the refinement step.
+- Flat sorted-by-source_id binary catalog sidecar (`SidecarRecord`,
+  `SidecarReader`, `write_sidecar`) with mmap + in-memory pivot table +
+  galloping-search batch lookup. Designed for the `.zdcl.gaia` companion
+  to existing index files (#45).
+- `RefinementCatalog::load_sidecar_filtered()` for loading only the rows
+  needed for a given FOV from a sidecar file.
+
+### Changed
+- Bumped `starfield` dependency from `0.9.1` to `0.11` to pick up the
+  apparent-place pipeline (`Position::observe`, `Position::apparent`,
+  `Star::observe_from`).
+- `solver::try_quad`: `SolverConfig::scale_range` and `SolverConfig::within`
+  are now applied **before** `fit_tan_wcs` rather than after. Eliminates a
+  ~12× pessimization observed when a wide scale_range hint causes every
+  index band to enter the inner fit loop (#48). The `within` filter pads
+  by `index.scale_upper` to keep boundary candidates intact.
+
+### Dependencies
+- Added `nalgebra = "0.32"` (matches starfield's pin) for sidecar interop.
+- Added `memmap2 = "0.9"` for the sidecar reader.
+
 ## 0.2.0
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,7 +168,7 @@ dependencies = [
  "num-traits",
  "pastey",
  "rayon",
- "thiserror 2.0.18",
+ "thiserror",
  "v_frame",
  "y4m",
 ]
@@ -189,12 +195,6 @@ checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
 dependencies = [
  "arrayvec",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -292,7 +292,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f43f12e4bfde350aa1936fa2896c5e8dd6d717ec27f854272b6f3cb2e478479"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bincode",
  "byteorder",
  "chrono",
@@ -308,7 +308,7 @@ dependencies = [
  "png 0.17.16",
  "rayon",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "toml",
 ]
 
@@ -676,6 +676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -710,6 +711,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -754,16 +756,6 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
-name = "gif"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
@@ -780,15 +772,15 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.3.27"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
  "http",
  "indexmap",
  "slab",
@@ -831,23 +823,34 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -858,46 +861,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1035,24 +1072,6 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "exr",
- "gif 0.13.3",
- "jpeg-decoder",
- "num-traits",
- "png 0.17.16",
- "qoi",
- "tiff 0.9.1",
-]
-
-[[package]]
-name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
@@ -1061,7 +1080,7 @@ dependencies = [
  "byteorder-lite",
  "color_quant",
  "exr",
- "gif 0.14.2",
+ "gif",
  "image-webp",
  "moxcms",
  "num-traits",
@@ -1070,7 +1089,7 @@ dependencies = [
  "ravif",
  "rayon",
  "rgb",
- "tiff 0.11.3",
+ "tiff",
  "zune-core",
  "zune-jpeg",
 ]
@@ -1147,6 +1166,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,15 +1204,6 @@ checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
-]
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
-dependencies = [
- "rayon",
 ]
 
 [[package]]
@@ -1317,6 +1337,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1782,33 +1812,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1818,16 +1827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -1866,10 +1866,10 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand",
+ "rand_chacha",
  "simd_helpers",
- "thiserror 2.0.18",
+ "thiserror",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -1946,42 +1946,45 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
  "http",
  "http-body",
+ "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
- "ipnet",
+ "hyper-util",
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
 ]
 
 [[package]]
@@ -1989,6 +1992,20 @@ name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rustix"
@@ -2004,12 +2021,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
- "base64 0.21.7",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2194,16 +2235,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -2220,16 +2251,16 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "starfield"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e158470f36d5b9842de2cce6d602890a5d95a3c6f0afbbd669a20756a6ad6413"
+checksum = "18b93ef240e0fc643093ef80412cae570bc46a0e802f39fc65b38f4322ece9e1"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "byteorder",
  "chrono",
  "clap",
  "flate2",
- "image 0.24.9",
+ "image",
  "indicatif 0.17.11",
  "lazy_static",
  "log",
@@ -2239,14 +2270,13 @@ dependencies = [
  "ndarray 0.16.1",
  "num",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
  "sgp4",
- "term_size",
- "thiserror 1.0.69",
+ "thiserror",
  "time",
  "uom",
 ]
@@ -2256,6 +2286,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2270,9 +2306,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2287,20 +2326,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2320,42 +2359,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2367,17 +2376,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tiff"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
-dependencies = [
- "flate2",
- "jpeg-decoder",
- "weezl",
 ]
 
 [[package]]
@@ -2433,7 +2431,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "windows-sys 0.61.2",
 ]
 
@@ -2444,6 +2442,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 
@@ -2502,6 +2510,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,6 +2586,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,6 +2614,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uom"
@@ -2772,28 +2831,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,6 +2872,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,20 +2902,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2876,7 +2915,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2890,40 +2929,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2933,21 +2951,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2963,21 +2969,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2987,21 +2981,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3016,16 +2998,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3193,6 +3165,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3233,14 +3211,16 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zodiacal"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cdshealpix",
  "clap",
  "fitsio-pure",
  "glob",
- "image 0.25.10",
+ "image",
  "indicatif 0.18.4",
+ "memmap2",
+ "nalgebra",
  "ndarray 0.17.2",
  "rayon",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "zodiacal"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 description = "A blind astrometry plate-solving library"
 license = "Apache-2.0"
-repository = "https://github.com/meawoppl/zodiacal"
+repository = "https://github.com/OrbitalCommons/zodiacal"
 keywords = ["astrometry", "plate-solving", "astronomy", "wcs"]
 categories = ["science"]
 exclude = ["external/", "PLAN.md", "benches/", "scripts/", "scratch/"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,12 @@ image = { version = "0.25.9", optional = true }
 indicatif = { version = "0.18.3", optional = true }
 ndarray = { version = "0.17.2", optional = true }
 cdshealpix = "0.9.1"
+memmap2 = "0.9"
+nalgebra = "0.32"
 rayon = "1.11.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-starfield = "0.9.1"
+starfield = "0.11"
 
 [[bin]]
 name = "zodiacal"

--- a/PLAN.md
+++ b/PLAN.md
@@ -749,10 +749,233 @@ src/
 
 ---
 
+---
+
+### Step 11 — High-Precision Refinement `(L)`
+
+**Module:** `src/refinement/`
+
+**Purpose:** Take the tweaked solution and refine it to ~10 mas absolute astrometric precision by accounting for:
+
+- **Proper motion** from the Gaia epoch (J2016.0) to the observation epoch
+- **Stellar parallax** using the observer's barycentric position
+- **Gravitational light deflection** by the Sun (and giant planets near the field)
+- **Stellar aberration** using the observer's barycentric velocity
+
+All the underlying physics is implemented in `starfield` via `Star::observe_from(observer, time).apparent().radec()` — this module is a thin adapter from zodiacal's types plus a weighted iterative WCS re-fit on top.
+
+#### 11.1 Public API
+
+```rust
+pub struct ObservationContext {
+    /// Time of observation (any starfield Timescale; converted to TT internally)
+    pub time: starfield::time::Time,
+    /// Observer state
+    pub observer: ObserverState,
+}
+
+pub enum ObserverState {
+    /// Ground station (or anywhere fixed to the rotating Earth)
+    Terrestrial {
+        lat_deg: f64,
+        lon_deg: f64,
+        height_m: f64,
+    },
+    /// Spacecraft or other body at a known BCRS state vector
+    Barycentric {
+        position_au: [f64; 3],
+        velocity_au_per_day: [f64; 3],
+    },
+}
+
+pub struct GaiaAstrometry {
+    pub ra_deg: f64,
+    pub dec_deg: f64,
+    pub pmra_mas_per_year: f64,        // already includes cos(dec)
+    pub pmdec_mas_per_year: f64,
+    pub parallax_mas: f64,
+    pub radial_km_per_s: f64,
+    pub ref_epoch_jyear: f64,          // J2016.0 for Gaia DR3
+    // Per-component 1-sigma uncertainties
+    pub sigma_ra_mas: f64,
+    pub sigma_dec_mas: f64,
+    pub sigma_pmra_mas_per_year: f64,
+    pub sigma_pmdec_mas_per_year: f64,
+    pub sigma_parallax_mas: f64,
+    // Covariance correlations are a future addition (see §11.4)
+}
+
+pub struct RefinementCatalog {
+    /// Full astrometry keyed by the same catalog_id stored in IndexStar
+    pub sources: HashMap<u64, GaiaAstrometry>,
+}
+
+pub struct RefinementConfig {
+    /// Initial match radius in pixels (for associating field ↔ catalog)
+    pub match_radius_pix: f64,
+    /// Maximum iterations (typically converges in 2-3)
+    pub max_iterations: usize,
+    /// Convergence threshold: stop when per-iteration WCS change < this (pixels RMS)
+    pub convergence_pix: f64,
+    /// Minimum matches required to attempt a refinement
+    pub min_matches: usize,
+}
+
+pub struct RefinedSolution {
+    pub wcs: SipWcs,                           // refined WCS
+    pub n_iterations: usize,
+    pub residual_rms_mas: f64,                 // sky-plane RMS residual
+    pub residual_rms_pix: f64,
+    pub matched: Vec<RefinedMatch>,            // per-star residuals
+}
+
+pub struct RefinedMatch {
+    pub catalog_id: u64,
+    pub field_source_idx: usize,
+    pub apparent_ra_deg: f64,
+    pub apparent_dec_deg: f64,
+    pub residual_mas: f64,
+    pub weight: f64,
+}
+
+pub fn refine_solution(
+    initial: &tweak::TweakedSolution,         // or whatever tweak.rs returns
+    field_sources: &[DetectedSource],
+    catalog: &RefinementCatalog,
+    obs: &ObservationContext,
+    config: &RefinementConfig,
+) -> Result<RefinedSolution, RefinementError>;
+```
+
+#### 11.2 Pipeline
+
+```
+initial WCS + field sources + catalog + obs context
+              │
+              ▼
+1. Match field sources to catalog stars using initial WCS.
+   (Project catalog RA/Dec → pixel via initial WCS, nearest within match_radius_pix.)
+              │
+              ▼
+2. For each matched catalog star:
+      a. Build starfield::Star from Gaia 6-parameter solution + ref_epoch.
+      b. Build observer starfield::Position:
+         - Terrestrial → construct topos, derive BCRS state at obs time.
+         - Barycentric → pass through.
+      c. direction_apparent = star.observe_from(observer, time).apparent().radec()
+      d. Compute per-star weight from propagated Gaia covariance
+         (position uncertainty at obs_epoch grows as sigma_pos² + sigma_pm² · Δt²).
+              │
+              ▼
+3. Weighted WCS re-fit:
+      - Re-fit SIP WCS using apparent (RA, Dec) as truth and pixel centroids as
+        measurements.
+      - Extend fitting.rs with a weighted-least-squares SIP fit.
+              │
+              ▼
+4. Check convergence. If (new WCS − old WCS) RMS > convergence_pix and
+   iterations remain → loop back to step 1 with refined WCS.
+              │
+              ▼
+5. Return RefinedSolution with per-match residuals.
+```
+
+#### 11.3 Catalog sidecar (deferred; depends on starfield-datasources)
+
+At runtime the `RefinementCatalog` is an in-memory HashMap. For persistence, the plan is a **sidecar file** next to each `.zdcl` index:
+
+```
+my_index.zdcl       ← fast solver index (existing)
+my_index.zdcl.gaia  ← columnar sidecar with full Gaia rows, keyed by catalog_id
+```
+
+**Format (v1):** Apache Arrow / Parquet. Columns: `catalog_id`, `ra`, `dec`, `pmra`, `pmdec`, `parallax`, `radial_velocity`, `ref_epoch`, plus per-component `sigma_*`. Parquet because:
+- Columnar access means loading only the columns we need.
+- Schema evolution: add covariance correlations, BP/RP, RV errors later without breaking readers.
+- Standard tooling — anyone can inspect with pandas or DuckDB.
+
+**Loading:** at solve time, load only the catalog_ids that appear in the FOV (from the initial solution). No need to load the whole sidecar.
+
+Implementation is deferred until `starfield-datasources` exposes a canonical Gaia ingest path. Until then, the in-memory `RefinementCatalog` is user-supplied by the caller.
+
+#### 11.4 Weighting strategy
+
+Per-star weight from Gaia covariance propagated to observation epoch:
+
+```
+sigma_ra(t_obs)  = sqrt(sigma_ra²        + (Δt · sigma_pmra)²)
+sigma_dec(t_obs) = sqrt(sigma_dec²       + (Δt · sigma_pmdec)²)
+sigma_pos(t_obs) = sqrt(sigma_ra(t_obs)² + sigma_dec(t_obs)²) / sqrt(2)
+weight            = 1 / sigma_pos(t_obs)²
+```
+
+where `Δt = t_obs − t_ref` in years. Treats RA and Dec errors as uncorrelated for v1.
+
+**Future work:** full 5×5 covariance propagation with Gaia correlation columns. Needed if residuals stall above ~5 mas and the user wants to go lower. Not blocking for 10 mas.
+
+#### 11.5 Iteration and convergence
+
+Typically 2–3 iterations converge for a well-posed problem:
+
+- **Iteration 1** uses apparent positions but the matching is based on the tweak solution, which may mis-identify stars near the match radius. Re-matching after the apparent-place correction usually adds a few more good matches and drops a few bad ones.
+- **Iteration 2+** re-fits with the improved match list.
+- Stop when per-iteration WCS change (measured as RMS pixel displacement of a grid of test points) drops below `convergence_pix` (default 0.05 pix).
+
+Robust outlier rejection: drop matches with residual > 3σ after each fit.
+
+#### 11.6 Open questions
+
+- **SIP order tradeoff.** Refined residuals may expose distortion the tweaker didn't capture. Refinement could optionally bump SIP order — but that risks over-fitting with few matches. Default: keep the order the tweaker chose.
+- **Deflection by planets.** `starfield::Position::apparent()` loops over `DEFLECTORS` (Sun + giants). For fields >30° from a giant this is ~1 mas. Default behavior is fine; add a feature flag only if a specific field warrants disabling/extending.
+- **Refraction.** Atmospheric refraction for ground-based observers is ~1" at zenith, tens of arc-seconds at low altitudes. starfield's `Position` doesn't apply refraction in the current path. For ground-based 10 mas absolute astrometry, refraction is a real concern. **Decision needed:** either (a) refuse ground observations below some altitude, (b) require callers to pre-correct, or (c) add a refraction model (Hohenkerk-Sinclair / Saastamoinen) as part of this module. Recommend (b) as the interim answer and open an issue on starfield for a proper refraction pipeline.
+- **Where to get the catalog_id → Gaia mapping.** If the index was built from a Gaia catalog, catalog_id IS the Gaia source_id and we're done. If the index was built from something else (Hipparcos, Tycho), we'd need a cross-match table. Defer; assume Gaia indexes for v1.
+
+#### 11.7 Testing
+
+**Unit tests:**
+- Synthetic star at J2016.0 → apparent at J2026.4 with known PM → verify displacement matches analytical expectation to <1 µas.
+- Round-trip: apparent direction → propagate backwards via `Position::observe`-inverse → recover catalog direction.
+- Parallax: source at 10 pc (100 mas parallax), observer at 1 AU different positions — verify apparent direction shifts by 100 mas correctly.
+- Aberration: observer moving at 30 km/s perpendicular to source — verify apparent direction shifted by ~20.5″ toward apex.
+
+**Integration test:**
+- Synthesize a field: take N Gaia sources with known full astrometry, propagate each to a known `(time, observer)` using this module's forward path, project through a known WCS with SIP distortion → generate field_sources with sub-pixel centroids.
+- Run solver → tweak → refinement.
+- Assert: final RMS residual < 10 mas; recovered WCS matches truth to <1 mas at all corners.
+
+**Validation against astropy:**
+- `python_tests.rs`-style harness. For each test case: compute apparent place via astropy's `SkyCoord.apply_space_motion()` + `.transform_to(GCRS(obstime=...))` chain, compare to zodiacal's output. Tolerance: 1 mas.
+
+---
+
+### Step 12 — Hook refinement into the solver output
+
+**Module:** `src/solver.rs` (extension)
+
+The existing solver pipeline ends at `tweak_solution()`. Add a top-level convenience that runs the whole chain:
+
+```rust
+pub fn solve_and_refine(
+    sources: &[DetectedSource],
+    indexes: &[Index],
+    catalog: &RefinementCatalog,
+    obs: &ObservationContext,
+    solver_config: &SolverConfig,
+    tweak_config: &TweakConfig,
+    refinement_config: &RefinementConfig,
+) -> Option<RefinedSolution>;
+```
+
+Refinement is **opt-in**: the base `solve()` and tweak paths stay unchanged. Callers who don't need 10 mas precision don't pay any cost.
+
+---
+
 ## Open Questions / Future Work
 
 - **Index tiling:** For all-sky solving, indexes should be tiled by healpix region. Defer to v2.
 - **Parallelism:** The solver loop over indexes is embarrassingly parallel. Add rayon later.
 - **GPU:** KD-tree range search could benefit from GPU. Way out of scope for v1.
-- **Proper motion:** For high-precision work, stars need epoch propagation. Starfield handles this — integrate when needed.
+- **Proper motion in solver (pre-refinement):** The current solver matches against catalog positions at the index's reference epoch, with no PM. For bright high-PM stars this can cause near-miss matches at >1" displacement after decades. Consider propagating catalog positions to approximate obs epoch before solving, or widening match tolerance for bright stars. Refinement stage fixes this post-hoc but matching-stage errors can prevent refinement from running at all.
 - **Multi-extension indexes:** astrometry.net packs multiple scales into one file. Start with one-scale-per-file.
+- **Refraction model:** See §11.6. Needs a decision if ground-based 10 mas work is in scope.
+- **Covariance-aware refinement:** Full Gaia 5×5 correlation matrix propagation. Needed for sub-5-mas work.

--- a/src/index/builder.rs
+++ b/src/index/builder.rs
@@ -993,11 +993,14 @@ mod tests {
     #[test]
     fn depth_for_scale_reasonable() {
         let d = depth_for_scale(0.0175);
-        assert!(d >= 4 && d <= 8, "depth_for_scale(1deg) = {d}, expected ~6");
+        assert!(
+            (4..=8).contains(&d),
+            "depth_for_scale(1deg) = {d}, expected ~6"
+        );
 
         let d2 = depth_for_scale(0.000291);
         assert!(
-            d2 >= 10 && d2 <= 14,
+            (10..=14).contains(&d2),
             "depth_for_scale(1arcmin) = {d2}, expected ~12"
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod geom;
 pub mod index;
 pub mod kdtree;
 pub mod quads;
+pub mod refinement;
 pub mod solver;
 pub mod tweak;
 pub mod verify;

--- a/src/refinement/apparent.rs
+++ b/src/refinement/apparent.rs
@@ -1,0 +1,186 @@
+//! Apparent-place adapter: maps a catalog Gaia source + observation
+//! context to its apparent (RA, Dec) direction at the observer.
+//!
+//! Delegates to starfield for the physics (PM propagation, light-time,
+//! parallax, aberration). Gravitational light deflection requires a
+//! `SpiceKernel` for deflector-body positions and is opt-in via
+//! [`apparent_radec_with_deflection`].
+
+use nalgebra::Vector3;
+use starfield::positions::Position;
+use starfield::starlib::Star;
+use starfield::time::Time;
+
+use super::types::{GaiaAstrometry, ObservationContext, ObserverState, RefinementError};
+
+/// Compute the apparent direction (RA, Dec, both in radians) of the given
+/// catalog source at the observation time, accounting for proper motion,
+/// parallax, light-time, and stellar aberration.
+///
+/// Gravitational light deflection is NOT applied. Callers who need it
+/// at the ~mas level (e.g. fields near the Sun) should use
+/// [`apparent_radec_with_deflection`].
+pub fn apparent_radec(
+    source: &GaiaAstrometry,
+    obs: &ObservationContext,
+) -> Result<(f64, f64), RefinementError> {
+    let observer = build_observer(&obs.observer)?;
+    let star = build_star(source);
+
+    // observe_from: proper-motion propagation + light-time correction,
+    // produces an Astrometric Position relative to the observer.
+    let astrometric = star.observe_from(&observer, &obs.time);
+
+    // Apply stellar aberration via relativity helper (no kernel needed).
+    // Deflection is skipped in this path.
+    let apparent_vec = apply_aberration_only(&astrometric, &observer);
+
+    Ok(xyz_to_radec(apparent_vec))
+}
+
+fn build_observer(state: &ObserverState) -> Result<Position, RefinementError> {
+    match state {
+        ObserverState::Barycentric {
+            position_au,
+            velocity_au_per_day,
+        } => Ok(Position::barycentric(
+            Vector3::new(position_au[0], position_au[1], position_au[2]),
+            Vector3::new(
+                velocity_au_per_day[0],
+                velocity_au_per_day[1],
+                velocity_au_per_day[2],
+            ),
+            // Target id = 0 (the observer itself as a body at SSB-relative state);
+            // not used downstream except for bookkeeping.
+            0,
+        )),
+    }
+}
+
+fn build_star(source: &GaiaAstrometry) -> Star {
+    let mut star = Star::new(
+        source.ra_deg,
+        source.dec_deg,
+        source.pmra_mas_per_year,
+        source.pmdec_mas_per_year,
+        source.parallax_mas,
+        source.radial_km_per_s,
+    );
+    // Gaia DR3 reference epoch is J2016.0. starfield expects TT Julian date;
+    // jyear_to_tt_jd does the conversion.
+    star = star.with_epoch(jyear_to_tt_jd(source.ref_epoch_jyear));
+    star
+}
+
+/// Apply only stellar aberration to an astrometric position, returning
+/// a unit direction vector. Used when a kernel isn't available for the
+/// full `Position::apparent()` chain.
+fn apply_aberration_only(astrometric: &Position, observer: &Position) -> Vector3<f64> {
+    let mut target = astrometric.position;
+    starfield::relativity::add_aberration(&mut target, &observer.velocity, astrometric.light_time);
+    target
+}
+
+/// Convert Julian year (e.g. 2016.0) to a TT Julian date.
+///
+/// Using the conventional J2000.0 = JD 2451545.0 TT anchor. Gaia uses
+/// TCB as its time system; for our purposes the difference (~30 s over
+/// 16 years) is negligible at the 10 mas level.
+fn jyear_to_tt_jd(jyear: f64) -> f64 {
+    2_451_545.0 + (jyear - 2000.0) * 365.25
+}
+
+fn xyz_to_radec(v: Vector3<f64>) -> (f64, f64) {
+    let r = (v.x * v.x + v.y * v.y + v.z * v.z).sqrt();
+    let ra = v.y.atan2(v.x);
+    let dec = (v.z / r).asin();
+    let ra_wrapped = if ra < 0.0 {
+        ra + 2.0 * std::f64::consts::PI
+    } else {
+        ra
+    };
+    (ra_wrapped, dec)
+}
+
+/// Suppress unused-import warnings for items we'll need in later phases
+/// (e.g. full `Position::apparent()` chain with kernel).
+#[allow(dead_code)]
+fn _keep_time_import_alive(_t: &Time) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A star at the ICRS origin at J2016.0 with no PM, no parallax, no RV,
+    /// observed from the SSB (zero observer velocity), should map back to
+    /// (RA=0, Dec=0) almost exactly.
+    #[test]
+    fn identity_apparent_position() {
+        let src = GaiaAstrometry {
+            ra_deg: 0.0,
+            dec_deg: 0.0,
+            pmra_mas_per_year: 0.0,
+            pmdec_mas_per_year: 0.0,
+            parallax_mas: 0.0,
+            radial_km_per_s: 0.0,
+            ref_epoch_jyear: 2016.0,
+            sigma_ra_mas: 0.0,
+            sigma_dec_mas: 0.0,
+            sigma_pmra_mas_per_year: 0.0,
+            sigma_pmdec_mas_per_year: 0.0,
+            sigma_parallax_mas: 0.0,
+        };
+        let ts = starfield::time::Timescale::default();
+        let time = ts.tt_jd(jyear_to_tt_jd(2016.0), None);
+        let obs = ObservationContext {
+            time,
+            observer: ObserverState::Barycentric {
+                position_au: [0.0, 0.0, 0.0],
+                velocity_au_per_day: [0.0, 0.0, 0.0],
+            },
+        };
+        let (ra, dec) = apparent_radec(&src, &obs).unwrap();
+        assert!(
+            ra.abs() < 1e-9 || (ra - 2.0 * std::f64::consts::PI).abs() < 1e-9,
+            "ra = {ra}"
+        );
+        assert!(dec.abs() < 1e-9, "dec = {dec}");
+    }
+
+    /// A star with 100 mas/yr of RA proper motion, propagated 10 years forward,
+    /// should have moved 1000 mas = 1 arcsec ≈ 4.848e-6 rad in RA.
+    #[test]
+    fn proper_motion_10_year_displacement() {
+        let src = GaiaAstrometry {
+            ra_deg: 0.0,
+            dec_deg: 0.0,
+            pmra_mas_per_year: 100.0, // already includes cos(dec)
+            pmdec_mas_per_year: 0.0,
+            parallax_mas: 0.0, // (degenerate — Star uses 1 Gpc fallback)
+            radial_km_per_s: 0.0,
+            ref_epoch_jyear: 2016.0,
+            sigma_ra_mas: 0.0,
+            sigma_dec_mas: 0.0,
+            sigma_pmra_mas_per_year: 0.0,
+            sigma_pmdec_mas_per_year: 0.0,
+            sigma_parallax_mas: 0.0,
+        };
+        let ts = starfield::time::Timescale::default();
+        let time = ts.tt_jd(jyear_to_tt_jd(2026.0), None);
+        let obs = ObservationContext {
+            time,
+            observer: ObserverState::Barycentric {
+                position_au: [0.0, 0.0, 0.0],
+                velocity_au_per_day: [0.0, 0.0, 0.0],
+            },
+        };
+        let (ra, _dec) = apparent_radec(&src, &obs).unwrap();
+
+        let expected_ra_rad = 1000.0 * (std::f64::consts::PI / (180.0 * 3_600_000.0));
+        let err_mas = (ra - expected_ra_rad).abs() * (180.0 * 3_600_000.0) / std::f64::consts::PI;
+        assert!(
+            err_mas < 1.0,
+            "RA error {err_mas} mas (expected ≈ 1000 mas displacement)"
+        );
+    }
+}

--- a/src/refinement/mod.rs
+++ b/src/refinement/mod.rs
@@ -18,7 +18,7 @@ mod tests;
 
 pub use apparent::apparent_radec;
 pub use refine::refine_solution;
-pub use sidecar::{SidecarReader, SidecarRecord, write_sidecar, DEFAULT_PIVOT_STRIDE};
+pub use sidecar::{DEFAULT_PIVOT_STRIDE, SidecarReader, SidecarRecord, write_sidecar};
 pub use types::{
     GaiaAstrometry, ObservationContext, ObserverState, RefinedMatch, RefinedSolution,
     RefinementCatalog, RefinementConfig, RefinementError,

--- a/src/refinement/mod.rs
+++ b/src/refinement/mod.rs
@@ -1,0 +1,25 @@
+//! High-precision astrometric refinement.
+//!
+//! Takes a solved WCS and refines it to the ~10 mas absolute-astrometry level
+//! by applying the full apparent-place transformation (proper motion, parallax,
+//! gravitational light deflection, stellar aberration) to matched catalog stars.
+//!
+//! The underlying physics is implemented in `starfield`; this module adapts
+//! zodiacal's catalog + observation types into starfield's `Star` / `Position`
+//! pipeline and adds a weighted iterative WCS re-fit on top.
+
+mod apparent;
+mod refine;
+mod sidecar;
+mod types;
+
+#[cfg(test)]
+mod tests;
+
+pub use apparent::apparent_radec;
+pub use refine::refine_solution;
+pub use sidecar::{SidecarReader, SidecarRecord, write_sidecar, DEFAULT_PIVOT_STRIDE};
+pub use types::{
+    GaiaAstrometry, ObservationContext, ObserverState, RefinedMatch, RefinedSolution,
+    RefinementCatalog, RefinementConfig, RefinementError,
+};

--- a/src/refinement/refine.rs
+++ b/src/refinement/refine.rs
@@ -164,10 +164,10 @@ pub fn refine_solution(
 /// epoch, treating RA and Dec errors as uncorrelated (see PLAN.md §11.4).
 fn gaia_weight(astro: &super::types::GaiaAstrometry, obs: &ObservationContext) -> f64 {
     let dt_years = (obs.time.tt() - jyear_to_tt_jd(astro.ref_epoch_jyear)) / 365.25;
-    let sigma_ra_sq = astro.sigma_ra_mas.powi(2)
-        + (dt_years * astro.sigma_pmra_mas_per_year).powi(2);
-    let sigma_dec_sq = astro.sigma_dec_mas.powi(2)
-        + (dt_years * astro.sigma_pmdec_mas_per_year).powi(2);
+    let sigma_ra_sq =
+        astro.sigma_ra_mas.powi(2) + (dt_years * astro.sigma_pmra_mas_per_year).powi(2);
+    let sigma_dec_sq =
+        astro.sigma_dec_mas.powi(2) + (dt_years * astro.sigma_pmdec_mas_per_year).powi(2);
     let sigma_pos_sq = (sigma_ra_sq + sigma_dec_sq) / 2.0;
     if sigma_pos_sq > 0.0 {
         1.0 / sigma_pos_sq
@@ -180,11 +180,7 @@ fn jyear_to_tt_jd(jyear: f64) -> f64 {
     2_451_545.0 + (jyear - 2000.0) * 365.25
 }
 
-fn rms_pixel(
-    sky_xyz: &[[f64; 3]],
-    field_xy: &[(f64, f64)],
-    wcs: &SipWcs,
-) -> f64 {
+fn rms_pixel(sky_xyz: &[[f64; 3]], field_xy: &[(f64, f64)], wcs: &SipWcs) -> f64 {
     let mut sum_sq = 0.0;
     let mut n = 0usize;
     for (xyz, (fx, fy)) in sky_xyz.iter().zip(field_xy.iter()) {
@@ -226,9 +222,9 @@ fn wcs_changed_less_than(
         ((d_ra * tan.crval[1].cos()).powi(2) + d_dec.powi(2)).sqrt() / scale_rad_per_pix;
 
     let mut cd_delta_sq = 0.0;
-    for i in 0..2 {
-        for j in 0..2 {
-            cd_delta_sq += (tan.cd[i][j] - prev_cd[i][j]).powi(2);
+    for (cd_row, prev_row) in tan.cd.iter().zip(prev_cd.iter()) {
+        for (cd_v, prev_v) in cd_row.iter().zip(prev_row.iter()) {
+            cd_delta_sq += (cd_v - prev_v).powi(2);
         }
     }
     let cd_delta = cd_delta_sq.sqrt() / scale_rad_per_pix.max(f64::EPSILON);

--- a/src/refinement/refine.rs
+++ b/src/refinement/refine.rs
@@ -1,0 +1,237 @@
+//! Iterative refinement of a tweaked WCS to ~10 mas absolute astrometry.
+//!
+//! Takes a `SipWcs` from `tweak_solution` plus a catalog of full Gaia
+//! astrometry and an observation context, and returns an updated WCS
+//! where matched catalog stars' **apparent** positions are used as the
+//! sky-side truth instead of their catalog (ICRS @ ref epoch) positions.
+//!
+//! SIP distortion coefficients are preserved across refinement (SIP
+//! captures optical distortion in pixel space, which does not change
+//! when the apparent-place correction is applied). Only the TAN
+//! parameters — CRVAL, CD matrix — are re-fit.
+
+use crate::extraction::DetectedSource;
+use crate::fitting::fit_tan_wcs;
+use crate::geom::sip::SipWcs;
+use crate::geom::sphere::radec_to_xyz;
+use crate::index::Index;
+use crate::kdtree::KdTree;
+
+use super::apparent::apparent_radec;
+use super::types::{
+    ObservationContext, RefinedMatch, RefinedSolution, RefinementCatalog, RefinementConfig,
+    RefinementError,
+};
+
+/// Refine a tweaked WCS by applying apparent-place corrections to matched
+/// catalog stars and re-fitting the TAN parameters.
+///
+/// The SIP distortion coefficients on `initial` are preserved unchanged.
+pub fn refine_solution(
+    initial: &SipWcs,
+    field_sources: &[DetectedSource],
+    index: &Index,
+    catalog: &RefinementCatalog,
+    obs: &ObservationContext,
+    config: &RefinementConfig,
+) -> Result<RefinedSolution, RefinementError> {
+    let field_points: Vec<[f64; 2]> = field_sources.iter().map(|s| [s.x, s.y]).collect();
+    let field_indices: Vec<usize> = (0..field_sources.len()).collect();
+    let field_tree = KdTree::<2>::build(field_points, field_indices);
+
+    let match_radius_sq = config.match_radius_pix * config.match_radius_pix;
+    let image_size = (initial.tan.image_size[0], initial.tan.image_size[1]);
+
+    let mut current = initial.clone();
+    let mut prev_crval = current.tan.crval;
+    let mut prev_cd = current.tan.cd;
+
+    let mut matches: Vec<RefinedMatch> = Vec::new();
+    let mut residual_rms_pix = f64::NAN;
+    let mut residual_rms_mas = f64::NAN;
+    let mut iterations_run = 0;
+
+    for iter in 0..config.max_iterations {
+        iterations_run = iter + 1;
+
+        // 1. Find candidate catalog stars in the field of view.
+        let (center_ra, center_dec) = current.field_center();
+        let center_xyz = radec_to_xyz(center_ra, center_dec);
+        let field_radius = current.field_radius();
+        let radius_sq = 2.0 * (1.0 - field_radius.cos());
+        let nearby = index.star_tree.range_search(&center_xyz, radius_sq);
+
+        // 2. For each catalog star with Gaia astrometry, compute apparent
+        //    position and attempt to match to a field source.
+        let mut matched_app_xyz: Vec<[f64; 3]> = Vec::new();
+        let mut matched_field_xy: Vec<(f64, f64)> = Vec::new();
+        let mut local_matches: Vec<RefinedMatch> = Vec::new();
+
+        for result in &nearby {
+            let star = &index.stars[result.index];
+            let Some(astro) = catalog.get(star.catalog_id) else {
+                continue;
+            };
+
+            let (apparent_ra, apparent_dec) = apparent_radec(astro, obs)
+                .map_err(|e| RefinementError::Starfield(format!("{e}")))?;
+            let app_xyz = radec_to_xyz(apparent_ra, apparent_dec);
+
+            let predicted_pixel = current.radec_to_pixel(apparent_ra, apparent_dec);
+            let Some((pred_x, pred_y)) = predicted_pixel else {
+                continue;
+            };
+
+            let margin = 10.0;
+            if pred_x < -margin
+                || pred_x > image_size.0 + margin
+                || pred_y < -margin
+                || pred_y > image_size.1 + margin
+            {
+                continue;
+            }
+
+            if let Some(nearest) = field_tree.nearest(&[pred_x, pred_y])
+                && nearest.dist_sq <= match_radius_sq
+            {
+                let fs = &field_sources[nearest.index];
+                let dx = pred_x - fs.x;
+                let dy = pred_y - fs.y;
+                let residual_pix = (dx * dx + dy * dy).sqrt();
+
+                matched_app_xyz.push(app_xyz);
+                matched_field_xy.push((fs.x, fs.y));
+
+                let weight = gaia_weight(astro, obs);
+                local_matches.push(RefinedMatch {
+                    catalog_id: star.catalog_id,
+                    field_source_idx: nearest.index,
+                    apparent_ra_deg: apparent_ra.to_degrees(),
+                    apparent_dec_deg: apparent_dec.to_degrees(),
+                    residual_mas: residual_pix_to_mas(residual_pix, &current),
+                    weight,
+                });
+            }
+        }
+
+        let n_matches = matched_app_xyz.len();
+        if n_matches < config.min_matches {
+            return Err(RefinementError::InsufficientMatches {
+                required: config.min_matches,
+                actual: n_matches,
+            });
+        }
+
+        // 3. Re-fit TAN using the apparent positions as the sky truth.
+        let new_tan = fit_tan_wcs(&matched_app_xyz, &matched_field_xy, image_size)
+            .map_err(|_| RefinementError::Starfield("fit_tan_wcs failed".into()))?;
+
+        // Preserve SIP distortion; only TAN parameters change across refinement.
+        current = SipWcs {
+            tan: new_tan,
+            a: current.a,
+            b: current.b,
+            a_order: current.a_order,
+            b_order: current.b_order,
+            ap: current.ap,
+            bp: current.bp,
+            ap_order: current.ap_order,
+            bp_order: current.bp_order,
+        };
+
+        // 4. Compute residual RMS and convergence diagnostics.
+        matches = local_matches;
+        residual_rms_pix = rms_pixel(&matched_app_xyz, &matched_field_xy, &current);
+        residual_rms_mas = residual_rms_pix * pixel_scale_mas(&current);
+
+        if wcs_changed_less_than(prev_crval, prev_cd, &current.tan, config.convergence_pix) {
+            break;
+        }
+        prev_crval = current.tan.crval;
+        prev_cd = current.tan.cd;
+    }
+
+    Ok(RefinedSolution {
+        wcs: current,
+        n_iterations: iterations_run,
+        residual_rms_mas,
+        residual_rms_pix,
+        matched: matches,
+    })
+}
+
+/// Per-source weight from Gaia uncertainties propagated to the observation
+/// epoch, treating RA and Dec errors as uncorrelated (see PLAN.md §11.4).
+fn gaia_weight(astro: &super::types::GaiaAstrometry, obs: &ObservationContext) -> f64 {
+    let dt_years = (obs.time.tt() - jyear_to_tt_jd(astro.ref_epoch_jyear)) / 365.25;
+    let sigma_ra_sq = astro.sigma_ra_mas.powi(2)
+        + (dt_years * astro.sigma_pmra_mas_per_year).powi(2);
+    let sigma_dec_sq = astro.sigma_dec_mas.powi(2)
+        + (dt_years * astro.sigma_pmdec_mas_per_year).powi(2);
+    let sigma_pos_sq = (sigma_ra_sq + sigma_dec_sq) / 2.0;
+    if sigma_pos_sq > 0.0 {
+        1.0 / sigma_pos_sq
+    } else {
+        1.0
+    }
+}
+
+fn jyear_to_tt_jd(jyear: f64) -> f64 {
+    2_451_545.0 + (jyear - 2000.0) * 365.25
+}
+
+fn rms_pixel(
+    sky_xyz: &[[f64; 3]],
+    field_xy: &[(f64, f64)],
+    wcs: &SipWcs,
+) -> f64 {
+    let mut sum_sq = 0.0;
+    let mut n = 0usize;
+    for (xyz, (fx, fy)) in sky_xyz.iter().zip(field_xy.iter()) {
+        if let Some((px, py)) = wcs.tan.xyz_to_pixel(*xyz) {
+            let dx = px - *fx;
+            let dy = py - *fy;
+            sum_sq += dx * dx + dy * dy;
+            n += 1;
+        }
+    }
+    if n > 0 {
+        (sum_sq / n as f64).sqrt()
+    } else {
+        f64::NAN
+    }
+}
+
+fn pixel_scale_mas(wcs: &SipWcs) -> f64 {
+    // Pixel scale in degrees/pixel → mas/pixel.
+    wcs.tan.pixel_scale() * 3_600_000.0
+}
+
+fn residual_pix_to_mas(residual_pix: f64, wcs: &SipWcs) -> f64 {
+    residual_pix * pixel_scale_mas(wcs)
+}
+
+fn wcs_changed_less_than(
+    prev_crval: [f64; 2],
+    prev_cd: [[f64; 2]; 2],
+    tan: &crate::geom::tan::TanWcs,
+    threshold_pix: f64,
+) -> bool {
+    // Approximate: test a ~1 pixel movement in crval against pixel scale,
+    // plus Frobenius norm of CD delta expressed in pixel-equivalent units.
+    let d_ra = (tan.crval[0] - prev_crval[0]).abs();
+    let d_dec = (tan.crval[1] - prev_crval[1]).abs();
+    let scale_rad_per_pix = tan.pixel_scale().to_radians();
+    let crval_shift_pix =
+        ((d_ra * tan.crval[1].cos()).powi(2) + d_dec.powi(2)).sqrt() / scale_rad_per_pix;
+
+    let mut cd_delta_sq = 0.0;
+    for i in 0..2 {
+        for j in 0..2 {
+            cd_delta_sq += (tan.cd[i][j] - prev_cd[i][j]).powi(2);
+        }
+    }
+    let cd_delta = cd_delta_sq.sqrt() / scale_rad_per_pix.max(f64::EPSILON);
+
+    crval_shift_pix < threshold_pix && cd_delta < threshold_pix
+}

--- a/src/refinement/sidecar.rs
+++ b/src/refinement/sidecar.rs
@@ -1,0 +1,506 @@
+//! Flat sorted-by-source_id binary sidecar for Gaia astrometry.
+//!
+//! The sidecar sits next to a `.zdcl` index file (`my_index.zdcl.gaia`) and
+//! carries the refinement-minimal Gaia astrometry subset needed to compute
+//! apparent-place positions. Access pattern is point lookups by Gaia
+//! `source_id`, optimized for batch FOV queries via galloping search from
+//! the previous hit.
+//!
+//! See issue #45 for the full rationale; briefly: Gaia's `source_id` has
+//! HEALPix locality baked in, so sorting records by source_id gives free
+//! spatial clustering on disk, and compression doesn't help enough to
+//! justify parquet's decompression cost on the query path.
+
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
+use std::path::Path;
+
+use memmap2::Mmap;
+
+const MAGIC: &[u8; 8] = b"ZDCLGAIA";
+const VERSION: u32 = 1;
+const HEADER_SIZE: usize = 64;
+pub const RECORD_SIZE: u32 = 88;
+pub const DEFAULT_PIVOT_STRIDE: u32 = 4096;
+
+/// One row of the refinement sidecar. `repr(C)` so the on-disk layout
+/// matches the in-memory struct byte-for-byte; this lets us cast slices
+/// of the mmap directly to `&[SidecarRecord]` without deserialization.
+///
+/// Unpublished fields (no parallax solution, no radial velocity) are
+/// stored as `f64::NAN` so the reader doesn't need a validity bitmap.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SidecarRecord {
+    pub source_id: u64,
+    pub ref_epoch: f64,
+    pub ra: f64,
+    pub dec: f64,
+    pub pmra: f64,
+    pub pmdec: f64,
+    pub parallax: f64,
+    pub radial_velocity: f64,
+    pub sigma_ra: f32,
+    pub sigma_dec: f32,
+    pub sigma_pmra: f32,
+    pub sigma_pmdec: f32,
+    pub sigma_parallax: f32,
+    pub flags: u32,
+}
+
+// Compile-time assertion that the Rust struct is exactly 88 bytes.
+const _: () = assert!(std::mem::size_of::<SidecarRecord>() == RECORD_SIZE as usize);
+
+/// Write a sidecar file. Records are sorted by `source_id` before being
+/// written, so the input iterator does not need to be pre-sorted.
+///
+/// `pivot_stride` controls the in-file pivot table density. `DEFAULT_PIVOT_STRIDE`
+/// (4096) gives ~7.5k pivots for a 31M-record sidecar — about 60 KB of
+/// in-memory index, which fits comfortably in L2.
+pub fn write_sidecar<I>(path: &Path, records: I, pivot_stride: u32) -> io::Result<()>
+where
+    I: IntoIterator<Item = SidecarRecord>,
+{
+    assert!(pivot_stride > 0, "pivot_stride must be positive");
+
+    let mut records: Vec<SidecarRecord> = records.into_iter().collect();
+    records.sort_by_key(|r| r.source_id);
+
+    let n_records = records.len() as u64;
+    let pivot_count = if records.is_empty() {
+        0
+    } else {
+        ((records.len() - 1) / pivot_stride as usize + 1) as u32
+    };
+
+    let file = File::create(path)?;
+    let mut w = BufWriter::new(file);
+
+    // Header.
+    w.write_all(MAGIC)?;
+    w.write_all(&VERSION.to_le_bytes())?;
+    w.write_all(&RECORD_SIZE.to_le_bytes())?;
+    w.write_all(&n_records.to_le_bytes())?;
+    w.write_all(&pivot_stride.to_le_bytes())?;
+    w.write_all(&pivot_count.to_le_bytes())?;
+    w.write_all(&[0u8; 32])?; // reserved
+
+    // Pivot table: source_id at each k*pivot_stride.
+    for k in 0..pivot_count as usize {
+        let idx = k * pivot_stride as usize;
+        w.write_all(&records[idx].source_id.to_le_bytes())?;
+    }
+
+    // Pad to the records-start offset, which must be 8-aligned.
+    let written_so_far = HEADER_SIZE + (pivot_count as usize) * 8;
+    let records_start = (written_so_far + 7) & !7;
+    let pad = records_start - written_so_far;
+    if pad > 0 {
+        w.write_all(&vec![0u8; pad])?;
+    }
+
+    // Records. Safe to cast because SidecarRecord is repr(C) with no padding
+    // gaps (verified by the size_of assertion above).
+    let records_bytes: &[u8] = unsafe {
+        std::slice::from_raw_parts(
+            records.as_ptr() as *const u8,
+            records.len() * RECORD_SIZE as usize,
+        )
+    };
+    w.write_all(records_bytes)?;
+
+    w.flush()?;
+    Ok(())
+}
+
+/// Mmap-backed random-access reader over a sidecar file.
+///
+/// Thread-safe for concurrent reads; the mmap and pivot table are immutable
+/// after `open`.
+pub struct SidecarReader {
+    mmap: Mmap,
+    n_records: usize,
+    pivot_stride: u32,
+    /// Pivot table kept in memory (small — ~60 KB for a 31M-row sidecar).
+    pivots: Vec<u64>,
+    /// Byte offset in the mmap where records[0] begins.
+    records_offset: usize,
+}
+
+impl SidecarReader {
+    pub fn open(path: &Path) -> io::Result<Self> {
+        let file = File::open(path)?;
+        let mmap = unsafe { Mmap::map(&file)? };
+
+        if mmap.len() < HEADER_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "sidecar file smaller than header",
+            ));
+        }
+        if &mmap[0..8] != MAGIC {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "sidecar magic mismatch",
+            ));
+        }
+        let version = u32::from_le_bytes(mmap[8..12].try_into().unwrap());
+        let record_size = u32::from_le_bytes(mmap[12..16].try_into().unwrap());
+        if version != VERSION || record_size != RECORD_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported sidecar: version={version} record_size={record_size}"),
+            ));
+        }
+        let n_records = u64::from_le_bytes(mmap[16..24].try_into().unwrap()) as usize;
+        let pivot_stride = u32::from_le_bytes(mmap[24..28].try_into().unwrap());
+        let pivot_count = u32::from_le_bytes(mmap[28..32].try_into().unwrap()) as usize;
+
+        // Parse pivot table.
+        let pivot_bytes_start = HEADER_SIZE;
+        let pivot_bytes_end = pivot_bytes_start + pivot_count * 8;
+        if mmap.len() < pivot_bytes_end {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "sidecar truncated in pivot table",
+            ));
+        }
+        let mut pivots = Vec::with_capacity(pivot_count);
+        for k in 0..pivot_count {
+            let off = pivot_bytes_start + k * 8;
+            pivots.push(u64::from_le_bytes(mmap[off..off + 8].try_into().unwrap()));
+        }
+
+        // Records start at the next 8-aligned offset after the pivot table.
+        let records_offset = (pivot_bytes_end + 7) & !7;
+        let expected_end = records_offset + n_records * RECORD_SIZE as usize;
+        if mmap.len() < expected_end {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "sidecar truncated in records",
+            ));
+        }
+
+        Ok(Self {
+            mmap,
+            n_records,
+            pivot_stride,
+            pivots,
+            records_offset,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.n_records
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.n_records == 0
+    }
+
+    /// Byte slice that covers `n_records * RECORD_SIZE` bytes of records.
+    fn records_bytes(&self) -> &[u8] {
+        &self.mmap[self.records_offset..self.records_offset + self.n_records * RECORD_SIZE as usize]
+    }
+
+    /// Borrow a single record by its index in the sorted records array.
+    fn record_at(&self, idx: usize) -> &SidecarRecord {
+        debug_assert!(idx < self.n_records);
+        let offset = idx * RECORD_SIZE as usize;
+        let bytes = &self.records_bytes()[offset..offset + RECORD_SIZE as usize];
+        // Safe: mmap is 8-aligned, records_offset is 8-aligned, and
+        // SidecarRecord is repr(C) with native alignment.
+        unsafe { &*(bytes.as_ptr() as *const SidecarRecord) }
+    }
+
+    /// Point lookup. O(log n).
+    pub fn get(&self, source_id: u64) -> Option<&SidecarRecord> {
+        if self.n_records == 0 {
+            return None;
+        }
+        let (lo, hi) = self.pivot_window(source_id);
+        self.binsearch_range(lo, hi, source_id)
+    }
+
+    /// Bulk lookup. Sorts the input internally (so callers may pass an
+    /// arbitrary order) and uses galloping search from the prior hit for
+    /// amortized linear-time scanning of spatially clustered queries.
+    ///
+    /// Returns one `Option<SidecarRecord>` per input source_id, in the
+    /// same order as the input (not sorted order).
+    pub fn get_many(&self, source_ids: &[u64]) -> Vec<Option<SidecarRecord>> {
+        let mut indexed: Vec<(usize, u64)> = source_ids
+            .iter()
+            .copied()
+            .enumerate()
+            .collect();
+        indexed.sort_by_key(|&(_, id)| id);
+
+        let mut out = vec![None; source_ids.len()];
+        if self.n_records == 0 {
+            return out;
+        }
+
+        // Galloping search from the previous hit's index.
+        let mut last_idx: usize = 0;
+        for &(orig_i, id) in &indexed {
+            match self.gallop_find(last_idx, id) {
+                Some(idx) => {
+                    out[orig_i] = Some(*self.record_at(idx));
+                    last_idx = idx;
+                }
+                None => {
+                    // id not present; last_idx unchanged.
+                }
+            }
+        }
+        out
+    }
+
+    /// Locate the window [lo, hi) of record indices that could contain
+    /// `source_id`, using the pivot table.
+    fn pivot_window(&self, source_id: u64) -> (usize, usize) {
+        if self.pivots.is_empty() {
+            return (0, self.n_records);
+        }
+        // partition_point: first pivot whose id > source_id.
+        let p = self.pivots.partition_point(|&pid| pid <= source_id);
+        let lo = if p == 0 { 0 } else { (p - 1) * self.pivot_stride as usize };
+        let hi = (p * self.pivot_stride as usize).min(self.n_records);
+        (lo, hi)
+    }
+
+    /// Binsearch for `source_id` within [lo, hi). Returns the record index
+    /// if found, else None.
+    fn binsearch_range(&self, mut lo: usize, mut hi: usize, source_id: u64) -> Option<&SidecarRecord> {
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+            let mid_id = self.record_at(mid).source_id;
+            match mid_id.cmp(&source_id) {
+                std::cmp::Ordering::Equal => return Some(self.record_at(mid)),
+                std::cmp::Ordering::Less => lo = mid + 1,
+                std::cmp::Ordering::Greater => hi = mid,
+            }
+        }
+        None
+    }
+
+    /// Galloping search starting from `start` for a record with the given
+    /// `source_id`. Returns the index if found. Backward galloping also
+    /// supported for occasional unsorted input.
+    fn gallop_find(&self, start: usize, source_id: u64) -> Option<usize> {
+        if self.n_records == 0 {
+            return None;
+        }
+        let start = start.min(self.n_records.saturating_sub(1));
+        let start_id = self.record_at(start).source_id;
+
+        if start_id == source_id {
+            return Some(start);
+        }
+
+        if source_id > start_id {
+            // Gallop forward.
+            let mut step = 1usize;
+            let mut prev = start;
+            loop {
+                let next = (start + step).min(self.n_records);
+                if next >= self.n_records {
+                    // Target is in [prev+1, n_records).
+                    let found_idx = self
+                        .binsearch_idx(prev + 1, self.n_records, source_id);
+                    return found_idx;
+                }
+                let id = self.record_at(next).source_id;
+                if id == source_id {
+                    return Some(next);
+                }
+                if id > source_id {
+                    // Target, if present, is in [prev+1, next).
+                    return self.binsearch_idx(prev + 1, next, source_id);
+                }
+                prev = next;
+                step *= 2;
+            }
+        } else {
+            // Gallop backward.
+            let mut step = 1usize;
+            let mut prev = start;
+            loop {
+                let next = start.saturating_sub(step);
+                let id = self.record_at(next).source_id;
+                if id == source_id {
+                    return Some(next);
+                }
+                if id < source_id {
+                    // Target, if present, is in [next+1, prev).
+                    return self.binsearch_idx(next + 1, prev, source_id);
+                }
+                if next == 0 {
+                    // Target, if present, is in [0, prev).
+                    return self.binsearch_idx(0, prev, source_id);
+                }
+                prev = next;
+                step *= 2;
+            }
+        }
+    }
+
+    /// Binsearch within [lo, hi) returning the matched index, else None.
+    fn binsearch_idx(&self, mut lo: usize, mut hi: usize, source_id: u64) -> Option<usize> {
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+            let mid_id = self.record_at(mid).source_id;
+            match mid_id.cmp(&source_id) {
+                std::cmp::Ordering::Equal => return Some(mid),
+                std::cmp::Ordering::Less => lo = mid + 1,
+                std::cmp::Ordering::Greater => hi = mid,
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn rec(source_id: u64, ra: f64, dec: f64) -> SidecarRecord {
+        SidecarRecord {
+            source_id,
+            ref_epoch: 2016.0,
+            ra,
+            dec,
+            pmra: 1.5,
+            pmdec: -0.7,
+            parallax: 5.25,
+            radial_velocity: 12.0,
+            sigma_ra: 0.1,
+            sigma_dec: 0.1,
+            sigma_pmra: 0.01,
+            sigma_pmdec: 0.01,
+            sigma_parallax: 0.02,
+            flags: 0,
+        }
+    }
+
+    fn tmp_path(name: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "zodiacal-sidecar-test-{}-{}.gaia",
+            name,
+            std::process::id()
+        ));
+        p
+    }
+
+    #[test]
+    fn roundtrip_small() {
+        let path = tmp_path("rt");
+        let records: Vec<_> = (0..50u64)
+            .map(|i| rec(1000 + i * 7, i as f64, -(i as f64)))
+            .collect();
+        // Pass in a shuffled order — writer should sort.
+        let mut shuffled = records.clone();
+        shuffled.reverse();
+        write_sidecar(&path, shuffled, 8).unwrap();
+
+        let reader = SidecarReader::open(&path).unwrap();
+        assert_eq!(reader.len(), 50);
+
+        for r in &records {
+            let got = reader.get(r.source_id).expect("should be present");
+            assert_eq!(got.source_id, r.source_id);
+            assert_eq!(got.ra, r.ra);
+            assert_eq!(got.dec, r.dec);
+        }
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn get_many_matches_get() {
+        let path = tmp_path("gm");
+        let records: Vec<_> = (0..200u64)
+            .map(|i| rec(10_000 + i * 3, i as f64 * 0.1, i as f64 * -0.05))
+            .collect();
+        write_sidecar(&path, records.clone(), 16).unwrap();
+        let reader = SidecarReader::open(&path).unwrap();
+
+        // Shuffled subset of ids, some not present.
+        let queries = vec![
+            10_015, 10_303, 10_000, 99_999, 10_597, 10_006, 10_003, 12_345, 10_594,
+        ];
+
+        let bulk = reader.get_many(&queries);
+        for (q, got) in queries.iter().zip(bulk.iter()) {
+            let single = reader.get(*q).cloned();
+            assert_eq!(single, *got, "mismatch at source_id {q}");
+        }
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn nan_fields_preserved() {
+        let path = tmp_path("nan");
+        let mut r = rec(42, 1.0, 2.0);
+        r.parallax = f64::NAN;
+        r.radial_velocity = f64::NAN;
+        write_sidecar(&path, vec![r], 1).unwrap();
+        let reader = SidecarReader::open(&path).unwrap();
+        let got = reader.get(42).unwrap();
+        assert!(got.parallax.is_nan());
+        assert!(got.radial_velocity.is_nan());
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn empty_sidecar_opens() {
+        let path = tmp_path("empty");
+        write_sidecar(&path, std::iter::empty::<SidecarRecord>(), 1).unwrap();
+        let reader = SidecarReader::open(&path).unwrap();
+        assert_eq!(reader.len(), 0);
+        assert!(reader.get(42).is_none());
+        assert!(reader.get_many(&[1, 2, 3]).iter().all(|x| x.is_none()));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn bad_magic_rejected() {
+        let path = tmp_path("bad");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"NOPE----").unwrap();
+        f.write_all(&[0u8; 64]).unwrap();
+        drop(f);
+        let err = match SidecarReader::open(&path) {
+            Ok(_) => panic!("bad-magic file should not open"),
+            Err(e) => e,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn clustered_queries_via_galloping() {
+        // 10k records with clustered id queries — exercises galloping forward
+        // across many matches without falling back to full-range binsearch.
+        let path = tmp_path("gallop");
+        let records: Vec<_> = (0..10_000u64)
+            .map(|i| rec(100_000 + i * 2, 0.0, 0.0))
+            .collect();
+        write_sidecar(&path, records, 256).unwrap();
+        let reader = SidecarReader::open(&path).unwrap();
+
+        // Query a contiguous cluster of 500 ids, shuffled.
+        let mut queries: Vec<u64> = (0..500u64).map(|i| 100_000 + (5000 + i) * 2).collect();
+        queries.reverse();
+        let results = reader.get_many(&queries);
+        assert_eq!(results.len(), 500);
+        assert!(results.iter().all(|r| r.is_some()));
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/src/refinement/sidecar.rs
+++ b/src/refinement/sidecar.rs
@@ -229,11 +229,7 @@ impl SidecarReader {
     /// Returns one `Option<SidecarRecord>` per input source_id, in the
     /// same order as the input (not sorted order).
     pub fn get_many(&self, source_ids: &[u64]) -> Vec<Option<SidecarRecord>> {
-        let mut indexed: Vec<(usize, u64)> = source_ids
-            .iter()
-            .copied()
-            .enumerate()
-            .collect();
+        let mut indexed: Vec<(usize, u64)> = source_ids.iter().copied().enumerate().collect();
         indexed.sort_by_key(|&(_, id)| id);
 
         let mut out = vec![None; source_ids.len()];
@@ -265,14 +261,23 @@ impl SidecarReader {
         }
         // partition_point: first pivot whose id > source_id.
         let p = self.pivots.partition_point(|&pid| pid <= source_id);
-        let lo = if p == 0 { 0 } else { (p - 1) * self.pivot_stride as usize };
+        let lo = if p == 0 {
+            0
+        } else {
+            (p - 1) * self.pivot_stride as usize
+        };
         let hi = (p * self.pivot_stride as usize).min(self.n_records);
         (lo, hi)
     }
 
     /// Binsearch for `source_id` within [lo, hi). Returns the record index
     /// if found, else None.
-    fn binsearch_range(&self, mut lo: usize, mut hi: usize, source_id: u64) -> Option<&SidecarRecord> {
+    fn binsearch_range(
+        &self,
+        mut lo: usize,
+        mut hi: usize,
+        source_id: u64,
+    ) -> Option<&SidecarRecord> {
         while lo < hi {
             let mid = lo + (hi - lo) / 2;
             let mid_id = self.record_at(mid).source_id;
@@ -307,8 +312,7 @@ impl SidecarReader {
                 let next = (start + step).min(self.n_records);
                 if next >= self.n_records {
                     // Target is in [prev+1, n_records).
-                    let found_idx = self
-                        .binsearch_idx(prev + 1, self.n_records, source_id);
+                    let found_idx = self.binsearch_idx(prev + 1, self.n_records, source_id);
                     return found_idx;
                 }
                 let id = self.record_at(next).source_id;

--- a/src/refinement/tests.rs
+++ b/src/refinement/tests.rs
@@ -53,8 +53,8 @@ fn make_scenario() -> (
     Vec<DetectedSource>,
     Index,
     RefinementCatalog,
-    TanWcs,          // truth
-    SipWcs,          // initial (biased)
+    TanWcs, // truth
+    SipWcs, // initial (biased)
     ObservationContext,
 ) {
     let wcs_truth = truth_wcs();
@@ -78,10 +78,8 @@ fn make_scenario() -> (
     for i in 0..N_STARS {
         let ix = i % side;
         let iy = i / side;
-        let px = IMAGE_SIZE * 0.1
-            + IMAGE_SIZE * 0.8 * (ix as f64) / (side as f64 - 1.0).max(1.0);
-        let py = IMAGE_SIZE * 0.1
-            + IMAGE_SIZE * 0.8 * (iy as f64) / (side as f64 - 1.0).max(1.0);
+        let px = IMAGE_SIZE * 0.1 + IMAGE_SIZE * 0.8 * (ix as f64) / (side as f64 - 1.0).max(1.0);
+        let py = IMAGE_SIZE * 0.1 + IMAGE_SIZE * 0.8 * (iy as f64) / (side as f64 - 1.0).max(1.0);
 
         // The pixel is the target *apparent* position. Work backwards to find
         // the apparent (RA, Dec), then back-propagate via PM to find the
@@ -201,10 +199,7 @@ fn refinement_via_sidecar_recovers_truth_wcs() {
 
     // Write the in-memory catalog to a sidecar.
     let mut sidecar_path = std::env::temp_dir();
-    sidecar_path.push(format!(
-        "zodiacal-refine-e2e-{}.gaia",
-        std::process::id()
-    ));
+    sidecar_path.push(format!("zodiacal-refine-e2e-{}.gaia", std::process::id()));
     let records: Vec<SidecarRecord> = catalog
         .sources
         .iter()
@@ -237,8 +232,7 @@ fn refinement_via_sidecar_recovers_truth_wcs() {
 
     // Load only the rows for the index's stars (here: all of them).
     let source_ids: Vec<u64> = index.stars.iter().map(|s| s.catalog_id).collect();
-    let reloaded =
-        RefinementCatalog::load_sidecar_filtered(&sidecar_path, &source_ids).unwrap();
+    let reloaded = RefinementCatalog::load_sidecar_filtered(&sidecar_path, &source_ids).unwrap();
     assert_eq!(reloaded.len(), catalog.len());
 
     // Run refinement through the reloaded catalog.
@@ -248,9 +242,8 @@ fn refinement_via_sidecar_recovers_truth_wcs() {
         convergence_pix: 0.001,
         min_matches: 10,
     };
-    let refined =
-        refine_solution(&initial, &field_sources, &index, &reloaded, &obs, &config)
-            .expect("refinement via sidecar should succeed");
+    let refined = refine_solution(&initial, &field_sources, &index, &reloaded, &obs, &config)
+        .expect("refinement via sidecar should succeed");
 
     assert!(
         refined.residual_rms_mas < 1.0,

--- a/src/refinement/tests.rs
+++ b/src/refinement/tests.rs
@@ -1,0 +1,321 @@
+//! End-to-end test: synthetic catalog → PM-displaced field → refinement
+//! recovers the true WCS.
+//!
+//! Setup:
+//! - 20 catalog stars at ref epoch J2016.0 with per-star proper motions
+//!   of ~50 mas/yr (chosen randomly per star).
+//! - Observation at J2026.0 (10 years later).
+//! - Observer at the solar system barycenter (zero velocity), so no
+//!   parallax or aberration effects — only PM propagation.
+//! - "Truth" WCS projects each star's APPARENT (J2026) position to a
+//!   pixel; those pixels are the field sources.
+//! - "Initial" WCS is what the blind solver would produce: we fit
+//!   fit_tan_wcs(catalog_xyz_at_ref_epoch, field_xy), which has
+//!   systematic bias because the catalog positions don't match the
+//!   field pixels.
+//! - Refinement should recover the truth WCS to sub-mas residuals.
+
+use super::*;
+use crate::extraction::DetectedSource;
+use crate::fitting::fit_tan_wcs;
+use crate::geom::sip::SipWcs;
+use crate::geom::sphere::radec_to_xyz;
+use crate::geom::tan::TanWcs;
+use crate::index::{Index, IndexStar};
+use crate::kdtree::KdTree;
+use crate::quads::{DIMCODES, Quad};
+
+const PIXEL_SCALE_ARCSEC: f64 = 2.0;
+const IMAGE_SIZE: f64 = 512.0;
+const REF_EPOCH: f64 = 2016.0;
+const OBS_EPOCH: f64 = 2026.0;
+const N_STARS: usize = 20;
+
+fn truth_wcs() -> TanWcs {
+    let arcsec_rad = (PIXEL_SCALE_ARCSEC / 3600.0).to_radians();
+    TanWcs {
+        crval: [1.0, 0.5],
+        crpix: [IMAGE_SIZE / 2.0, IMAGE_SIZE / 2.0],
+        cd: [[arcsec_rad, 0.0], [0.0, arcsec_rad]],
+        image_size: [IMAGE_SIZE, IMAGE_SIZE],
+    }
+}
+
+fn deterministic_pm(i: usize) -> (f64, f64) {
+    // Per-star PMs in mas/yr, chosen to be nontrivial but not pathological.
+    let state = (i as u64).wrapping_mul(2_654_435_761);
+    let a = ((state % 200) as f64) - 100.0; // -100..+99 mas/yr
+    let b = (((state / 200) % 200) as f64) - 100.0;
+    (a, b)
+}
+
+fn make_scenario() -> (
+    Vec<DetectedSource>,
+    Index,
+    RefinementCatalog,
+    TanWcs,          // truth
+    SipWcs,          // initial (biased)
+    ObservationContext,
+) {
+    let wcs_truth = truth_wcs();
+    let ts = starfield::time::Timescale::default();
+    let obs = ObservationContext {
+        time: ts.tt_jd(jyear_to_tt_jd(OBS_EPOCH), None),
+        observer: ObserverState::Barycentric {
+            position_au: [0.0, 0.0, 0.0],
+            velocity_au_per_day: [0.0, 0.0, 0.0],
+        },
+    };
+
+    let mut index_stars: Vec<IndexStar> = Vec::new();
+    let mut field_sources: Vec<DetectedSource> = Vec::new();
+    let mut catalog = RefinementCatalog::new();
+    let mut ref_xyz: Vec<[f64; 3]> = Vec::new();
+    let mut field_xy: Vec<(f64, f64)> = Vec::new();
+
+    let side = (N_STARS as f64).sqrt().ceil() as usize;
+
+    for i in 0..N_STARS {
+        let ix = i % side;
+        let iy = i / side;
+        let px = IMAGE_SIZE * 0.1
+            + IMAGE_SIZE * 0.8 * (ix as f64) / (side as f64 - 1.0).max(1.0);
+        let py = IMAGE_SIZE * 0.1
+            + IMAGE_SIZE * 0.8 * (iy as f64) / (side as f64 - 1.0).max(1.0);
+
+        // The pixel is the target *apparent* position. Work backwards to find
+        // the apparent (RA, Dec), then back-propagate via PM to find the
+        // catalog (J2016) position.
+        let (apparent_ra, apparent_dec) = wcs_truth.pixel_to_radec(px, py);
+
+        let (pmra_mas_per_year, pmdec_mas_per_year) = deterministic_pm(i);
+        let dt_years = OBS_EPOCH - REF_EPOCH;
+
+        // Back-propagate to get the catalog RA/Dec at J2016.0.
+        // PM is given in RA*cos(dec) and Dec, so RA shift is divided by cos(dec).
+        let mas_per_rad = 180.0 * 3_600_000.0 / std::f64::consts::PI;
+        let d_ra = (pmra_mas_per_year * dt_years) / mas_per_rad / apparent_dec.cos();
+        let d_dec = (pmdec_mas_per_year * dt_years) / mas_per_rad;
+        let ref_ra = apparent_ra - d_ra;
+        let ref_dec = apparent_dec - d_dec;
+
+        index_stars.push(IndexStar {
+            catalog_id: i as u64,
+            ra: ref_ra,
+            dec: ref_dec,
+            mag: i as f64,
+        });
+
+        field_sources.push(DetectedSource {
+            x: px,
+            y: py,
+            flux: 1000.0 - i as f64,
+        });
+
+        catalog.insert(
+            i as u64,
+            GaiaAstrometry {
+                ra_deg: ref_ra.to_degrees(),
+                dec_deg: ref_dec.to_degrees(),
+                pmra_mas_per_year,
+                pmdec_mas_per_year,
+                parallax_mas: 0.0,
+                radial_km_per_s: 0.0,
+                ref_epoch_jyear: REF_EPOCH,
+                sigma_ra_mas: 0.5,
+                sigma_dec_mas: 0.5,
+                sigma_pmra_mas_per_year: 0.1,
+                sigma_pmdec_mas_per_year: 0.1,
+                sigma_parallax_mas: 0.1,
+            },
+        );
+
+        ref_xyz.push(radec_to_xyz(ref_ra, ref_dec));
+        field_xy.push((px, py));
+    }
+
+    // Build Index.
+    let star_points: Vec<[f64; 3]> = index_stars
+        .iter()
+        .map(|s| radec_to_xyz(s.ra, s.dec))
+        .collect();
+    let star_indices: Vec<usize> = (0..index_stars.len()).collect();
+    let star_tree = KdTree::<3>::build(star_points, star_indices);
+    let code_tree = KdTree::<{ DIMCODES }>::build(vec![], vec![]);
+    let index = Index {
+        star_tree,
+        stars: index_stars,
+        code_tree,
+        quads: Vec::<Quad>::new(),
+        scale_lower: 0.0,
+        scale_upper: std::f64::consts::PI,
+        metadata: None,
+    };
+
+    // Biased initial WCS: fit using catalog (J2016.0) positions against
+    // observed pixels (which correspond to J2026.0 apparent positions).
+    let biased_tan = fit_tan_wcs(&ref_xyz, &field_xy, (IMAGE_SIZE, IMAGE_SIZE)).unwrap();
+    let initial = SipWcs::from_tan(biased_tan, 2);
+
+    (field_sources, index, catalog, wcs_truth, initial, obs)
+}
+
+fn jyear_to_tt_jd(jyear: f64) -> f64 {
+    2_451_545.0 + (jyear - 2000.0) * 365.25
+}
+
+/// The biased initial WCS (fit against catalog J2016 positions while the
+/// field sources are at apparent J2026 positions) should have observable
+/// residuals. If this test fails, the scenario isn't exercising refinement.
+#[test]
+fn biased_initial_wcs_has_nontrivial_residuals() {
+    let (field_sources, _index, catalog, truth, initial, obs) = make_scenario();
+
+    // Compute residual of initial WCS at each field source.
+    let mut max_residual_mas = 0.0f64;
+    for (i, fs) in field_sources.iter().enumerate() {
+        let astro = catalog.get(i as u64).unwrap();
+        let (app_ra, app_dec) = apparent_radec(astro, &obs).unwrap();
+        if let Some((px, py)) = initial.radec_to_pixel(app_ra, app_dec) {
+            let dx = px - fs.x;
+            let dy = py - fs.y;
+            let r_pix = (dx * dx + dy * dy).sqrt();
+            let r_mas = r_pix * truth.pixel_scale() * 3_600_000.0;
+            if r_mas > max_residual_mas {
+                max_residual_mas = r_mas;
+            }
+        }
+    }
+    assert!(
+        max_residual_mas > 10.0,
+        "scenario not exercising refinement: max initial residual only {} mas",
+        max_residual_mas
+    );
+}
+
+#[test]
+fn refinement_via_sidecar_recovers_truth_wcs() {
+    // Same scenario as `refinement_recovers_truth_wcs`, but route the
+    // catalog through a persisted sidecar file + load_sidecar_filtered.
+    let (field_sources, index, catalog, _truth, initial, obs) = make_scenario();
+
+    // Write the in-memory catalog to a sidecar.
+    let mut sidecar_path = std::env::temp_dir();
+    sidecar_path.push(format!(
+        "zodiacal-refine-e2e-{}.gaia",
+        std::process::id()
+    ));
+    let records: Vec<SidecarRecord> = catalog
+        .sources
+        .iter()
+        .map(|(source_id, astro)| SidecarRecord {
+            source_id: *source_id,
+            ref_epoch: astro.ref_epoch_jyear,
+            ra: astro.ra_deg,
+            dec: astro.dec_deg,
+            pmra: astro.pmra_mas_per_year,
+            pmdec: astro.pmdec_mas_per_year,
+            parallax: if astro.parallax_mas == 0.0 {
+                f64::NAN
+            } else {
+                astro.parallax_mas
+            },
+            radial_velocity: if astro.radial_km_per_s == 0.0 {
+                f64::NAN
+            } else {
+                astro.radial_km_per_s
+            },
+            sigma_ra: astro.sigma_ra_mas as f32,
+            sigma_dec: astro.sigma_dec_mas as f32,
+            sigma_pmra: astro.sigma_pmra_mas_per_year as f32,
+            sigma_pmdec: astro.sigma_pmdec_mas_per_year as f32,
+            sigma_parallax: astro.sigma_parallax_mas as f32,
+            flags: 0,
+        })
+        .collect();
+    write_sidecar(&sidecar_path, records, 8).unwrap();
+
+    // Load only the rows for the index's stars (here: all of them).
+    let source_ids: Vec<u64> = index.stars.iter().map(|s| s.catalog_id).collect();
+    let reloaded =
+        RefinementCatalog::load_sidecar_filtered(&sidecar_path, &source_ids).unwrap();
+    assert_eq!(reloaded.len(), catalog.len());
+
+    // Run refinement through the reloaded catalog.
+    let config = RefinementConfig {
+        match_radius_pix: 5.0,
+        max_iterations: 5,
+        convergence_pix: 0.001,
+        min_matches: 10,
+    };
+    let refined =
+        refine_solution(&initial, &field_sources, &index, &reloaded, &obs, &config)
+            .expect("refinement via sidecar should succeed");
+
+    assert!(
+        refined.residual_rms_mas < 1.0,
+        "residual RMS via sidecar {} mas",
+        refined.residual_rms_mas
+    );
+    assert_eq!(refined.matched.len(), N_STARS);
+
+    let _ = std::fs::remove_file(&sidecar_path);
+}
+
+#[test]
+fn refinement_recovers_truth_wcs() {
+    let (field_sources, index, catalog, truth, initial, obs) = make_scenario();
+
+    let config = RefinementConfig {
+        match_radius_pix: 5.0,
+        max_iterations: 5,
+        convergence_pix: 0.001,
+        min_matches: 10,
+    };
+
+    let refined = refine_solution(&initial, &field_sources, &index, &catalog, &obs, &config)
+        .expect("refinement should succeed");
+
+    assert!(
+        refined.residual_rms_mas < 1.0,
+        "residual RMS {} mas exceeds 1 mas (expected near-zero for noise-free synthetic)",
+        refined.residual_rms_mas
+    );
+
+    // Compare the pixel→sky mapping at the image center rather than CRVAL
+    // directly: fit_tan_wcs re-parameterizes the tangent point at the
+    // centroid of stars, so CRVAL differs from the truth CRVAL even though
+    // the mapping is equivalent.
+    let (truth_ra, truth_dec) = wcs_pixel_to_radec(&truth, IMAGE_SIZE / 2.0, IMAGE_SIZE / 2.0);
+    let (refined_ra, refined_dec) =
+        wcs_pixel_to_radec_sip(&refined.wcs, IMAGE_SIZE / 2.0, IMAGE_SIZE / 2.0);
+
+    let arcsec = std::f64::consts::PI / (180.0 * 3600.0);
+    let mas = arcsec / 1000.0;
+
+    // Angular separation in mas.
+    let cos_dec = truth_dec.cos();
+    let d_ra_mas = ((refined_ra - truth_ra) * cos_dec) / mas;
+    let d_dec_mas = (refined_dec - truth_dec) / mas;
+    let sep_mas = (d_ra_mas * d_ra_mas + d_dec_mas * d_dec_mas).sqrt();
+
+    assert!(
+        sep_mas < 1.0,
+        "image-center sky position recovered to {sep_mas} mas (should be <1 mas)",
+    );
+
+    assert_eq!(
+        refined.matched.len(),
+        N_STARS,
+        "expected all {} stars to match",
+        N_STARS
+    );
+}
+
+fn wcs_pixel_to_radec(tan: &TanWcs, px: f64, py: f64) -> (f64, f64) {
+    tan.pixel_to_radec(px, py)
+}
+
+fn wcs_pixel_to_radec_sip(sip: &SipWcs, px: f64, py: f64) -> (f64, f64) {
+    sip.pixel_to_radec(px, py)
+}

--- a/src/refinement/types.rs
+++ b/src/refinement/types.rs
@@ -1,0 +1,191 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::geom::sip::SipWcs;
+
+use super::sidecar::{SidecarReader, SidecarRecord};
+
+/// Observation time + observer state, used to evaluate the apparent
+/// direction of a catalog star at the moment of exposure.
+pub struct ObservationContext {
+    pub time: starfield::time::Time,
+    pub observer: ObserverState,
+}
+
+/// Where the observer is in the solar system at the observation time.
+///
+/// For v1 only `Barycentric` is supported. Terrestrial observations must
+/// be pre-reduced to a BCRS state vector by the caller.
+pub enum ObserverState {
+    /// BCRS position and velocity of the observer at `ObservationContext::time`.
+    /// Units: AU and AU/day.
+    Barycentric {
+        position_au: [f64; 3],
+        velocity_au_per_day: [f64; 3],
+    },
+}
+
+/// Full Gaia 6-parameter astrometric solution for one source, plus 1-sigma
+/// uncertainties. Correlations are intentionally omitted from v1; a full
+/// 5x5 covariance block is a future addition (see PLAN.md §11.4).
+#[derive(Debug, Clone, Copy)]
+pub struct GaiaAstrometry {
+    pub ra_deg: f64,
+    pub dec_deg: f64,
+    /// Proper motion in RA, already including cos(dec).
+    pub pmra_mas_per_year: f64,
+    pub pmdec_mas_per_year: f64,
+    pub parallax_mas: f64,
+    pub radial_km_per_s: f64,
+    /// Reference epoch as a Julian year (e.g. 2016.0 for Gaia DR3).
+    pub ref_epoch_jyear: f64,
+
+    pub sigma_ra_mas: f64,
+    pub sigma_dec_mas: f64,
+    pub sigma_pmra_mas_per_year: f64,
+    pub sigma_pmdec_mas_per_year: f64,
+    pub sigma_parallax_mas: f64,
+}
+
+/// In-memory catalog of Gaia astrometry keyed by the same `catalog_id`
+/// stored on each `IndexStar`. A persistent sidecar format (parquet) is
+/// deferred until `starfield-datasources` exposes a canonical ingest path.
+#[derive(Debug, Default, Clone)]
+pub struct RefinementCatalog {
+    pub sources: HashMap<u64, GaiaAstrometry>,
+}
+
+impl RefinementCatalog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, catalog_id: u64, astrometry: GaiaAstrometry) {
+        self.sources.insert(catalog_id, astrometry);
+    }
+
+    pub fn get(&self, catalog_id: u64) -> Option<&GaiaAstrometry> {
+        self.sources.get(&catalog_id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.sources.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.sources.is_empty()
+    }
+
+    /// Load a subset of the sidecar at `path` filtered to the given
+    /// `source_ids`. Missing ids are silently skipped. The caller owns
+    /// the list (typically the `catalog_id`s from the in-memory `Index`).
+    pub fn load_sidecar_filtered(
+        path: &Path,
+        source_ids: &[u64],
+    ) -> Result<Self, RefinementError> {
+        let reader = SidecarReader::open(path).map_err(|e| {
+            RefinementError::Starfield(format!("sidecar open failed: {e}"))
+        })?;
+        let results = reader.get_many(source_ids);
+
+        let mut sources = HashMap::with_capacity(results.len());
+        for record in results.into_iter().flatten() {
+            sources.insert(record.source_id, sidecar_record_to_astrometry(&record));
+        }
+        Ok(Self { sources })
+    }
+}
+
+/// Convert a sidecar on-disk record into the in-memory `GaiaAstrometry`
+/// used by the refinement pipeline.
+///
+/// NaN astrometry fields (unpublished parallax, missing RV) become zero,
+/// matching `starfield::starlib::Star`'s fallback behavior.
+fn sidecar_record_to_astrometry(r: &SidecarRecord) -> GaiaAstrometry {
+    fn nan_to_zero(v: f64) -> f64 {
+        if v.is_nan() { 0.0 } else { v }
+    }
+    GaiaAstrometry {
+        ra_deg: r.ra,
+        dec_deg: r.dec,
+        pmra_mas_per_year: nan_to_zero(r.pmra),
+        pmdec_mas_per_year: nan_to_zero(r.pmdec),
+        parallax_mas: nan_to_zero(r.parallax),
+        radial_km_per_s: nan_to_zero(r.radial_velocity),
+        ref_epoch_jyear: r.ref_epoch,
+        sigma_ra_mas: r.sigma_ra as f64,
+        sigma_dec_mas: r.sigma_dec as f64,
+        sigma_pmra_mas_per_year: r.sigma_pmra as f64,
+        sigma_pmdec_mas_per_year: r.sigma_pmdec as f64,
+        sigma_parallax_mas: r.sigma_parallax as f64,
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RefinementConfig {
+    pub match_radius_pix: f64,
+    pub max_iterations: usize,
+    pub convergence_pix: f64,
+    pub min_matches: usize,
+}
+
+impl Default for RefinementConfig {
+    fn default() -> Self {
+        Self {
+            match_radius_pix: 3.0,
+            max_iterations: 5,
+            convergence_pix: 0.05,
+            min_matches: 10,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RefinedSolution {
+    pub wcs: SipWcs,
+    pub n_iterations: usize,
+    pub residual_rms_mas: f64,
+    pub residual_rms_pix: f64,
+    pub matched: Vec<RefinedMatch>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RefinedMatch {
+    pub catalog_id: u64,
+    pub field_source_idx: usize,
+    pub apparent_ra_deg: f64,
+    pub apparent_dec_deg: f64,
+    pub residual_mas: f64,
+    pub weight: f64,
+}
+
+#[derive(Debug)]
+pub enum RefinementError {
+    InsufficientMatches { required: usize, actual: usize },
+    DidNotConverge(usize),
+    TerrestrialNotSupported,
+    Starfield(String),
+}
+
+impl std::fmt::Display for RefinementError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InsufficientMatches { required, actual } => {
+                write!(
+                    f,
+                    "fewer than {required} field↔catalog matches found ({actual})"
+                )
+            }
+            Self::DidNotConverge(n) => write!(f, "refinement did not converge in {n} iterations"),
+            Self::TerrestrialNotSupported => {
+                write!(
+                    f,
+                    "terrestrial observer not yet supported; provide Barycentric state"
+                )
+            }
+            Self::Starfield(msg) => write!(f, "starfield error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for RefinementError {}

--- a/src/refinement/types.rs
+++ b/src/refinement/types.rs
@@ -79,13 +79,9 @@ impl RefinementCatalog {
     /// Load a subset of the sidecar at `path` filtered to the given
     /// `source_ids`. Missing ids are silently skipped. The caller owns
     /// the list (typically the `catalog_id`s from the in-memory `Index`).
-    pub fn load_sidecar_filtered(
-        path: &Path,
-        source_ids: &[u64],
-    ) -> Result<Self, RefinementError> {
-        let reader = SidecarReader::open(path).map_err(|e| {
-            RefinementError::Starfield(format!("sidecar open failed: {e}"))
-        })?;
+    pub fn load_sidecar_filtered(path: &Path, source_ids: &[u64]) -> Result<Self, RefinementError> {
+        let reader = SidecarReader::open(path)
+            .map_err(|e| RefinementError::Starfield(format!("sidecar open failed: {e}")))?;
         let results = reader.get_many(source_ids);
 
         let mut sources = HashMap::with_capacity(results.len());

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -206,6 +206,37 @@ fn try_quad(
                     radec_to_xyz(s.ra, s.dec)
                 });
 
+                // Pre-fit cheap rejection: see issue #48. The eventual fit's
+                // pixel_scale() and field_center() are well-approximated by
+                // the AB backbone scale and the 4-star centroid respectively;
+                // testing them here lets us skip wrong candidates without
+                // paying for fit_tan_wcs.
+                if let Some((lo_arcsec, hi_arcsec)) = config.scale_range {
+                    let ang_rad = angular_distance(star_xyz[0], star_xyz[1]);
+                    let scale_arcsec = ang_rad.to_degrees() * 3600.0 / ab_dist_px;
+                    if scale_arcsec < lo_arcsec || scale_arcsec > hi_arcsec {
+                        continue;
+                    }
+                }
+                if let Some(ref region) = config.within {
+                    let cx = star_xyz.iter().fold([0.0_f64; 3], |a, v| {
+                        [a[0] + v[0], a[1] + v[1], a[2] + v[2]]
+                    });
+                    let n = (cx[0] * cx[0] + cx[1] * cx[1] + cx[2] * cx[2]).sqrt();
+                    let centroid = [cx[0] / n, cx[1] / n, cx[2] / n];
+                    // The 4-star centroid can sit up to roughly half a quad's
+                    // angular extent away from the eventual fitted tangent
+                    // point. Pad by index.scale_upper to be safely inclusive
+                    // — false positives are caught by verify, false negatives
+                    // would silently drop valid solves.
+                    let region_center =
+                        radec_to_xyz(region.center.ra, region.center.dec);
+                    let padded_radius = region.radius_rad + index.scale_upper;
+                    if angular_distance(region_center, centroid) > padded_radius {
+                        continue;
+                    }
+                }
+
                 let field_xy: [(f64, f64); DIMQUADS] = reordered_positions;
 
                 let fit_result = fit_tan_wcs(star_xyz.as_slice(), field_xy.as_slice(), image_size);
@@ -216,20 +247,6 @@ fn try_quad(
                     | Err(FitError::SingularMatrix)
                     | Err(FitError::ProjectionFailed) => continue,
                 };
-
-                if let Some((lo, hi)) = config.scale_range {
-                    let scale_arcsec = wcs.pixel_scale() * 3600.0;
-                    if scale_arcsec < lo || scale_arcsec > hi {
-                        continue;
-                    }
-                }
-
-                if let Some(ref region) = config.within {
-                    let (ra, dec) = wcs.field_center();
-                    if !region.contains(ra, dec) {
-                        continue;
-                    }
-                }
 
                 let quad_residual_limit = 10.0;
                 let max_residual_sq = quad_residual_limit * quad_residual_limit;
@@ -1009,6 +1026,91 @@ mod tests {
             (0.95..=1.05).contains(&scale_ratio),
             "pixel scale ratio {} outside [0.95, 1.05]",
             scale_ratio
+        );
+    }
+
+    /// Issue #48: a wildly wrong scale_range hint should be rejected before
+    /// fit_tan_wcs runs, so no candidate ever reaches the verify stage.
+    #[test]
+    fn scale_filtering_rejects_pre_fit() {
+        let (sources, index, _) = make_synthetic_scenario();
+        let config = SolverConfig {
+            scale_range: Some((100.0, 200.0)), // truth is 2 arcsec/pixel
+            max_field_stars: 30,
+            code_tolerance: 0.01,
+            verify: VerifyConfig {
+                match_radius_pix: 10.0,
+                log_odds_accept: 10.0,
+                min_matches: 3,
+                ..VerifyConfig::default()
+            },
+            ..SolverConfig::default()
+        };
+        let (solution, stats) = solve(&sources, &[&index], (512.0, 512.0), &config);
+        assert!(solution.is_none());
+        assert_eq!(
+            stats.n_verified, 0,
+            "pre-fit scale filter should prevent any candidate from reaching verify"
+        );
+    }
+
+    /// Issue #48: a `within` region elsewhere on the sky should be rejected
+    /// before fit_tan_wcs runs.
+    #[test]
+    fn within_filter_rejects_pre_fit() {
+        let (sources, index, known_wcs) = make_synthetic_scenario();
+        let (true_ra, true_dec) = known_wcs.field_center();
+        let elsewhere = SkyRegion::from_radians(
+            Equatorial {
+                ra: true_ra + 1.5,
+                dec: (true_dec - 0.8).max(-PI / 2.0 + 0.01),
+            },
+            0.001,
+        );
+        let config = SolverConfig {
+            within: Some(elsewhere),
+            max_field_stars: 25,
+            code_tolerance: 0.002,
+            verify: VerifyConfig {
+                match_radius_pix: 3.0,
+                log_odds_accept: 10.0,
+                min_matches: 3,
+                ..VerifyConfig::default()
+            },
+            ..SolverConfig::default()
+        };
+        let (solution, stats) = solve(&sources, &[&index], (512.0, 512.0), &config);
+        assert!(solution.is_none());
+        assert_eq!(
+            stats.n_verified, 0,
+            "pre-fit within filter should prevent any candidate from reaching verify"
+        );
+    }
+
+    /// Issue #48: a wide scale_range that includes the truth must still let
+    /// the solver succeed (the optimization is allowed to skip non-matching
+    /// candidates but must not reject correct ones).
+    #[test]
+    fn wide_scale_range_still_solves() {
+        let (sources, index, known_wcs) = make_synthetic_scenario();
+        let known_scale_arcsec = known_wcs.pixel_scale() * 3600.0;
+        // ~6× wider than truth on each side.
+        let config = SolverConfig {
+            scale_range: Some((known_scale_arcsec / 6.0, known_scale_arcsec * 6.0)),
+            max_field_stars: 25,
+            code_tolerance: 0.002,
+            verify: VerifyConfig {
+                match_radius_pix: 3.0,
+                log_odds_accept: 10.0,
+                min_matches: 3,
+                ..VerifyConfig::default()
+            },
+            ..SolverConfig::default()
+        };
+        let (solution, _) = solve(&sources, &[&index], (512.0, 512.0), &config);
+        assert!(
+            solution.is_some(),
+            "wide scale_range that includes truth should still solve"
         );
     }
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -219,9 +219,9 @@ fn try_quad(
                     }
                 }
                 if let Some(ref region) = config.within {
-                    let cx = star_xyz.iter().fold([0.0_f64; 3], |a, v| {
-                        [a[0] + v[0], a[1] + v[1], a[2] + v[2]]
-                    });
+                    let cx = star_xyz
+                        .iter()
+                        .fold([0.0_f64; 3], |a, v| [a[0] + v[0], a[1] + v[1], a[2] + v[2]]);
                     let n = (cx[0] * cx[0] + cx[1] * cx[1] + cx[2] * cx[2]).sqrt();
                     let centroid = [cx[0] / n, cx[1] / n, cx[2] / n];
                     // The 4-star centroid can sit up to roughly half a quad's
@@ -229,8 +229,7 @@ fn try_quad(
                     // point. Pad by index.scale_upper to be safely inclusive
                     // — false positives are caught by verify, false negatives
                     // would silently drop valid solves.
-                    let region_center =
-                        radec_to_xyz(region.center.ra, region.center.dec);
+                    let region_center = radec_to_xyz(region.center.ra, region.center.dec);
                     let padded_radius = region.radius_rad + index.scale_upper;
                     if angular_distance(region_center, centroid) > padded_radius {
                         continue;


### PR DESCRIPTION
## Summary

Two logical changes bundled into a 0.3.0 release:

1. **New `src/refinement/` module** — high-precision astrometric refinement on top of the existing tweak step, using starfield's apparent-place pipeline (PM, parallax, light-time, stellar aberration). Targets ~10 mas absolute astrometry. Includes a flat sorted-by-source_id binary sidecar format (`.zdcl.gaia`) for Gaia astrometry, with mmap + galloping-search reads.
2. **Pre-fit solver filters (#48)** — `SolverConfig::scale_range` and `SolverConfig::within` now run before `fit_tan_wcs` instead of after. Eliminates a ~12× pessimization observed when a wide scale_range hint causes every index band to enter the inner fit loop.

Bumps to **0.3.0**, adds CHANGELOG entry, fixes stale `repository` URL in `Cargo.toml`.

## Refinement module

- `ObservationContext` / `ObserverState::Barycentric` — terrestrial deferred (#44).
- `GaiaAstrometry` + `RefinementCatalog` — full 6-parameter Gaia solution + 1σ errors keyed by source_id.
- `apparent_radec()` — proper motion, parallax, light-time, stellar aberration. Gravitational deflection deferred (#43).
- `refine_solution()` — match field ↔ catalog using initial WCS, compute apparent positions, refit TAN preserving SIP distortion, iterate to convergence.
- **Sidecar (#45)**:
  - 88-byte fixed records, repr(C), sorted by source_id
  - File header (64 B) + in-file pivot table for fast binsearch entry
  - `SidecarReader::get_many()` sorts inputs and gallops from the prior hit — for spatially-clustered queries (any single FOV) this collapses to one sequential scan of a ~1 MB cache-hot region
  - NaN sentinel for unpublished parallax/RV (no validity bitmap needed)
- New deps: `memmap2 = "0.9"`, `nalgebra = "0.32"`. Bumps `starfield 0.9.1 → 0.11`.

## Pre-fit filters (#48)

- Scale check: `angular_distance(star_xyz[0], star_xyz[1]) / ab_dist_px → arcsec/pixel`. Equivalent to `wcs.pixel_scale()` post-fit.
- Within check: 4-star centroid → unit vector → (RA, Dec). Padded by `index.scale_upper` to keep boundary candidates intact (false positives are caught by verify; false negatives would silently drop valid solves).
- Drops the now-redundant post-fit versions of both checks.

## Tests

- 124/124 passing.
- 11 new tests in `src/refinement/` covering apparent-place primitives, sidecar round-trip, `get_many` correctness, NaN preservation, end-to-end refinement with both in-memory and sidecar-backed catalogs.
- 3 new tests in `src/solver/tests` for the pre-fit filter behavior (`scale_filtering_rejects_pre_fit`, `within_filter_rejects_pre_fit`, `wide_scale_range_still_solves`).

## Test plan

- [x] `cargo test --lib` — 124/124 passing.
- [x] `cargo build` — clean.
- [x] Verify `RefinementCatalog::load_sidecar_filtered` end-to-end via the new `refinement_via_sidecar_recovers_truth_wcs` test.
- [ ] (post-merge) `cargo publish --dry-run` to confirm the package is healthy before tagging 0.3.0.

## Linked issues

Implements #48 (pre-fit filters). Lays foundation for #45 (sidecar). Issues #43 (deflection), #44 (terrestrial), #46 (`solve_and_refine`), #47 (weighted LSQ) remain open as scoped follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)