### PR TITLE
Read FITS as standard NAXIS1=cols and bump batch-solve precision

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -279,9 +279,11 @@ fn load_fits(path: &Path) -> Array2<f32> {
         process::exit(1);
     });
 
-    let naxis1 = shape[0];
-    let naxis2 = shape[1];
-    eprintln!("FITS: {}x{}", naxis1, naxis2);
+    // Standard FITS: NAXIS1 = fastest-varying axis = image cols (width),
+    // NAXIS2 = slower axis = image rows (height), origin bottom-left.
+    let cols = shape[0];
+    let rows = shape[1];
+    eprintln!("FITS: {}x{}", cols, rows);
 
     // Read pixels as f32 (compat API handles BSCALE/BZERO automatically)
     let pixels: Vec<f32> = f32::read_image(&fitsfile, &hdu).unwrap_or_else(|e| {
@@ -289,24 +291,22 @@ fn load_fits(path: &Path) -> Array2<f32> {
         process::exit(1);
     });
 
-    let expected = naxis1 * naxis2;
+    let expected = cols * rows;
     if pixels.len() != expected {
         eprintln!(
             "FITS pixel count mismatch: expected {} ({}x{}), got {}",
             expected,
-            naxis1,
-            naxis2,
+            cols,
+            rows,
             pixels.len()
         );
         process::exit(1);
     }
 
-    // The test FITS files are written by meter-sim's fitsio which passes
-    // ndarray dimensions as [rows, cols] to FITS, mapping them to
-    // NAXIS1=rows and NAXIS2=cols (non-standard). The data is also flipped
-    // vertically on write (FITS origin is bottom-left). We reshape as
-    // (naxis1, naxis2) = (rows, cols) and flip vertically to undo both.
-    let arr = Array2::from_shape_vec((naxis1, naxis2), pixels).unwrap_or_else(|e| {
+    // FITS storage is NAXIS1-fastest, so the buffer is laid out as
+    // (rows, cols) row-major with row 0 = NAXIS2=1 = bottom of the image.
+    // ndarray Array2 conventionally puts row 0 at the top, so flip rows.
+    let arr = Array2::from_shape_vec((rows, cols), pixels).unwrap_or_else(|e| {
         eprintln!("Failed to reshape FITS data: {e}");
         process::exit(1);
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -538,7 +538,7 @@ fn cmd_batch_solve(
                 let (ra, dec) = solution.wcs.field_center();
                 let best_reject_lo = stats.best_rejected.map(|(lo, _)| lo).unwrap_or(0.0);
                 eprintln!(
-                    "SOLVED in {:.1}s  RA={:.4} Dec={:+.4}  matched={}  verified={}  accept_lo={:.1}  best_reject_lo={:.1}",
+                    "SOLVED in {:.1}s  RA={:.8} Dec={:+.8}  matched={}  verified={}  accept_lo={:.1}  best_reject_lo={:.1}",
                     elapsed,
                     ra.to_degrees(),
                     dec.to_degrees(),


### PR DESCRIPTION
## Summary

Two small changes prompted by the residual investigation in #67 and the upstream FITS-writer fix CosmicFrontierLabs/cfl-foundations#11 (pulled into focalplane via CosmicFrontierLabs/focalplane#79).

### 1. `load_fits` now reads standard FITS correctly

The previous reshape `Array2::from_shape_vec((naxis1, naxis2), pixels)` interpreted `shape[0]=NAXIS1` as rows, but FITS-standard (and what cfl-foundations writes) is `NAXIS1 = fastest-varying axis = cols`. For non-square images that produced a transposed-with-wrap array — verified empirically against the 88×104 checkerboard test FITS in `fits-test-cases`:

| | image_width | image_height | source count |
|---|---|---|---|
| Before | 104 (wrong) | 88 (wrong) | 100 (false detections from scrambled data) |
| After | 88 ✓ | 104 ✓ | 71 ✓ |

The vertical-flip `arr.slice(s![..;-1, ..])` is **retained** — standard FITS storage puts NAXIS2=1 at the bottom of the image (origin bottom-left), so reading the buffer in row-major (rows, cols) order puts the bottom image row at `array[0, :]`. Flipping yields `array[0, :] = top of image`, matching the convention used elsewhere in the codebase. (The cfl-foundations PR description suggested dropping the flip; tracing through the standard FITS read path indicates the flip is still needed once the reshape is corrected.)

### 2. `batch-solve` log: bump RA/Dec from 4 to 8 decimals

The 4-decimal print precision (~0.36" / cos(δ)) was coarser than the solver's intrinsic precision and made residual analysis a quantization-floor study rather than a precision study. 8 decimals is sub-mas and the line is still readable.

## Caveat for the residual benchmark

Existing `test_cases/*.json` were extracted from FITS files that have since been deleted by the test-case generator. They are JSON-only inputs to `batch-solve`, so this PR does not affect their numerics. To validate the end-to-end fix (residual systematic gone), test cases need to be regenerated against post-fix focalplane FITS — that's a follow-up.

## Test plan

- [x] `cargo test --release` — 128 tests pass
- [x] `cargo fmt`
- [x] Empirical extract on `checkerboard_8px_blocks_11x13_grid.fits` produces correct `image_width=88, image_height=104`
- [ ] Regenerate `test_cases/` against post-fix focalplane and re-run residual benchmark (follow-up)

Refs #67, CosmicFrontierLabs/focalplane#77.