### PR TITLE
Release 0.4.1: exclude test_cases/ (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.4.1
+
+### Changed
+- Exclude `test_cases/` from the published crate (#58). The 0.4.0 package
+  shipped 1036 files / 10.3 MiB uncompressed; ~1000 of those were
+  `test_cases/*.json` solver fixtures with no value to downstream library
+  users. 0.4.1 drops the same surface to ~36 files / a few hundred KB.
+  No code or API change.
+
 ## 0.4.0
 
 Five-step deployment-mode roadmap: the index now supports sparse loading,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,7 +3211,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zodiacal"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cdshealpix",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "zodiacal"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "A blind astrometry plate-solving library"
 license = "Apache-2.0"
 repository = "https://github.com/OrbitalCommons/zodiacal"
 keywords = ["astrometry", "plate-solving", "astronomy", "wcs"]
 categories = ["science"]
-exclude = ["external/", "PLAN.md", "benches/", "scripts/", "scratch/"]
+exclude = ["external/", "PLAN.md", "benches/", "scripts/", "scratch/", "test_cases/"]
 
 [features]
 default = ["fits"]


### PR DESCRIPTION
## Summary

Patch release fixing #58. Adds `test_cases/` to `Cargo.toml` exclude so the published crate stops shipping ~1000 solver fixture files that downstream library users don't need.

## Before / after

| | 0.4.0 | 0.4.1 |
|---|---|---|
| Files | 1036 | **36** |
| Uncompressed | 10.3 MiB | 560.6 KiB |
| Compressed | 3.9 MiB | **135.7 KiB** |

19× reduction in compressed download size.

## Notes on the secondary item from #58

The orphan `[[bench]] name = "attitude_hint" harness = false` declaration in `Cargo.toml` is intentionally retained. The `harness = false` is needed for local `cargo bench --bench attitude_hint -- --indexes-dir ...` use to bypass libtest's CLI-arg interception. The cargo warning during `cargo package` ("ignoring benchmark") is cosmetic — the bench file is excluded from the package via `benches/` already in the exclude list, so there's nothing to actually ignore.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --lib` — 177/177 pass (no behavior change)
- [x] `cargo package --list | grep -c '^test_cases/'` → 0
- [x] `cargo publish --dry-run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)