### PR TITLE
zodiacal-tools: require --max-quads, drop the 1M default

### DIFF
--- a/zodiacal-tools/src/build_from_shards.rs
+++ b/zodiacal-tools/src/build_from_shards.rs
@@ -138,7 +138,7 @@ pub struct BuildFromShardsConfig {
     pub scale_lower_arcsec: f64,
     /// Upper scale bound in arcseconds.
     pub scale_upper_arcsec: f64,
-    pub max_quads: Option<usize>,
+    pub max_quads: usize,
     pub cell_depth: u8,
     /// Rayon thread pool size; pass `None` to use rayon's default.
     pub threads: Option<usize>,
@@ -259,11 +259,7 @@ pub fn run(cfg: &BuildFromShardsConfig) -> Result<(), String> {
 
     let scale_lower_rad = (cfg.scale_lower_arcsec / 3600.0).to_radians();
     let scale_upper_rad = (cfg.scale_upper_arcsec / 3600.0).to_radians();
-    // Default max_quads is 1M unless the caller overrides — empirically
-    // a reasonable balance of index size and matching quality. The
-    // direct `build_index` path doesn't HEALPix-uniformize, so without
-    // a cap it can balloon to 8× n_stars and OOM on large inputs.
-    let max_quads = cfg.max_quads.unwrap_or(1_000_000);
+    let max_quads = cfg.max_quads;
     let max_stars = n_stars;
     let builder_cfg = IndexBuilderConfig {
         scale_lower: scale_lower_rad,
@@ -432,7 +428,7 @@ mod tests {
             mag_limit: 19.5,
             scale_lower_arcsec: 60.0,
             scale_upper_arcsec: 1800.0,
-            max_quads: Some(1000),
+            max_quads: 1000,
             cell_depth: 5,
             threads: Some(1),
         };
@@ -448,7 +444,7 @@ mod tests {
             mag_limit: 14.0,
             scale_lower_arcsec: 1800.0,
             scale_upper_arcsec: 60.0,
-            max_quads: Some(1000),
+            max_quads: 1000,
             cell_depth: 5,
             threads: Some(1),
         };

--- a/zodiacal-tools/src/main.rs
+++ b/zodiacal-tools/src/main.rs
@@ -62,9 +62,13 @@ enum Commands {
         #[arg(long, default_value = "1800.0")]
         scale_upper: f64,
 
-        /// Maximum number of quads to generate (default: 1,000,000).
+        /// Maximum number of quads to generate. Required: there is no
+        /// default because the right value depends on the catalog
+        /// depth, FOV target, and host RAM — picking one for the user
+        /// hides the trade-off and (for the brightness-first builder)
+        /// concentrates the budget in a few dense sky regions.
         #[arg(long)]
-        max_quads: Option<usize>,
+        max_quads: usize,
 
         /// HEALPix depth used to group stars in the v3 `.zdcl` file.
         #[arg(long, default_value_t = DEFAULT_CELL_DEPTH)]


### PR DESCRIPTION
## Summary

- Removes the implicit `--max-quads` default of 1,000,000 in `build-from-shards`.
- `--max-quads` is now a required CLI flag; `BuildFromShardsConfig.max_quads` is `usize` (was `Option<usize>`).

## Motivation

The default hid a real trade-off. At `--max-quads 1000000` on a G ≤ 14 build (`scratch/gaia_g14.zdcl`), the brightness-first `build_index` path concentrates the entire budget in ~133 of 12,288 HEALPix cells (1.1 % of the sky) — galactic-plane / Hyades / Pleiades clusters where the brightest stars live. A 0.5° random-pointing FOV-coverage measurement comes back **empty 99.8 % of the time**. The single most-reused star (G = 7.6) appears in 257,870 quads on its own.

Diagnostics from `scripts/analyze_index.py` (in #65 branch):
- Per-cell quad density: 133 cells populated, max 257k quads in one cell.
- Per-cell index depth (faintest used star): in the populated cells, the dimmest used star saturates at G ≈ 14 — so depth is fine where reached. The problem is purely sky coverage.
- 99.9 % of catalog stars are unused.

The right value for `--max-quads` depends on catalog depth, target FOV, and host RAM. Picking one silently has been masking the question.

## What this PR is *not*

It does not fix the underlying brightness-first concentration — that's a separate, larger fix (switching `build-from-shards` to the HEALPix-uniformized `build_index_from_catalog` path or the cell-driven builder in #65). This PR just stops the silent default from hiding the problem.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 177 + 4 + 0 doc tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo run … build-from-shards --output-prefix /tmp/x` (without `--max-quads`) errors with `the following required arguments were not provided: --max-quads <MAX_QUADS>`
- [x] `--help` shows the new required arg with the rationale in the description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)