### PR TITLE
Add zodiacal-tools workspace crate (build-from-shards lives here)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,12 +147,236 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "arrow"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca025bd0f38eeecb57c2153c0123b960494138e6a957bbda10da2b25415209fe"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ead0914e4861a531be48fe05858265cf854a4880b9ed12618b1d08cba9bebc8"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+
+[[package]]
+name = "arrow-select"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "as-slice"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -168,7 +406,7 @@ dependencies = [
  "num-traits",
  "pastey",
  "rayon",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "y4m",
 ]
@@ -308,7 +546,7 @@ dependencies = [
  "png 0.17.16",
  "rayon",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
 ]
 
@@ -416,6 +654,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +738,27 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "deranged"
@@ -621,6 +900,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ca48d4628ccda1011fb25581b6001eb61490d27d4433029db65bd63aa9096da"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustc_version",
 ]
 
 [[package]]
@@ -797,6 +1086,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -808,6 +1098,12 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
@@ -1243,6 +1539,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1610,12 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1571,6 +1930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1812,12 +2172,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1827,7 +2208,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1866,10 +2256,10 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand",
- "rand_chacha",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "simd_helpers",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -2005,6 +2395,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -2222,6 +2621,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,15 +2675,74 @@ dependencies = [
  "ndarray 0.16.1",
  "num",
  "once_cell",
- "rand",
+ "rand 0.9.4",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
  "sgp4",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "uom",
+]
+
+[[package]]
+name = "starfield"
+version = "0.12.0"
+source = "git+https://github.com/OrbitalCommons/starfield.git#41839fc85f1e13e68ffe8dd75b1f202fc8483d98"
+dependencies = [
+ "base64",
+ "byteorder",
+ "chrono",
+ "clap",
+ "flate2",
+ "image",
+ "indicatif 0.17.11",
+ "lazy_static",
+ "log",
+ "md5",
+ "memmap2",
+ "nalgebra",
+ "ndarray 0.16.1",
+ "num",
+ "once_cell",
+ "rand 0.9.4",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sgp4",
+ "thiserror 2.0.18",
+ "time",
+ "uom",
+]
+
+[[package]]
+name = "starfield-datasource-utils"
+version = "0.1.0"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources#98044f92fccf0144235c07fd4bf2b9c0c3f9b012"
+dependencies = [
+ "indicatif 0.17.11",
+ "reqwest",
+ "starfield 0.12.0",
+]
+
+[[package]]
+name = "starfield-gaia"
+version = "0.2.0"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources#98044f92fccf0144235c07fd4bf2b9c0c3f9b012"
+dependencies = [
+ "arrow",
+ "cdshealpix",
+ "flate2",
+ "md5",
+ "nalgebra",
+ "rand 0.8.6",
+ "regex",
+ "serde",
+ "starfield 0.12.0",
+ "starfield-datasource-utils",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2360,11 +2824,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2410,6 +2894,15 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "tinystr"
@@ -2671,6 +3164,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -3225,7 +3724,17 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "starfield",
+ "starfield 0.11.0",
+]
+
+[[package]]
+name = "zodiacal-tools"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "rayon",
+ "starfield-gaia",
+ "zodiacal",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["zodiacal-tools"]
+
 [package]
 name = "zodiacal"
 version = "0.4.1"
@@ -7,7 +10,15 @@ license = "Apache-2.0"
 repository = "https://github.com/OrbitalCommons/zodiacal"
 keywords = ["astrometry", "plate-solving", "astronomy", "wcs"]
 categories = ["science"]
-exclude = ["external/", "PLAN.md", "benches/", "scripts/", "scratch/", "test_cases/"]
+exclude = [
+    "external/",
+    "PLAN.md",
+    "benches/",
+    "scripts/",
+    "scratch/",
+    "test_cases/",
+    "zodiacal-tools/",
+]
 
 [features]
 default = ["fits"]

