### PR TITLE
Add build-from-shards: one-pass Gaia DR3 → .zdcl + .zdcl.gaia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,12 +147,236 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "arrow"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca025bd0f38eeecb57c2153c0123b960494138e6a957bbda10da2b25415209fe"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ead0914e4861a531be48fe05858265cf854a4880b9ed12618b1d08cba9bebc8"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+
+[[package]]
+name = "arrow-select"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "as-slice"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -168,7 +406,7 @@ dependencies = [
  "num-traits",
  "pastey",
  "rayon",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "y4m",
 ]
@@ -308,7 +546,7 @@ dependencies = [
  "png 0.17.16",
  "rayon",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
 ]
 
@@ -416,6 +654,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +738,27 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "deranged"
@@ -621,6 +900,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ca48d4628ccda1011fb25581b6001eb61490d27d4433029db65bd63aa9096da"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustc_version",
 ]
 
 [[package]]
@@ -797,6 +1086,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -808,6 +1098,12 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
@@ -1243,6 +1539,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1610,12 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1571,6 +1930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1812,12 +2172,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1827,7 +2208,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1866,10 +2256,10 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand",
- "rand_chacha",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "simd_helpers",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -2005,6 +2395,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -2222,6 +2621,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,15 +2675,72 @@ dependencies = [
  "ndarray 0.16.1",
  "num",
  "once_cell",
- "rand",
+ "rand 0.9.4",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
  "sgp4",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "uom",
+]
+
+[[package]]
+name = "starfield"
+version = "0.12.0"
+source = "git+https://github.com/OrbitalCommons/starfield.git#42a423d8c222c09bf3adfef245eae0cef9e9b8a6"
+dependencies = [
+ "base64",
+ "byteorder",
+ "chrono",
+ "clap",
+ "flate2",
+ "image",
+ "indicatif 0.17.11",
+ "lazy_static",
+ "log",
+ "md5",
+ "memmap2",
+ "nalgebra",
+ "ndarray 0.16.1",
+ "num",
+ "once_cell",
+ "rand 0.9.4",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sgp4",
+ "thiserror 2.0.18",
+ "time",
+ "uom",
+]
+
+[[package]]
+name = "starfield-datasource-utils"
+version = "0.1.0"
+dependencies = [
+ "indicatif 0.17.11",
+ "reqwest",
+ "starfield 0.12.0",
+]
+
+[[package]]
+name = "starfield-gaia"
+version = "0.2.0"
+dependencies = [
+ "arrow",
+ "cdshealpix",
+ "flate2",
+ "md5",
+ "nalgebra",
+ "rand 0.8.6",
+ "regex",
+ "serde",
+ "starfield 0.12.0",
+ "starfield-datasource-utils",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2360,11 +2822,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2410,6 +2892,15 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "tinystr"
@@ -2671,6 +3162,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -3225,7 +3722,8 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "starfield",
+ "starfield 0.11.0",
+ "starfield-gaia",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2720,6 +2720,7 @@ dependencies = [
 [[package]]
 name = "starfield-datasource-utils"
 version = "0.1.0"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources#98044f92fccf0144235c07fd4bf2b9c0c3f9b012"
 dependencies = [
  "indicatif 0.17.11",
  "reqwest",
@@ -2729,6 +2730,7 @@ dependencies = [
 [[package]]
 name = "starfield-gaia"
 version = "0.2.0"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources#98044f92fccf0144235c07fd4bf2b9c0c3f9b012"
 dependencies = [
  "arrow",
  "cdshealpix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,14 @@ default = ["fits"]
 fits = ["dep:fitsio-pure"]
 image-processing = ["dep:ndarray"]
 cli = ["dep:clap", "dep:glob", "dep:image", "dep:indicatif", "image-processing"]
+# `gaia-shards` enables the `build-from-shards` CLI subcommand, which reads
+# a directory of Gaia DR3 `.csv.gz` shards and emits a `.zdcl` index plus
+# matching `.zdcl.gaia` refinement sidecar in one pass.
+#
+# This pulls in `starfield-gaia` from a sibling repo via a path dep
+# (the crate is not yet published to crates.io), so it's gated behind a
+# non-default feature to keep the public crate buildable from crates.io.
+gaia-shards = ["dep:starfield-gaia"]
 
 [dependencies]
 clap = { version = "4.5.57", features = ["derive"], optional = true }
@@ -29,6 +37,7 @@ rayon = "1.11.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 starfield = "0.11"
+starfield-gaia = { path = "../starfield-datasources/crates/gaia", optional = true }
 
 [[bin]]
 name = "zodiacal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rayon = "1.11.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 starfield = "0.11"
-starfield-gaia = { path = "../starfield-datasources/crates/gaia", optional = true }
+starfield-gaia = { git = "https://github.com/OrbitalCommons/starfield-datasources", optional = true }
 
 [[bin]]
 name = "zodiacal"

--- a/src/cli_build_from_shards.rs
+++ b/src/cli_build_from_shards.rs
@@ -19,9 +19,8 @@ use std::sync::Mutex;
 use std::time::Instant;
 
 use rayon::prelude::*;
-use starfield_gaia::common::reader::CsvSourceReader;
 use starfield_gaia::download::Downloader;
-use starfield_gaia::{Dr3, Dr3Entry};
+use starfield_gaia::{Dr3, Dr3Catalog, Dr3Entry};
 
 use crate::index::builder::{IndexBuilderConfig, build_index};
 use crate::refinement::{DEFAULT_PIVOT_STRIDE, SidecarRecord, write_sidecar};
@@ -37,7 +36,13 @@ pub type IndexStarTuple = (u64, f64, f64, f64);
 /// Pair emitted per accepted Gaia row.
 pub type ShardRow = (IndexStarTuple, SidecarRecord);
 
-/// Find every `GaiaSource_*.csv.gz` in `dir`. Returns sorted paths.
+/// Find every `*.csv` or `*.csv.gz` in `dir`. Returns sorted paths.
+///
+/// Accepts both starfield-gaia's "excerpt" layout
+/// (`shard_NNNN.csv.gz` under `~/.cache/starfield/gaia-excerpts/<name>/`)
+/// and the raw ESA `GaiaSource_NNN-NNN-NNN.csv.gz` layout — the column
+/// schema is identical in both cases, so `CsvSourceReader::<Dr3>` reads
+/// either uniformly.
 fn find_shard_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
     let mut files: Vec<PathBuf> = Vec::new();
     for entry in std::fs::read_dir(dir)? {
@@ -50,8 +55,7 @@ fn find_shard_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
             Some(n) => n,
             None => continue,
         };
-        if name.starts_with("GaiaSource_") && (name.ends_with(".csv.gz") || name.ends_with(".csv"))
-        {
+        if name.ends_with(".csv.gz") || name.ends_with(".csv") {
             files.push(path);
         }
     }
@@ -98,22 +102,29 @@ pub fn entry_to_records(entry: &Dr3Entry) -> ShardRow {
 
 /// Read one shard file and return all kept stars as (tuple, record) pairs.
 ///
-/// Uses the streaming `CsvSourceReader` to avoid materializing the whole
-/// file into a `HashMap` (which would otherwise double our memory budget
-/// before we ever start building).
+/// Delegates to `starfield_gaia::Dr3Catalog::from_csv_file`, which is
+/// the canonical high-level reader for Gaia DR3 CSV shards (whether
+/// raw ESA `GaiaSource_*.csv.gz` or starfield-gaia "excerpt"
+/// `shard_*.csv.gz` — both share the DR3 column layout).
 fn read_shard(path: &Path, mag_limit: f64) -> Result<Vec<ShardRow>, String> {
-    let reader = CsvSourceReader::<Dr3>::open(path, mag_limit)
-        .map_err(|e| format!("{}: open failed: {e}", path.display()))?;
+    let catalog = Dr3Catalog::from_csv_file(path, mag_limit)
+        .map_err(|e| format!("{}: load failed: {e}", path.display()))?;
 
-    let mut out = Vec::new();
-    for entry_result in reader {
-        let entry = entry_result.map_err(|e| format!("{}: parse failed: {e}", path.display()))?;
-        // mag_limit is already applied inside CsvSourceReader, but skip NaN mags
-        // defensively — a NaN here would corrupt the brightness sort.
+    // `brighter_than_ref(f64::INFINITY)` is the only inherent (non-trait)
+    // accessor on `GaiaCatalogBase` that yields `&R::Entry` for every
+    // loaded row — using `StarCatalog::stars()` would require both
+    // crates to agree on a single `starfield` instance, which they
+    // don't (starfield-gaia is workspace-pinned to git, zodiacal pulls
+    // from crates.io).
+    let entries = catalog.0.brighter_than_ref(f64::INFINITY);
+    let mut out = Vec::with_capacity(entries.len());
+    for entry in entries {
+        // mag_limit is already applied at load time, but defensively
+        // skip NaN mags — a NaN here would corrupt the brightness sort.
         if !entry.core.phot_g_mean_mag.is_finite() {
             continue;
         }
-        out.push(entry_to_records(&entry));
+        out.push(entry_to_records(entry));
     }
     Ok(out)
 }

--- a/src/cli_build_from_shards.rs
+++ b/src/cli_build_from_shards.rs
@@ -1,0 +1,506 @@
+//! `build-from-shards` CLI subcommand: build a `.zdcl` index plus a
+//! refinement `.zdcl.gaia` sidecar from a directory of Gaia DR3 CSV
+//! shards in one pass.
+//!
+//! Gated behind the `gaia-shards` feature so the public crate doesn't
+//! need to pull `starfield-gaia` (which is a path dep — not yet on
+//! crates.io).
+//!
+//! # Memory budget
+//!
+//! Each accepted star occupies ~120 bytes in memory (32 B index tuple +
+//! 88 B sidecar record). At G ≤ 16 (~83 M stars) that's ≈ 10 GB and fits
+//! in 64 GB hosts; at G ≤ 19 (~565 M stars) it's ≈ 70 GB and won't fit
+//! on any sensible workstation. The tool refuses `--mag-limit > 17.0`
+//! up front to avoid blowing the box.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Instant;
+
+use rayon::prelude::*;
+use starfield_gaia::common::reader::CsvSourceReader;
+use starfield_gaia::{Dr3, Dr3Entry};
+
+use crate::index::builder::{IndexBuilderConfig, build_index};
+use crate::refinement::{DEFAULT_PIVOT_STRIDE, SidecarRecord, write_sidecar};
+
+/// Hard cap on the magnitude limit; deeper than this won't fit in
+/// reasonable host RAM with the in-memory v1 sidecar contract.
+pub const MAX_MAG_LIMIT: f64 = 17.0;
+
+/// `(catalog_id, ra_radians, dec_radians, magnitude)` — the tuple shape
+/// `build_index` expects.
+pub type IndexStarTuple = (u64, f64, f64, f64);
+
+/// Pair emitted per accepted Gaia row.
+pub type ShardRow = (IndexStarTuple, SidecarRecord);
+
+/// Find every `GaiaSource_*.csv.gz` in `dir`. Returns sorted paths.
+fn find_shard_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut files: Vec<PathBuf> = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if name.starts_with("GaiaSource_") && (name.ends_with(".csv.gz") || name.ends_with(".csv"))
+        {
+            files.push(path);
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+/// Convert a single `Dr3Entry` to (index tuple, sidecar record).
+///
+/// `f64::NAN` is used for unpublished optional astrometry, matching the
+/// `SidecarRecord` schema. Sigmas (which `GaiaCore` stores as `f32`) are
+/// passed through; `NaN` for unpublished optional sigmas.
+pub fn entry_to_records(entry: &Dr3Entry) -> ShardRow {
+    let core = &entry.core;
+    let ra_rad = core.ra.to_radians();
+    let dec_rad = core.dec.to_radians();
+    let mag = core.phot_g_mean_mag;
+
+    let radial_velocity = entry
+        .radial_velocity
+        .as_ref()
+        .and_then(|rv| rv.radial_velocity)
+        .unwrap_or(f64::NAN);
+
+    let record = SidecarRecord {
+        source_id: core.source_id,
+        ref_epoch: core.ref_epoch,
+        ra: core.ra,
+        dec: core.dec,
+        pmra: core.pmra.unwrap_or(f64::NAN),
+        pmdec: core.pmdec.unwrap_or(f64::NAN),
+        parallax: core.parallax.unwrap_or(f64::NAN),
+        radial_velocity,
+        sigma_ra: core.ra_error,
+        sigma_dec: core.dec_error,
+        sigma_pmra: core.pmra_error.unwrap_or(f32::NAN),
+        sigma_pmdec: core.pmdec_error.unwrap_or(f32::NAN),
+        sigma_parallax: core.parallax_error.unwrap_or(f32::NAN),
+        flags: 0,
+    };
+
+    ((core.source_id, ra_rad, dec_rad, mag), record)
+}
+
+/// Read one shard file and return all kept stars as (tuple, record) pairs.
+///
+/// Uses the streaming `CsvSourceReader` to avoid materializing the whole
+/// file into a `HashMap` (which would otherwise double our memory budget
+/// before we ever start building).
+fn read_shard(path: &Path, mag_limit: f64) -> Result<Vec<ShardRow>, String> {
+    let reader = CsvSourceReader::<Dr3>::open(path, mag_limit)
+        .map_err(|e| format!("{}: open failed: {e}", path.display()))?;
+
+    let mut out = Vec::new();
+    for entry_result in reader {
+        let entry = entry_result.map_err(|e| format!("{}: parse failed: {e}", path.display()))?;
+        // mag_limit is already applied inside CsvSourceReader, but skip NaN mags
+        // defensively — a NaN here would corrupt the brightness sort.
+        if !entry.core.phot_g_mean_mag.is_finite() {
+            continue;
+        }
+        out.push(entry_to_records(&entry));
+    }
+    Ok(out)
+}
+
+/// Configuration for `run`.
+pub struct BuildFromShardsConfig {
+    pub shards_dir: PathBuf,
+    pub output_prefix: PathBuf,
+    pub mag_limit: f64,
+    /// Lower scale bound in arcseconds.
+    pub scale_lower_arcsec: f64,
+    /// Upper scale bound in arcseconds.
+    pub scale_upper_arcsec: f64,
+    pub max_stars_per_cell: usize,
+    pub max_quads: Option<usize>,
+    pub cell_depth: u8,
+    /// Rayon thread pool size; pass `None` to use rayon's default.
+    pub threads: Option<usize>,
+}
+
+/// Top-level entry point.
+pub fn run(cfg: &BuildFromShardsConfig) -> Result<(), String> {
+    if !cfg.mag_limit.is_finite() || cfg.mag_limit > MAX_MAG_LIMIT {
+        return Err(format!(
+            "--mag-limit {} exceeds hard cap {}; v1 sidecar writer holds all records in RAM, \
+             and going deeper than ~17 won't fit on a 64 GB box. Either tighten the limit or \
+             wait for the streaming sidecar writer.",
+            cfg.mag_limit, MAX_MAG_LIMIT,
+        ));
+    }
+    if cfg.scale_lower_arcsec <= 0.0 || cfg.scale_upper_arcsec <= cfg.scale_lower_arcsec {
+        return Err(format!(
+            "invalid scale range: lower={}\" upper={}\" (must satisfy 0 < lower < upper)",
+            cfg.scale_lower_arcsec, cfg.scale_upper_arcsec
+        ));
+    }
+
+    let t0 = Instant::now();
+
+    let shards = find_shard_files(&cfg.shards_dir).map_err(|e| {
+        format!(
+            "failed to scan shards directory {}: {e}",
+            cfg.shards_dir.display()
+        )
+    })?;
+    if shards.is_empty() {
+        return Err(format!(
+            "no GaiaSource_*.csv(.gz) shards found in {}",
+            cfg.shards_dir.display()
+        ));
+    }
+    eprintln!(
+        "Found {} shard(s) in {}",
+        shards.len(),
+        cfg.shards_dir.display()
+    );
+
+    // Set up rayon (best-effort: ignore the error if the global pool is
+    // already configured by another caller).
+    if let Some(n) = cfg.threads {
+        let _ = rayon::ThreadPoolBuilder::new()
+            .num_threads(n)
+            .build_global();
+    }
+
+    // Read shards in parallel. Each shard accumulates into a thread-local
+    // Vec; we then merge under a single mutex to bound peak memory.
+    let star_tuples: Mutex<Vec<IndexStarTuple>> = Mutex::new(Vec::new());
+    let sidecar_records: Mutex<Vec<SidecarRecord>> = Mutex::new(Vec::new());
+    let progress = std::sync::atomic::AtomicUsize::new(0);
+    let n_shards = shards.len();
+    let any_error: Mutex<Option<String>> = Mutex::new(None);
+
+    shards.par_iter().for_each(|path| {
+        // Skip remaining shards if a sibling already failed.
+        if any_error.lock().unwrap().is_some() {
+            return;
+        }
+        match read_shard(path, cfg.mag_limit) {
+            Ok(rows) => {
+                let n = rows.len();
+                let mut tuples = star_tuples.lock().unwrap();
+                let mut records = sidecar_records.lock().unwrap();
+                tuples.reserve(n);
+                records.reserve(n);
+                for (t, r) in rows {
+                    tuples.push(t);
+                    records.push(r);
+                }
+                drop(tuples);
+                drop(records);
+                let done = progress.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                if done.is_multiple_of(50) || done == n_shards {
+                    let stars_so_far = star_tuples.lock().unwrap().len();
+                    eprintln!("  shard {done}/{n_shards} done ({stars_so_far} stars accumulated)");
+                }
+            }
+            Err(e) => {
+                let mut slot = any_error.lock().unwrap();
+                if slot.is_none() {
+                    *slot = Some(e);
+                }
+            }
+        }
+    });
+
+    if let Some(e) = any_error.into_inner().unwrap() {
+        return Err(e);
+    }
+
+    let star_tuples = star_tuples.into_inner().unwrap();
+    let sidecar_records = sidecar_records.into_inner().unwrap();
+    let n_stars = star_tuples.len();
+    let read_elapsed = t0.elapsed();
+    eprintln!(
+        "Read {} stars across {} shards in {:.1}s ({:.0} stars/s)",
+        n_stars,
+        n_shards,
+        read_elapsed.as_secs_f64(),
+        n_stars as f64 / read_elapsed.as_secs_f64().max(1e-9),
+    );
+
+    if n_stars == 0 {
+        return Err("no stars survived the magnitude cut; nothing to index".into());
+    }
+
+    // Build the quad index.
+    let scale_lower_rad = (cfg.scale_lower_arcsec / 3600.0).to_radians();
+    let scale_upper_rad = (cfg.scale_upper_arcsec / 3600.0).to_radians();
+    let max_quads = cfg.max_quads.unwrap_or(n_stars * 8);
+    let max_stars = n_stars; // build_index truncates after sorting; we want all
+    let builder_cfg = IndexBuilderConfig {
+        scale_lower: scale_lower_rad,
+        scale_upper: scale_upper_rad,
+        max_stars,
+        max_quads,
+    };
+
+    eprintln!(
+        "Building index: scale=[{:.1}\",{:.1}\"], max_stars_per_cell={} (advisory), max_quads={}",
+        cfg.scale_lower_arcsec, cfg.scale_upper_arcsec, cfg.max_stars_per_cell, max_quads,
+    );
+
+    // Note: `max_stars_per_cell` is a `CatalogBuilderConfig` knob (HEALPix-
+    // uniformized builder); the direct `build_index(&[(u64,f64,f64,f64)])`
+    // path doesn't take it. We accept it on the CLI for forward-compat with
+    // a future uniformization step but currently pass everything through.
+    let _ = cfg.max_stars_per_cell;
+
+    let index = build_index(&star_tuples, &builder_cfg);
+    drop(star_tuples);
+    let build_elapsed = t0.elapsed() - read_elapsed;
+    eprintln!(
+        "Index built: {} stars, {} quads in {:.1}s",
+        index.stars.len(),
+        index.quads.len(),
+        build_elapsed.as_secs_f64()
+    );
+
+    // Persist outputs.
+    let zdcl_path = with_suffix(&cfg.output_prefix, "zdcl");
+    let sidecar_path = with_suffix(&cfg.output_prefix, "zdcl.gaia");
+
+    index
+        .save_v3(&zdcl_path, cfg.cell_depth)
+        .map_err(|e| format!("failed to write {}: {e}", zdcl_path.display()))?;
+    let zdcl_size = std::fs::metadata(&zdcl_path).map(|m| m.len()).unwrap_or(0);
+
+    write_sidecar(&sidecar_path, sidecar_records, DEFAULT_PIVOT_STRIDE)
+        .map_err(|e| format!("failed to write {}: {e}", sidecar_path.display()))?;
+    let sidecar_size = std::fs::metadata(&sidecar_path)
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    let total = t0.elapsed();
+    eprintln!();
+    eprintln!("=== Summary ===");
+    eprintln!("Stars read:   {n_stars}");
+    eprintln!(
+        "Index file:   {} ({:.1} MB)",
+        zdcl_path.display(),
+        zdcl_size as f64 / 1024.0 / 1024.0
+    );
+    eprintln!(
+        "Sidecar file: {} ({:.1} MB)",
+        sidecar_path.display(),
+        sidecar_size as f64 / 1024.0 / 1024.0
+    );
+    eprintln!("Elapsed:      {:.1}s", total.as_secs_f64());
+
+    Ok(())
+}
+
+/// Append (or replace) the trailing extension on `prefix`. We append rather
+/// than `set_extension` because callers commonly pass a prefix like
+/// `out/gaia_g16` which has no extension; if they pass `out.foo` we still
+/// want `out.foo.zdcl`, not `out.zdcl`.
+fn with_suffix(prefix: &Path, suffix: &str) -> PathBuf {
+    let mut s = prefix.as_os_str().to_owned();
+    s.push(".");
+    s.push(suffix);
+    PathBuf::from(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `Dr3Entry` with all the optional astrometry fields populated; useful
+    /// for asserting we don't drop any fields on the way through.
+    fn make_filled_entry(source_id: u64, ra_deg: f64, dec_deg: f64, mag: f64) -> Dr3Entry {
+        use starfield_gaia::dr3::entry::{
+            AstrometricExtra, BpRpPhotometry, Classifications, DataLinks, GspPhot, IpdQuality,
+            RadialVelocityDr3,
+        };
+        use starfield_gaia::{GaiaCore, VarFlag};
+        let core = GaiaCore {
+            source_id,
+            solution_id: 0,
+            ref_epoch: 2016.0,
+            random_index: None,
+            ra: ra_deg,
+            ra_error: 0.25,
+            dec: dec_deg,
+            dec_error: 0.18,
+            ra_dec_corr: None,
+            parallax: Some(2.5),
+            parallax_error: Some(0.04),
+            pmra: Some(-3.7),
+            pmra_error: Some(0.05),
+            pmdec: Some(1.2),
+            pmdec_error: Some(0.06),
+            l: 0.0,
+            b: 0.0,
+            ecl_lon: 0.0,
+            ecl_lat: 0.0,
+            phot_g_mean_mag: mag,
+            phot_g_mean_flux: None,
+            phot_g_mean_flux_error: None,
+            phot_g_n_obs: None,
+            phot_variable_flag: VarFlag::NotAvailable,
+            astrometric_n_obs_al: None,
+            astrometric_excess_noise: None,
+            astrometric_excess_noise_sig: None,
+            astrometric_primary_flag: None,
+            duplicated_source: None,
+            matched_observations: None,
+        };
+        Dr3Entry {
+            core,
+            designation: None,
+            pm: None,
+            parallax_over_error: None,
+            astrometric_extra: AstrometricExtra::default(),
+            ipd: IpdQuality::default(),
+            bp_rp: Some(BpRpPhotometry::default()),
+            radial_velocity: Some(RadialVelocityDr3 {
+                radial_velocity: Some(15.0),
+                ..RadialVelocityDr3::default()
+            }),
+            gspphot: Some(GspPhot::default()),
+            data_links: DataLinks::default(),
+            classifications: Classifications::default(),
+        }
+    }
+
+    /// A `Dr3Entry` with everything optional left as `None` — a faint
+    /// 5-parameter or even 2-parameter source.
+    fn make_minimal_entry(source_id: u64, ra_deg: f64, dec_deg: f64, mag: f64) -> Dr3Entry {
+        use starfield_gaia::dr3::entry::{
+            AstrometricExtra, Classifications, DataLinks, IpdQuality,
+        };
+        use starfield_gaia::{GaiaCore, VarFlag};
+        let core = GaiaCore {
+            source_id,
+            solution_id: 0,
+            ref_epoch: 2016.0,
+            random_index: None,
+            ra: ra_deg,
+            ra_error: 1.5,
+            dec: dec_deg,
+            dec_error: 1.7,
+            ra_dec_corr: None,
+            parallax: None,
+            parallax_error: None,
+            pmra: None,
+            pmra_error: None,
+            pmdec: None,
+            pmdec_error: None,
+            l: 0.0,
+            b: 0.0,
+            ecl_lon: 0.0,
+            ecl_lat: 0.0,
+            phot_g_mean_mag: mag,
+            phot_g_mean_flux: None,
+            phot_g_mean_flux_error: None,
+            phot_g_n_obs: None,
+            phot_variable_flag: VarFlag::NotAvailable,
+            astrometric_n_obs_al: None,
+            astrometric_excess_noise: None,
+            astrometric_excess_noise_sig: None,
+            astrometric_primary_flag: None,
+            duplicated_source: None,
+            matched_observations: None,
+        };
+        Dr3Entry {
+            core,
+            designation: None,
+            pm: None,
+            parallax_over_error: None,
+            astrometric_extra: AstrometricExtra::default(),
+            ipd: IpdQuality::default(),
+            bp_rp: None,
+            radial_velocity: None,
+            gspphot: None,
+            data_links: DataLinks::default(),
+            classifications: Classifications::default(),
+        }
+    }
+
+    #[test]
+    fn filled_entry_round_trips_units() {
+        let entry = make_filled_entry(1234, 45.0, 30.0, 14.5);
+        let ((sid, ra_rad, dec_rad, mag), record) = entry_to_records(&entry);
+
+        assert_eq!(sid, 1234);
+        assert!((ra_rad - 45.0_f64.to_radians()).abs() < 1e-12);
+        assert!((dec_rad - 30.0_f64.to_radians()).abs() < 1e-12);
+        assert_eq!(mag, 14.5);
+
+        // Sidecar stores degrees, not radians.
+        assert_eq!(record.source_id, 1234);
+        assert_eq!(record.ra, 45.0);
+        assert_eq!(record.dec, 30.0);
+        assert_eq!(record.ref_epoch, 2016.0);
+        assert_eq!(record.pmra, -3.7);
+        assert_eq!(record.pmdec, 1.2);
+        assert_eq!(record.parallax, 2.5);
+        assert_eq!(record.radial_velocity, 15.0);
+        assert_eq!(record.sigma_ra, 0.25);
+        assert_eq!(record.sigma_dec, 0.18);
+        assert_eq!(record.sigma_pmra, 0.05);
+        assert_eq!(record.sigma_pmdec, 0.06);
+        assert_eq!(record.sigma_parallax, 0.04);
+        assert_eq!(record.flags, 0);
+    }
+
+    #[test]
+    fn minimal_entry_uses_nan_for_missing_fields() {
+        let entry = make_minimal_entry(7, 0.0, 0.0, 19.5);
+        let (_tuple, record) = entry_to_records(&entry);
+        assert!(record.pmra.is_nan());
+        assert!(record.pmdec.is_nan());
+        assert!(record.parallax.is_nan());
+        assert!(record.radial_velocity.is_nan());
+        assert!(record.sigma_pmra.is_nan());
+        assert!(record.sigma_pmdec.is_nan());
+        assert!(record.sigma_parallax.is_nan());
+        // ra_error / dec_error are non-optional in GaiaCore, so they pass through.
+        assert_eq!(record.sigma_ra, 1.5);
+        assert_eq!(record.sigma_dec, 1.7);
+    }
+
+    #[test]
+    fn rv_present_but_value_missing_yields_nan() {
+        use starfield_gaia::dr3::entry::RadialVelocityDr3;
+        let mut entry = make_minimal_entry(99, 10.0, -5.0, 13.0);
+        entry.radial_velocity = Some(RadialVelocityDr3 {
+            radial_velocity: None,
+            ..RadialVelocityDr3::default()
+        });
+        let (_tuple, record) = entry_to_records(&entry);
+        assert!(record.radial_velocity.is_nan());
+    }
+
+    #[test]
+    fn with_suffix_appends_not_replaces() {
+        assert_eq!(
+            with_suffix(Path::new("foo"), "zdcl"),
+            PathBuf::from("foo.zdcl")
+        );
+        assert_eq!(
+            with_suffix(Path::new("foo.bar"), "zdcl"),
+            PathBuf::from("foo.bar.zdcl")
+        );
+        assert_eq!(
+            with_suffix(Path::new("/tmp/out"), "zdcl.gaia"),
+            PathBuf::from("/tmp/out.zdcl.gaia")
+        );
+    }
+}

--- a/src/cli_build_from_shards.rs
+++ b/src/cli_build_from_shards.rs
@@ -20,6 +20,7 @@ use std::time::Instant;
 
 use rayon::prelude::*;
 use starfield_gaia::common::reader::CsvSourceReader;
+use starfield_gaia::download::Downloader;
 use starfield_gaia::{Dr3, Dr3Entry};
 
 use crate::index::builder::{IndexBuilderConfig, build_index};
@@ -118,8 +119,11 @@ fn read_shard(path: &Path, mag_limit: f64) -> Result<Vec<ShardRow>, String> {
 }
 
 /// Configuration for `run`.
+///
+/// `shards_dir = None` tells the tool to use the shard set cached by
+/// `starfield-gaia` (i.e. files under `~/.cache/starfield/gaia/`).
 pub struct BuildFromShardsConfig {
-    pub shards_dir: PathBuf,
+    pub shards_dir: Option<PathBuf>,
     pub output_prefix: PathBuf,
     pub mag_limit: f64,
     /// Lower scale bound in arcseconds.
@@ -152,23 +156,36 @@ pub fn run(cfg: &BuildFromShardsConfig) -> Result<(), String> {
 
     let t0 = Instant::now();
 
-    let shards = find_shard_files(&cfg.shards_dir).map_err(|e| {
-        format!(
-            "failed to scan shards directory {}: {e}",
-            cfg.shards_dir.display()
-        )
-    })?;
+    // Resolve shards. If --shards-dir is provided, scan that directory.
+    // Otherwise use the shard set cached by `starfield-gaia` (typically at
+    // `~/.cache/starfield/gaia/`), which is the canonical location for
+    // already-downloaded GaiaSource files.
+    let (shards, source_label) = match cfg.shards_dir.as_ref() {
+        Some(dir) => {
+            let files = find_shard_files(dir)
+                .map_err(|e| format!("failed to scan shards directory {}: {e}", dir.display()))?;
+            (files, format!("directory {}", dir.display()))
+        }
+        None => {
+            let cached = Downloader::<Dr3>::list_cached().map_err(|e| {
+                format!(
+                    "failed to list starfield-gaia cached shards: {e}; \
+                     pass --shards-dir to override"
+                )
+            })?;
+            (cached, "starfield-gaia cache".to_string())
+        }
+    };
     if shards.is_empty() {
-        return Err(format!(
-            "no GaiaSource_*.csv(.gz) shards found in {}",
-            cfg.shards_dir.display()
-        ));
+        return Err(match cfg.shards_dir.as_ref() {
+            Some(dir) => format!("no GaiaSource_*.csv(.gz) shards found in {}", dir.display()),
+            None => "starfield-gaia cache is empty (no GaiaSource_*.csv.gz files \
+                     downloaded yet); run starfield-gaia downloader or pass \
+                     --shards-dir"
+                .to_string(),
+        });
     }
-    eprintln!(
-        "Found {} shard(s) in {}",
-        shards.len(),
-        cfg.shards_dir.display()
-    );
+    eprintln!("Found {} shard(s) from {}", shards.len(), source_label);
 
     // Set up rayon (best-effort: ignore the error if the global pool is
     // already configured by another caller).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 //! by matching geometric star patterns against a reference catalog,
 //! returning a WCS (World Coordinate System) solution.
 
+#[cfg(feature = "gaia-shards")]
+pub mod cli_build_from_shards;
 pub mod extraction;
 pub mod fitting;
 pub mod geom;

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,9 +265,11 @@ enum Commands {
     /// on a 64 GB box; G>17 is rejected up front.
     #[cfg(feature = "gaia-shards")]
     BuildFromShards {
-        /// Directory containing `GaiaSource_*.csv(.gz)` shards.
+        /// Directory containing `GaiaSource_*.csv(.gz)` shards. If omitted,
+        /// the tool scans the starfield-managed cache
+        /// (`Downloader::<Dr3>::list_cached()`).
         #[arg(long)]
-        shards_dir: PathBuf,
+        shards_dir: Option<PathBuf>,
 
         /// Output prefix; emits `<prefix>.zdcl` and `<prefix>.zdcl.gaia`.
         #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,11 @@ use zodiacal::index::{Index, IndexMetadata};
 use zodiacal::solver::{SolveStats, SolverConfig, solve, solve_image};
 use zodiacal::verify::VerifyConfig;
 
+#[cfg(feature = "gaia-shards")]
+use zodiacal::cli_build_from_shards::{BuildFromShardsConfig, run as run_build_from_shards};
+#[cfg(feature = "gaia-shards")]
+use zodiacal::index::source::DEFAULT_CELL_DEPTH;
+
 #[derive(Parser)]
 #[command(name = "zodiacal", about = "Blind astrometry plate solver")]
 struct Cli {
@@ -247,6 +252,56 @@ enum Commands {
     Info {
         /// Path to the index file (.zdcl).
         index: PathBuf,
+    },
+
+    /// Build a `.zdcl` index plus a `.zdcl.gaia` refinement sidecar from
+    /// a directory of Gaia DR3 `GaiaSource_*.csv.gz` shards in one pass.
+    ///
+    /// Reads every shard once, applies the magnitude limit, then builds the
+    /// quad index and writes the sidecar in v3 / v1 formats respectively.
+    ///
+    /// Memory note: the v1 sidecar writer holds all records in RAM. Each
+    /// star is ~120 bytes, so G≤16 (~83M stars) is the practical ceiling
+    /// on a 64 GB box; G>17 is rejected up front.
+    #[cfg(feature = "gaia-shards")]
+    BuildFromShards {
+        /// Directory containing `GaiaSource_*.csv(.gz)` shards.
+        #[arg(long)]
+        shards_dir: PathBuf,
+
+        /// Output prefix; emits `<prefix>.zdcl` and `<prefix>.zdcl.gaia`.
+        #[arg(long)]
+        output_prefix: PathBuf,
+
+        /// G-band magnitude cutoff (must be <= 17.0; deeper won't fit in RAM).
+        #[arg(long, default_value = "16.0")]
+        mag_limit: f64,
+
+        /// Minimum quad scale in arcseconds.
+        #[arg(long, default_value = "30.0")]
+        scale_lower: f64,
+
+        /// Maximum quad scale in arcseconds.
+        #[arg(long, default_value = "1800.0")]
+        scale_upper: f64,
+
+        /// Maximum brightest stars per HEALPix cell (advisory; reserved for
+        /// a future uniformization step — currently unused by `build_index`).
+        #[arg(long, default_value = "30")]
+        max_stars_per_cell: usize,
+
+        /// Maximum number of quads to generate (default: 8 × n_stars).
+        #[arg(long)]
+        max_quads: Option<usize>,
+
+        /// HEALPix depth used to group stars in the v3 `.zdcl` file.
+        #[arg(long, default_value_t = DEFAULT_CELL_DEPTH)]
+        cell_depth: u8,
+
+        /// Rayon worker thread count for parallel shard reads
+        /// (default: rayon's default = all logical cores).
+        #[arg(long)]
+        threads: Option<usize>,
     },
 }
 
@@ -1420,6 +1475,34 @@ fn main() {
         }
         Commands::Info { index } => {
             cmd_info(index);
+        }
+        #[cfg(feature = "gaia-shards")]
+        Commands::BuildFromShards {
+            shards_dir,
+            output_prefix,
+            mag_limit,
+            scale_lower,
+            scale_upper,
+            max_stars_per_cell,
+            max_quads,
+            cell_depth,
+            threads,
+        } => {
+            let cfg = BuildFromShardsConfig {
+                shards_dir: shards_dir.clone(),
+                output_prefix: output_prefix.clone(),
+                mag_limit: *mag_limit,
+                scale_lower_arcsec: *scale_lower,
+                scale_upper_arcsec: *scale_upper,
+                max_stars_per_cell: *max_stars_per_cell,
+                max_quads: *max_quads,
+                cell_depth: *cell_depth,
+                threads: *threads,
+            };
+            if let Err(e) = run_build_from_shards(&cfg) {
+                eprintln!("build-from-shards failed: {e}");
+                process::exit(1);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- New `build-from-shards` CLI subcommand that reads a directory of Gaia DR3 `GaiaSource_*.csv(.gz)` shards in parallel and emits both the `.zdcl` index (v3 format) and the matching `.zdcl.gaia` refinement sidecar in one pass.
- Gated behind a new non-default `gaia-shards` feature so the public crate keeps its existing dep surface; `starfield-gaia` is pulled in via a path dep (`../starfield-datasources/crates/gaia`) since it isn't on crates.io yet.
- Refuses `--mag-limit > 17.0` up front because the v1 sidecar writer holds all records in RAM (~120 B/star); deeper cuts won't fit on a 64 GB box.

## Notes

- `entry_to_records` is the per-row converter, factored out and unit-tested directly so we don't need a real shard fixture.
- Sidecar stores `ra`/`dec` in **degrees** (matching the `GaiaAstrometry::ra_deg` / `dec_deg` consumers in `refinement::types`); the index builder gets radians as it expects.
- Per-shard CSV reads use `starfield_gaia::common::reader::CsvSourceReader::<Dr3>` directly rather than `Dr3Catalog::from_csv_file` to skip the per-shard `HashMap` allocation — keeps peak memory closer to the single-Vec target.
- `--max-stars-per-cell` is currently advisory: the direct `build_index((id, ra, dec, mag))` path doesn't take it. Wired up in the CLI for forward-compat with a future uniformization step.

## Test plan

- [x] `cargo build` (default features) — clean
- [x] `cargo build --features cli` — clean
- [x] `cargo build --features cli,gaia-shards` — clean
- [x] `cargo build --release --features cli,gaia-shards` — clean
- [x] `cargo test --lib` — 177 pass
- [x] `cargo test --lib --features cli,gaia-shards` — 190 pass (including 4 new)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets -- -D warnings` (default) — clean
- [x] `zodiacal build-from-shards --help` renders correctly
- [x] Smoke-tested error paths: missing shards dir, `--mag-limit 22` rejected
- [ ] End-to-end run on a real Gaia DR3 mirror (deferred — needs the shards on disk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)