--- a/zodiacal-tools/Cargo.toml
+++ b/zodiacal-tools/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "zodiacal-tools"
+version = "0.1.0"
+edition = "2024"
+description = "Operational tools for building and inspecting zodiacal indexes (.zdcl) and refinement sidecars (.zdcl.gaia)"
+license = "Apache-2.0"
+repository = "https://github.com/OrbitalCommons/zodiacal"
+keywords = ["astrometry", "gaia", "starfield", "tooling"]
+categories = ["command-line-utilities", "science"]
+
+[[bin]]
+name = "zodiacal-tools"
+path = "src/main.rs"
+
+[dependencies]
+zodiacal = { path = "..", version = "0.4" }
+starfield-gaia = { git = "https://github.com/OrbitalCommons/starfield-datasources" }
+clap = { version = "4.5", features = ["derive"] }
+rayon = "1.11"

--- a/zodiacal-tools/src/build_from_shards.rs
+++ b/zodiacal-tools/src/build_from_shards.rs
@@ -1,0 +1,458 @@
+//! `build-from-shards`: build a `.zdcl` index plus a refinement
+//! `.zdcl.gaia` sidecar from a directory of Gaia DR3 CSV shards in
+//! one pass.
+//!
+//! Reads every shard once, applies a magnitude limit, then builds the
+//! quad index (v3 layout, HEALPix-grouped) and writes the sidecar
+//! (v1 flat sorted-by-source_id binary).
+//!
+//! # Memory budget
+//!
+//! Each accepted star occupies ~120 bytes in memory (32 B index tuple +
+//! 88 B sidecar record). At G ≤ 16 (~83 M stars) that's ≈ 10 GB and fits
+//! in 64 GB hosts; at G ≤ 19 (~565 M stars) it's ≈ 70 GB and won't fit
+//! on any sensible workstation. The tool refuses `--mag-limit > 17.0`
+//! up front to avoid blowing the box.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Instant;
+
+use rayon::prelude::*;
+use starfield_gaia::download::Downloader;
+use starfield_gaia::{Dr3, Dr3Catalog, Dr3Entry};
+
+use zodiacal::index::builder::{IndexBuilderConfig, build_index};
+use zodiacal::refinement::{DEFAULT_PIVOT_STRIDE, SidecarRecord, write_sidecar};
+
+/// Hard cap on the magnitude limit; deeper than this won't fit in
+/// reasonable host RAM with the in-memory v1 sidecar contract.
+pub const MAX_MAG_LIMIT: f64 = 17.0;
+
+/// `(catalog_id, ra_radians, dec_radians, magnitude)` — the tuple shape
+/// `build_index` expects.
+pub type IndexStarTuple = (u64, f64, f64, f64);
+
+/// Pair emitted per accepted Gaia row.
+pub type ShardRow = (IndexStarTuple, SidecarRecord);
+
+/// Find every `*.csv` or `*.csv.gz` in `dir`. Returns sorted paths.
+///
+/// Accepts both starfield-gaia's "excerpt" layout
+/// (`shard_NNNN.csv.gz` under `~/.cache/starfield/gaia-excerpts/<name>/`)
+/// and the raw ESA `GaiaSource_NNN-NNN-NNN.csv.gz` layout — the column
+/// schema is identical in both cases, so `Dr3Catalog::from_csv_file`
+/// reads either uniformly.
+fn find_shard_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut files: Vec<PathBuf> = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if name.ends_with(".csv.gz") || name.ends_with(".csv") {
+            files.push(path);
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+/// Convert a single `Dr3Entry` to (index tuple, sidecar record).
+///
+/// `f64::NAN` is used for unpublished optional astrometry, matching the
+/// `SidecarRecord` schema. Sigmas (which `GaiaCore` stores as `f32`) are
+/// passed through; `NaN` for unpublished optional sigmas.
+pub fn entry_to_records(entry: &Dr3Entry) -> ShardRow {
+    let core = &entry.core;
+    let ra_rad = core.ra.to_radians();
+    let dec_rad = core.dec.to_radians();
+    let mag = core.phot_g_mean_mag;
+
+    let radial_velocity = entry
+        .radial_velocity
+        .as_ref()
+        .and_then(|rv| rv.radial_velocity)
+        .unwrap_or(f64::NAN);
+
+    let record = SidecarRecord {
+        source_id: core.source_id,
+        ref_epoch: core.ref_epoch,
+        ra: core.ra,
+        dec: core.dec,
+        pmra: core.pmra.unwrap_or(f64::NAN),
+        pmdec: core.pmdec.unwrap_or(f64::NAN),
+        parallax: core.parallax.unwrap_or(f64::NAN),
+        radial_velocity,
+        sigma_ra: core.ra_error,
+        sigma_dec: core.dec_error,
+        sigma_pmra: core.pmra_error.unwrap_or(f32::NAN),
+        sigma_pmdec: core.pmdec_error.unwrap_or(f32::NAN),
+        sigma_parallax: core.parallax_error.unwrap_or(f32::NAN),
+        flags: 0,
+    };
+
+    ((core.source_id, ra_rad, dec_rad, mag), record)
+}
+
+/// Read one shard via `Dr3Catalog::from_csv_file` (the canonical
+/// high-level reader for Gaia DR3 CSV shards) and return all kept
+/// stars as (tuple, record) pairs.
+fn read_shard(path: &Path, mag_limit: f64) -> Result<Vec<ShardRow>, String> {
+    let catalog = Dr3Catalog::from_csv_file(path, mag_limit)
+        .map_err(|e| format!("{}: load failed: {e}", path.display()))?;
+
+    // `brighter_than_ref(f64::INFINITY)` is the only inherent (non-trait)
+    // accessor on `GaiaCatalogBase` that yields `&R::Entry` for every
+    // loaded row — using `StarCatalog::stars()` would require both
+    // crates to agree on a single `starfield` instance, which they
+    // don't (starfield-gaia is git-pinned, zodiacal pulls from
+    // crates.io).
+    let entries = catalog.0.brighter_than_ref(f64::INFINITY);
+    let mut out = Vec::with_capacity(entries.len());
+    for entry in entries {
+        // mag_limit is already applied at load time, but defensively
+        // skip NaN mags — a NaN here would corrupt the brightness sort.
+        if !entry.core.phot_g_mean_mag.is_finite() {
+            continue;
+        }
+        out.push(entry_to_records(entry));
+    }
+    Ok(out)
+}
+
+/// Configuration for `run`.
+///
+/// `shards_dir = None` tells the tool to use the shard set cached by
+/// `starfield-gaia` (i.e. files under `~/.cache/starfield/gaia/dr3/`).
+pub struct BuildFromShardsConfig {
+    pub shards_dir: Option<PathBuf>,
+    pub output_prefix: PathBuf,
+    pub mag_limit: f64,
+    /// Lower scale bound in arcseconds.
+    pub scale_lower_arcsec: f64,
+    /// Upper scale bound in arcseconds.
+    pub scale_upper_arcsec: f64,
+    pub max_quads: Option<usize>,
+    pub cell_depth: u8,
+    /// Rayon thread pool size; pass `None` to use rayon's default.
+    pub threads: Option<usize>,
+}
+
+/// Top-level entry point.
+pub fn run(cfg: &BuildFromShardsConfig) -> Result<(), String> {
+    if !cfg.mag_limit.is_finite() || cfg.mag_limit > MAX_MAG_LIMIT {
+        return Err(format!(
+            "--mag-limit {} exceeds hard cap {}; v1 sidecar writer holds all records in RAM, \
+             and going deeper than ~17 won't fit on a 64 GB box. Either tighten the limit or \
+             wait for the streaming sidecar writer.",
+            cfg.mag_limit, MAX_MAG_LIMIT,
+        ));
+    }
+    if cfg.scale_lower_arcsec <= 0.0 || cfg.scale_upper_arcsec <= cfg.scale_lower_arcsec {
+        return Err(format!(
+            "invalid scale range: lower={}\" upper={}\" (must satisfy 0 < lower < upper)",
+            cfg.scale_lower_arcsec, cfg.scale_upper_arcsec
+        ));
+    }
+
+    let t0 = Instant::now();
+
+    // Resolve shards. If --shards-dir is provided, scan that directory.
+    // Otherwise use the shard set cached by `starfield-gaia` (typically
+    // `~/.cache/starfield/gaia/dr3/`), which is the canonical location
+    // for already-downloaded GaiaSource files.
+    let (shards, source_label) = match cfg.shards_dir.as_ref() {
+        Some(dir) => {
+            let files = find_shard_files(dir)
+                .map_err(|e| format!("failed to scan shards directory {}: {e}", dir.display()))?;
+            (files, format!("directory {}", dir.display()))
+        }
+        None => {
+            let cached = Downloader::<Dr3>::list_cached().map_err(|e| {
+                format!(
+                    "failed to list starfield-gaia cached shards: {e}; \
+                     pass --shards-dir to override"
+                )
+            })?;
+            (cached, "starfield-gaia cache".to_string())
+        }
+    };
+    if shards.is_empty() {
+        return Err(match cfg.shards_dir.as_ref() {
+            Some(dir) => format!("no .csv(.gz) shards found in {}", dir.display()),
+            None => "starfield-gaia cache is empty (no Gaia DR3 shards downloaded yet); \
+                     run starfield-gaia downloader or pass --shards-dir"
+                .to_string(),
+        });
+    }
+    eprintln!("Found {} shard(s) from {}", shards.len(), source_label);
+
+    if let Some(n) = cfg.threads {
+        let _ = rayon::ThreadPoolBuilder::new()
+            .num_threads(n)
+            .build_global();
+    }
+
+    let star_tuples: Mutex<Vec<IndexStarTuple>> = Mutex::new(Vec::new());
+    let sidecar_records: Mutex<Vec<SidecarRecord>> = Mutex::new(Vec::new());
+    let progress = std::sync::atomic::AtomicUsize::new(0);
+    let n_shards = shards.len();
+    let any_error: Mutex<Option<String>> = Mutex::new(None);
+
+    shards.par_iter().for_each(|path| {
+        if any_error.lock().unwrap().is_some() {
+            return;
+        }
+        match read_shard(path, cfg.mag_limit) {
+            Ok(rows) => {
+                let n = rows.len();
+                let mut tuples = star_tuples.lock().unwrap();
+                let mut records = sidecar_records.lock().unwrap();
+                tuples.reserve(n);
+                records.reserve(n);
+                for (t, r) in rows {
+                    tuples.push(t);
+                    records.push(r);
+                }
+                drop(tuples);
+                drop(records);
+                let done = progress.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                if done.is_multiple_of(50) || done == n_shards {
+                    let stars_so_far = star_tuples.lock().unwrap().len();
+                    eprintln!("  shard {done}/{n_shards} done ({stars_so_far} stars accumulated)");
+                }
+            }
+            Err(e) => {
+                let mut slot = any_error.lock().unwrap();
+                if slot.is_none() {
+                    *slot = Some(e);
+                }
+            }
+        }
+    });
+
+    if let Some(e) = any_error.into_inner().unwrap() {
+        return Err(e);
+    }
+
+    let star_tuples = star_tuples.into_inner().unwrap();
+    let sidecar_records = sidecar_records.into_inner().unwrap();
+    let n_stars = star_tuples.len();
+    let read_elapsed = t0.elapsed();
+    eprintln!(
+        "Read {} stars across {} shards in {:.1}s ({:.0} stars/s)",
+        n_stars,
+        n_shards,
+        read_elapsed.as_secs_f64(),
+        n_stars as f64 / read_elapsed.as_secs_f64().max(1e-9),
+    );
+
+    if n_stars == 0 {
+        return Err("no stars survived the magnitude cut; nothing to index".into());
+    }
+
+    let scale_lower_rad = (cfg.scale_lower_arcsec / 3600.0).to_radians();
+    let scale_upper_rad = (cfg.scale_upper_arcsec / 3600.0).to_radians();
+    // Default max_quads is 1M unless the caller overrides — empirically
+    // a reasonable balance of index size and matching quality. The
+    // direct `build_index` path doesn't HEALPix-uniformize, so without
+    // a cap it can balloon to 8× n_stars and OOM on large inputs.
+    let max_quads = cfg.max_quads.unwrap_or(1_000_000);
+    let max_stars = n_stars;
+    let builder_cfg = IndexBuilderConfig {
+        scale_lower: scale_lower_rad,
+        scale_upper: scale_upper_rad,
+        max_stars,
+        max_quads,
+    };
+
+    eprintln!(
+        "Building index: scale=[{:.1}\",{:.1}\"], max_quads={}",
+        cfg.scale_lower_arcsec, cfg.scale_upper_arcsec, max_quads,
+    );
+
+    let index = build_index(&star_tuples, &builder_cfg);
+    drop(star_tuples);
+    let build_elapsed = t0.elapsed() - read_elapsed;
+    eprintln!(
+        "Index built: {} stars, {} quads in {:.1}s",
+        index.stars.len(),
+        index.quads.len(),
+        build_elapsed.as_secs_f64()
+    );
+
+    let zdcl_path = with_suffix(&cfg.output_prefix, "zdcl");
+    let sidecar_path = with_suffix(&cfg.output_prefix, "zdcl.gaia");
+
+    index
+        .save_v3(&zdcl_path, cfg.cell_depth)
+        .map_err(|e| format!("failed to write {}: {e}", zdcl_path.display()))?;
+    let zdcl_size = std::fs::metadata(&zdcl_path).map(|m| m.len()).unwrap_or(0);
+
+    write_sidecar(&sidecar_path, sidecar_records, DEFAULT_PIVOT_STRIDE)
+        .map_err(|e| format!("failed to write {}: {e}", sidecar_path.display()))?;
+    let sidecar_size = std::fs::metadata(&sidecar_path)
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    let total = t0.elapsed();
+    eprintln!();
+    eprintln!("=== Summary ===");
+    eprintln!("Stars read:   {n_stars}");
+    eprintln!(
+        "Index file:   {} ({:.1} MB)",
+        zdcl_path.display(),
+        zdcl_size as f64 / 1024.0 / 1024.0
+    );
+    eprintln!(
+        "Sidecar file: {} ({:.1} MB)",
+        sidecar_path.display(),
+        sidecar_size as f64 / 1024.0 / 1024.0
+    );
+    eprintln!("Elapsed:      {:.1}s", total.as_secs_f64());
+
+    Ok(())
+}
+
+/// Append `.<suffix>` to `prefix`. Used because `Path::set_extension`
+/// would replace any trailing extension on the prefix; we want
+/// `out/foo` → `out/foo.zdcl`, and `out/foo.bar` → `out/foo.bar.zdcl`.
+fn with_suffix(prefix: &Path, suffix: &str) -> PathBuf {
+    let mut s = prefix.as_os_str().to_owned();
+    s.push(".");
+    s.push(suffix);
+    PathBuf::from(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use starfield_gaia::common::core::{GaiaCore, VarFlag};
+    use starfield_gaia::dr3::entry::Dr3Entry;
+
+    fn make_entry(source_id: u64, ra: f64, dec: f64, mag: f64) -> Dr3Entry {
+        Dr3Entry {
+            core: GaiaCore {
+                source_id,
+                solution_id: 1,
+                ref_epoch: 2016.0,
+                random_index: None,
+                ra,
+                ra_error: 0.1,
+                dec,
+                dec_error: 0.1,
+                ra_dec_corr: None,
+                parallax: Some(5.5),
+                parallax_error: Some(0.2),
+                pmra: Some(-12.3),
+                pmra_error: Some(0.05),
+                pmdec: Some(7.1),
+                pmdec_error: Some(0.04),
+                l: 0.0,
+                b: 0.0,
+                ecl_lon: 0.0,
+                ecl_lat: 0.0,
+                phot_g_mean_mag: mag,
+                phot_g_mean_flux: None,
+                phot_g_mean_flux_error: None,
+                phot_g_n_obs: None,
+                phot_variable_flag: VarFlag::NotAvailable,
+                astrometric_n_obs_al: None,
+                astrometric_excess_noise: None,
+                astrometric_excess_noise_sig: None,
+                astrometric_primary_flag: None,
+                duplicated_source: None,
+                matched_observations: None,
+            },
+            designation: None,
+            pm: None,
+            parallax_over_error: None,
+            astrometric_extra: Default::default(),
+            ipd: Default::default(),
+            bp_rp: None,
+            radial_velocity: None,
+            gspphot: None,
+            data_links: Default::default(),
+            classifications: Default::default(),
+        }
+    }
+
+    #[test]
+    fn entry_to_records_converts_units_and_passes_through_sigmas() {
+        let entry = make_entry(42, 90.0, -45.0, 12.5);
+        let ((source_id, ra_rad, dec_rad, mag), record) = entry_to_records(&entry);
+        assert_eq!(source_id, 42);
+        assert!((ra_rad - std::f64::consts::FRAC_PI_2).abs() < 1e-12);
+        assert!((dec_rad - (-std::f64::consts::FRAC_PI_4)).abs() < 1e-12);
+        assert_eq!(mag, 12.5);
+
+        // Sidecar record stores RA/Dec in degrees (matching the on-disk
+        // schema documented in zodiacal::refinement::sidecar).
+        assert_eq!(record.ra, 90.0);
+        assert_eq!(record.dec, -45.0);
+        assert_eq!(record.pmra, -12.3);
+        assert_eq!(record.pmdec, 7.1);
+        assert_eq!(record.parallax, 5.5);
+        assert!(record.radial_velocity.is_nan()); // unpublished
+        assert_eq!(record.sigma_ra, 0.1);
+        assert_eq!(record.sigma_pmra, 0.05);
+        assert_eq!(record.sigma_pmdec, 0.04);
+        assert_eq!(record.sigma_parallax, 0.2);
+    }
+
+    #[test]
+    fn entry_to_records_uses_nan_for_missing_optional_astrometry() {
+        let mut entry = make_entry(7, 1.0, 2.0, 11.0);
+        entry.core.pmra = None;
+        entry.core.pmdec = None;
+        entry.core.parallax = None;
+        entry.core.parallax_error = None;
+        entry.core.pmra_error = None;
+        entry.core.pmdec_error = None;
+        let (_, record) = entry_to_records(&entry);
+        assert!(record.pmra.is_nan());
+        assert!(record.pmdec.is_nan());
+        assert!(record.parallax.is_nan());
+        assert!(record.sigma_pmra.is_nan());
+        assert!(record.sigma_pmdec.is_nan());
+        assert!(record.sigma_parallax.is_nan());
+    }
+
+    #[test]
+    fn run_rejects_excessive_mag_limit() {
+        let cfg = BuildFromShardsConfig {
+            shards_dir: Some(PathBuf::from("/nonexistent")),
+            output_prefix: PathBuf::from("/tmp/_zt_test"),
+            mag_limit: 19.5,
+            scale_lower_arcsec: 60.0,
+            scale_upper_arcsec: 1800.0,
+            max_quads: Some(1000),
+            cell_depth: 5,
+            threads: Some(1),
+        };
+        let err = run(&cfg).unwrap_err();
+        assert!(err.contains("exceeds hard cap"), "got: {err}");
+    }
+
+    #[test]
+    fn run_rejects_inverted_scale_range() {
+        let cfg = BuildFromShardsConfig {
+            shards_dir: Some(PathBuf::from("/nonexistent")),
+            output_prefix: PathBuf::from("/tmp/_zt_test"),
+            mag_limit: 14.0,
+            scale_lower_arcsec: 1800.0,
+            scale_upper_arcsec: 60.0,
+            max_quads: Some(1000),
+            cell_depth: 5,
+            threads: Some(1),
+        };
+        let err = run(&cfg).unwrap_err();
+        assert!(err.contains("invalid scale range"), "got: {err}");
+    }
+}

--- a/zodiacal-tools/src/main.rs
+++ b/zodiacal-tools/src/main.rs
@@ -1,0 +1,109 @@
+//! `zodiacal-tools` — operational binaries for building and inspecting
+//! zodiacal indexes (`.zdcl`) and refinement sidecars (`.zdcl.gaia`).
+//!
+//! These tools depend on `starfield-gaia` (currently a git dep until it
+//! publishes to crates.io) and are deliberately split out of the
+//! `zodiacal` library crate so that crate stays publishable without
+//! pulling unpublished deps into its feature graph.
+
+use std::path::PathBuf;
+use std::process;
+
+use clap::{Parser, Subcommand};
+
+use zodiacal::index::source::DEFAULT_CELL_DEPTH;
+
+mod build_from_shards;
+
+use build_from_shards::{BuildFromShardsConfig, run as run_build_from_shards};
+
+#[derive(Parser)]
+#[command(
+    name = "zodiacal-tools",
+    about = "Operational tools for zodiacal indexes and sidecars"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Build a `.zdcl` index plus a `.zdcl.gaia` refinement sidecar
+    /// from a directory of Gaia DR3 `GaiaSource_*.csv.gz` (or
+    /// excerpt-cache `shard_*.csv.gz`) shards in one pass.
+    ///
+    /// Reads every shard once, applies the magnitude limit, then builds
+    /// the quad index (v3 layout) and writes the sidecar (sorted by
+    /// source_id).
+    ///
+    /// Memory note: the v1 sidecar writer holds all records in RAM.
+    /// Each star is ~120 bytes, so G≤16 (~83 M stars) is the practical
+    /// ceiling on a 64 GB box; G>17 is rejected up front.
+    BuildFromShards {
+        /// Directory containing `*.csv(.gz)` shards. If omitted, uses
+        /// the starfield-managed cache (`Downloader::<Dr3>::list_cached()`).
+        #[arg(long)]
+        shards_dir: Option<PathBuf>,
+
+        /// Output prefix; emits `<prefix>.zdcl` and `<prefix>.zdcl.gaia`.
+        #[arg(long)]
+        output_prefix: PathBuf,
+
+        /// G-band magnitude cutoff (must be <= 17.0; deeper won't fit in RAM).
+        #[arg(long, default_value = "16.0")]
+        mag_limit: f64,
+
+        /// Minimum quad scale in arcseconds.
+        #[arg(long, default_value = "30.0")]
+        scale_lower: f64,
+
+        /// Maximum quad scale in arcseconds.
+        #[arg(long, default_value = "1800.0")]
+        scale_upper: f64,
+
+        /// Maximum number of quads to generate (default: 1,000,000).
+        #[arg(long)]
+        max_quads: Option<usize>,
+
+        /// HEALPix depth used to group stars in the v3 `.zdcl` file.
+        #[arg(long, default_value_t = DEFAULT_CELL_DEPTH)]
+        cell_depth: u8,
+
+        /// Rayon worker thread count for parallel shard reads
+        /// (default: rayon's default = all logical cores).
+        #[arg(long)]
+        threads: Option<usize>,
+    },
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match &cli.command {
+        Commands::BuildFromShards {
+            shards_dir,
+            output_prefix,
+            mag_limit,
+            scale_lower,
+            scale_upper,
+            max_quads,
+            cell_depth,
+            threads,
+        } => {
+            let cfg = BuildFromShardsConfig {
+                shards_dir: shards_dir.clone(),
+                output_prefix: output_prefix.clone(),
+                mag_limit: *mag_limit,
+                scale_lower_arcsec: *scale_lower,
+                scale_upper_arcsec: *scale_upper,
+                max_quads: *max_quads,
+                cell_depth: *cell_depth,
+                threads: *threads,
+            };
+            if let Err(e) = run_build_from_shards(&cfg) {
+                eprintln!("build-from-shards failed: {e}");
+                process::exit(1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the closed [PR #61](https://github.com/OrbitalCommons/zodiacal/pull/61) with a cleaner architecture: `build-from-shards` is now in a separate `zodiacal-tools` workspace crate instead of a feature on the zodiacal library.

## Why

The earlier approach added a `gaia-shards` feature to zodiacal, which pulled `starfield-gaia` into zodiacal's dependency graph. `starfield-gaia` is unpublished (only available via git), and **`cargo publish` forbids git deps in published crates** — so any future zodiacal release that exposed the `gaia-shards` feature would silently fail to publish.

The build-from-shards subcommand is an operational tool (you run it once per index build), not a library API. Splitting it off keeps the zodiacal library cleanly publishable while still letting the tool iterate freely.

## Layout

```
zodiacal/                      ← workspace root + zodiacal lib + zodiacal bin
├── Cargo.toml                 ← [workspace] members = ["zodiacal-tools"]
├── src/                       ← library (unchanged)
└── zodiacal-tools/            ← NEW — separate published crate
    ├── Cargo.toml             ← deps: zodiacal (path/version), starfield-gaia (git), clap, rayon
    └── src/
        ├── main.rs            ← CLI entry (subcommand router)
        └── build_from_shards.rs   ← the actual implementation
```

The zodiacal library Cargo.toml gains zero new dependencies. zodiacal-tools is intended as the home for future operational binaries (sidecar inspector, v3-aware info command, etc.).

## What `build-from-shards` does

Same as the closed #61 work (incorporated wholesale):

- Reads Gaia DR3 CSV shards via `Dr3Catalog::from_csv_file` (the canonical starfield-gaia high-level API).
- `--shards-dir` defaults to `Downloader::<Dr3>::list_cached()`. Canonical command on a box that already has the data downloaded:
  ```
  zodiacal-tools build-from-shards --output-prefix <p> --mag-limit 14.0
  ```
- Accepts both raw ESA (`GaiaSource_*.csv.gz`) and excerpt-cache (`shard_*.csv.gz`) layouts.
- Emits `.zdcl` (v3 layout, `cell_depth = 5`) + `.zdcl.gaia` (sorted by source_id).
- `--max-quads` default lowered to **1,000,000** — the old `n_stars * 8` default would balloon to ~134M for a mag-14 read and OOM-kill on a 64 GB box.
- Hard-rejects `--mag-limit > 17.0` (memory budget for the in-RAM v1 sidecar writer).

Depends on the upstream multi-member-gzip fix already landed in [OrbitalCommons/starfield-datasources#37](https://github.com/OrbitalCommons/starfield-datasources/pull/37).

## Verified end-to-end against `~/.cache/starfield/gaia-excerpts/dr3-mag20`

- 16,844,164 stars read at mag ≤ 14 in 9.3 min
- index: 560 MB v3 layout, 1M quads
- sidecar: 1.4 GB (16.8M records)
- both load via `ZdclFile::open` / `SidecarReader::open`

## Test plan

- [x] `cargo build` (default features) — clean
- [x] `cargo build --workspace` — clean
- [x] `cargo build --release -p zodiacal-tools` — clean
- [x] `cargo test --workspace` — 181 pass (177 zodiacal + 4 zodiacal-tools)
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `zodiacal-tools build-from-shards --help` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)