### PR TITLE
Cell-driven, resumable index builder primitives (#65)

### DIFF
--- a/scripts/analyze_index.py
+++ b/scripts/analyze_index.py
@@ -1,0 +1,650 @@
+"""Visual analysis of a built `.zdcl` v3 index.
+
+Loads a `.zdcl` file via mmap-backed numpy views (no full-file copy) and
+emits a set of self-contained figures characterising the index's quad
+coverage, sky distribution, code-space density, and star reuse.
+
+Usage
+-----
+    python3 scripts/analyze_index.py scratch/gaia_g14.zdcl
+
+By default, figures are written to `scripts/out/<index-stem>/`. Pass
+`--out-dir` to override.
+
+Each figure answers one question about the index:
+
+  scale_coverage.png : What scales / magnitudes does the index cover?
+                       What's the per-cell quad density spread?
+  sky_density.png    : Where on the sky are the stars and quads? Are
+                       there dead zones or galactic-plane oversampling?
+  code_space.png     : Do the canonical 4-D codes spread out (good for
+                       matching) or pile up in a corner (bad)?
+  star_reuse.png     : Does any one star dominate? Is the `max_reuse`
+                       cap hitting?
+  fov_coverage.png   : For a typical FOV at random sky positions, how
+                       many quads land inside? (this is the metric the
+                       solver actually cares about)
+
+The point of these plots is to give a fast intuition for whether a
+freshly-built index is well-behaved before trusting it on real data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import struct
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.colors import LogNorm
+from matplotlib.figure import Figure
+
+
+STAR_DTYPE = np.dtype([
+    ("catalog_id", "<u8"),
+    ("ra", "<f8"),
+    ("dec", "<f8"),
+    ("mag", "<f8"),
+])
+QUAD_DTYPE = np.dtype([("star_ids", "<u4", (4,))])
+CODE_DTYPE = np.dtype([("code", "<f8", (4,))])
+
+ARCSEC_PER_RAD = (180.0 / math.pi) * 3600.0
+
+
+@dataclass
+class IndexHeader:
+    version: int
+    cell_depth: int
+    n_cells: int
+    n_stars: int
+    n_quads: int
+    scale_lower_rad: float
+    scale_upper_rad: float
+    metadata: Optional[dict]
+
+
+class ZdclV3:
+    """Memory-mapped view of a `.zdcl` v3 file.
+
+    Star, quad, and code blocks are exposed as numpy structured arrays
+    backed by the mmap — no copy until you index into them.
+    """
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.size_bytes = path.stat().st_size
+
+        with path.open("rb") as f:
+            magic = f.read(4)
+            if magic != b"ZDCL":
+                raise ValueError(f"bad magic {magic!r} in {path}")
+            (version,) = struct.unpack("<I", f.read(4))
+            if version != 3:
+                raise ValueError(f"only v3 is supported; got v{version}")
+            (meta_len,) = struct.unpack("<Q", f.read(8))
+            meta_bytes = f.read(meta_len)
+            metadata = json.loads(meta_bytes) if meta_bytes else None
+            (cell_depth,) = struct.unpack("<B", f.read(1))
+            f.read(7)  # reserved
+            (n_cells,) = struct.unpack("<Q", f.read(8))
+
+            cell_table_bytes = n_cells * (8 + 8 + 4)
+            cell_table_buf = f.read(cell_table_bytes)
+
+            consumed = 4 + 4 + 8 + meta_len + 1 + 7 + 8 + cell_table_bytes
+            pad = (-consumed) & 7
+            if pad:
+                f.read(pad)
+            consumed += pad
+
+            (n_stars,) = struct.unpack("<Q", f.read(8))
+            (n_quads,) = struct.unpack("<Q", f.read(8))
+            (scale_lower,) = struct.unpack("<d", f.read(8))
+            (scale_upper,) = struct.unpack("<d", f.read(8))
+            consumed += 8 * 4
+            stars_offset = consumed
+
+        self.header = IndexHeader(
+            version=version,
+            cell_depth=cell_depth,
+            n_cells=n_cells,
+            n_stars=n_stars,
+            n_quads=n_quads,
+            scale_lower_rad=scale_lower,
+            scale_upper_rad=scale_upper,
+            metadata=metadata,
+        )
+
+        # Cell table as structured array.
+        cell_dtype = np.dtype([("cell_id", "<u8"), ("star_offset", "<u8"), ("star_count", "<u4")])
+        self.cell_table = np.frombuffer(cell_table_buf, dtype=cell_dtype)
+
+        # mmap the whole file once for the bulk arrays.
+        self._mm = np.memmap(path, dtype=np.uint8, mode="r")
+        stars_size = n_stars * STAR_DTYPE.itemsize
+        quads_offset = stars_offset + stars_size
+        quads_size = n_quads * QUAD_DTYPE.itemsize
+        codes_offset = quads_offset + quads_size
+        codes_size = n_quads * CODE_DTYPE.itemsize
+        self.stars = np.frombuffer(
+            self._mm[stars_offset:stars_offset + stars_size].tobytes(),
+            dtype=STAR_DTYPE,
+        )
+        self.quads = np.frombuffer(
+            self._mm[quads_offset:quads_offset + quads_size].tobytes(),
+            dtype=QUAD_DTYPE,
+        )["star_ids"]
+        self.codes = np.frombuffer(
+            self._mm[codes_offset:codes_offset + codes_size].tobytes(),
+            dtype=CODE_DTYPE,
+        )["code"]
+
+
+# --- analyses -----------------------------------------------------------
+
+
+def angular_distance_rad(ra1, dec1, ra2, dec2):
+    """Vectorised great-circle distance in radians."""
+    sin_dec = np.sin(dec1) * np.sin(dec2)
+    cos_dec = np.cos(dec1) * np.cos(dec2)
+    cos_sep = sin_dec + cos_dec * np.cos(ra1 - ra2)
+    return np.arccos(np.clip(cos_sep, -1.0, 1.0))
+
+
+def quad_backbone_arcsec(z: ZdclV3) -> np.ndarray:
+    """Maximum angular separation (arcsec) over all 6 pairs of stars in
+    each quad.
+
+    Note: `canonical_quad_order` puts the longest pair at indices [0],[1]
+    pre-encoding, but `compute_canonical_code` may then reorder the
+    members during canonical encoding — so reading just `star_ids[0]`
+    vs `star_ids[1]` from disk does NOT always give the longest pair.
+    We take the max over all 6 pairwise distances to recover the
+    defining backbone scale unambiguously.
+    """
+    sids = z.quads
+    rs = z.stars["ra"][sids]   # (N, 4)
+    ds = z.stars["dec"][sids]  # (N, 4)
+    sin_d = np.sin(ds)
+    cos_d = np.cos(ds)
+    pairs = [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
+    n = sids.shape[0]
+    max_sep = np.zeros(n, dtype=np.float64)
+    for i, j in pairs:
+        cos_sep = sin_d[:, i] * sin_d[:, j] + cos_d[:, i] * cos_d[:, j] * np.cos(rs[:, i] - rs[:, j])
+        sep = np.arccos(np.clip(cos_sep, -1.0, 1.0))
+        np.maximum(max_sep, sep, out=max_sep)
+    return max_sep * ARCSEC_PER_RAD
+
+
+def star_reuse_counts(z: ZdclV3) -> np.ndarray:
+    """How many quads each star participates in, indexed by star id."""
+    flat = z.quads.reshape(-1)
+    counts = np.bincount(flat, minlength=z.header.n_stars)
+    return counts
+
+
+def quads_per_cell(z: ZdclV3) -> np.ndarray:
+    """Quads per HEALPix cell (anchor-star-defined): count quads whose
+    `star_ids[0]` falls in each cell.
+    """
+    # cell_table is (cell_id, star_offset, star_count). Build a bin
+    # edge array so np.searchsorted maps each anchor's star idx to a
+    # cell bucket.
+    bin_edges = np.empty(len(z.cell_table) + 1, dtype=np.int64)
+    bin_edges[:-1] = z.cell_table["star_offset"]
+    bin_edges[-1] = z.header.n_stars
+    anchor_star = z.quads[:, 0].astype(np.int64)
+    bucket = np.searchsorted(bin_edges, anchor_star, side="right") - 1
+    counts = np.bincount(bucket, minlength=len(z.cell_table))
+    return counts
+
+
+def quad_centers(z: ZdclV3) -> tuple[np.ndarray, np.ndarray]:
+    """Approximate (ra, dec) of each quad's centroid (mean of 3-D unit
+    vectors of its 4 stars). Returns radians.
+    """
+    sids = z.quads
+    rs = z.stars["ra"]
+    ds = z.stars["dec"]
+    # Stack (N, 4) → 4 unit vectors per quad.
+    cos_d = np.cos(ds)
+    x = cos_d * np.cos(rs)
+    y = cos_d * np.sin(rs)
+    zc = np.sin(ds)
+    # Sum across the 4 members for each quad.
+    sx = x[sids].sum(axis=1)
+    sy = y[sids].sum(axis=1)
+    sz = zc[sids].sum(axis=1)
+    norm = np.sqrt(sx * sx + sy * sy + sz * sz)
+    sx /= norm
+    sy /= norm
+    sz /= norm
+    ra = np.arctan2(sy, sx)
+    ra = np.where(ra < 0, ra + 2 * np.pi, ra)  # [0, 2π)
+    dec = np.arcsin(np.clip(sz, -1.0, 1.0))
+    return ra, dec
+
+
+def fov_quad_count(
+    z: ZdclV3,
+    n_samples: int = 2000,
+    fov_radius_deg: float = 0.5,
+    rng: Optional[np.random.Generator] = None,
+) -> np.ndarray:
+    """For `n_samples` random sky pointings, count quads whose centroid
+    lies within `fov_radius_deg`. Sampling is uniform on the sphere.
+
+    Implemented as a chunked BLAS GEMM over XYZ unit vectors:
+    cos(separation) = sample_xyz · quad_xyz. One pass, ~seconds for
+    1 M quads × 2 k samples on a single core.
+    """
+    rng = rng or np.random.default_rng(20260504)
+    u = rng.uniform(size=n_samples)
+    v = rng.uniform(size=n_samples)
+    sample_ra = 2 * np.pi * u
+    sample_dec = np.arcsin(2 * v - 1)
+    cos_sd = np.cos(sample_dec)
+    sample_xyz = np.column_stack([
+        cos_sd * np.cos(sample_ra),
+        cos_sd * np.sin(sample_ra),
+        np.sin(sample_dec),
+    ])  # (n_samples, 3)
+
+    quad_ra, quad_dec = quad_centers(z)
+    cos_qd = np.cos(quad_dec)
+    quad_xyz = np.column_stack([
+        cos_qd * np.cos(quad_ra),
+        cos_qd * np.sin(quad_ra),
+        np.sin(quad_dec),
+    ])  # (n_quads, 3)
+
+    cos_radius = math.cos(math.radians(fov_radius_deg))
+
+    counts = np.zeros(n_samples, dtype=np.int64)
+    # Chunk over samples so peak (chunk × n_quads) stays under ~1.5 GB.
+    chunk = max(1, int(2_000_000 // max(quad_xyz.shape[0], 1)))
+    chunk = max(min(chunk, n_samples), 1)
+    for i in range(0, n_samples, chunk):
+        block = sample_xyz[i:i + chunk]
+        cos_sep = block @ quad_xyz.T  # (chunk, n_quads)
+        counts[i:i + chunk] = np.sum(cos_sep >= cos_radius, axis=1)
+    return counts
+
+
+# --- figures ------------------------------------------------------------
+
+
+def setup_style():
+    plt.rcParams.update({
+        "figure.dpi": 110,
+        "savefig.dpi": 140,
+        "savefig.bbox": "tight",
+        "font.family": "DejaVu Sans",
+        "axes.titlesize": 11,
+        "axes.titleweight": "bold",
+        "axes.labelsize": 10,
+        "axes.grid": True,
+        "grid.alpha": 0.25,
+        "grid.linewidth": 0.5,
+        "axes.spines.top": False,
+        "axes.spines.right": False,
+    })
+
+
+def fig_scale_coverage(z: ZdclV3) -> Figure:
+    backbone = quad_backbone_arcsec(z)
+    qpc = quads_per_cell(z)
+    mags = z.stars["mag"]
+
+    fig, axes = plt.subplots(1, 3, figsize=(15, 5.0))
+    fig.suptitle("Scale coverage & per-cell density", fontsize=13, weight="bold", y=1.02)
+
+    # Backbone.
+    ax = axes[0]
+    lo = z.header.scale_lower_rad * ARCSEC_PER_RAD
+    hi = z.header.scale_upper_rad * ARCSEC_PER_RAD
+    bins = np.geomspace(max(lo * 0.8, 1.0), hi * 1.2, 80)
+    ax.hist(backbone, bins=bins, color="#4c72b0", edgecolor="white", linewidth=0.3)
+    ax.axvline(lo, color="#c44", ls="--", lw=1, label=f"scale_lower = {lo:.0f}″")
+    ax.axvline(hi, color="#c44", ls="--", lw=1, label=f"scale_upper = {hi:.0f}″")
+    ax.set_xscale("log")
+    ax.set_xlabel("backbone angular distance (arcsec)")
+    ax.set_ylabel("quads")
+    ax.set_title(f"Quad backbone scale\n(N = {len(backbone):,})")
+    ax.legend(loc="upper left", frameon=False, fontsize=8)
+
+    # Magnitudes.
+    ax = axes[1]
+    ax.hist(mags, bins=80, color="#55a868", edgecolor="white", linewidth=0.3)
+    ax.set_xlabel("Gaia G magnitude")
+    ax.set_ylabel("stars")
+    median_mag = float(np.median(mags))
+    p99 = float(np.percentile(mags, 99))
+    ax.axvline(median_mag, color="#444", ls=":", lw=1)
+    ax.text(
+        median_mag, ax.get_ylim()[1] * 0.92,
+        f"  median {median_mag:.2f}", color="#444", fontsize=9,
+    )
+    ax.set_title(f"Star magnitude depth\n(N = {len(mags):,}, p99 = {p99:.2f})")
+
+    # Quads per cell.
+    ax = axes[2]
+    populated = qpc[qpc > 0]
+    ax.hist(populated, bins=60, color="#c44e52", edgecolor="white", linewidth=0.3)
+    ax.set_yscale("log")
+    ax.set_xlabel("quads per HEALPix cell (anchor-defined)")
+    ax.set_ylabel("cells (log)")
+    n_pop = int(np.sum(qpc > 0))
+    n_total = len(qpc)
+    median_q = float(np.median(populated)) if populated.size else 0.0
+    ax.set_title(
+        f"Per-cell quad density\n"
+        f"({n_pop:,}/{n_total:,} cells populated, median {median_q:.0f})"
+    )
+    return fig
+
+
+def fig_sky_density(z: ZdclV3) -> Figure:
+    fig, axes = plt.subplots(2, 1, figsize=(14, 12), subplot_kw={"projection": "mollweide"})
+    fig.suptitle("Sky density (Mollweide, log-scale)", fontsize=14, weight="bold", y=0.94)
+
+    # Mollweide expects RA in [-π, π], Dec in [-π/2, π/2].
+    star_ra = np.where(z.stars["ra"] > np.pi, z.stars["ra"] - 2 * np.pi, z.stars["ra"])
+    star_dec = z.stars["dec"]
+
+    quad_ra_full, quad_dec = quad_centers(z)
+    quad_ra = np.where(quad_ra_full > np.pi, quad_ra_full - 2 * np.pi, quad_ra_full)
+
+    # Subsample stars for hexbin to keep memory & runtime sane on 16 M.
+    if star_ra.size > 2_000_000:
+        idx = np.random.default_rng(0).choice(star_ra.size, size=2_000_000, replace=False)
+        sra = star_ra[idx]
+        sdec = star_dec[idx]
+        sub_factor = star_ra.size / sra.size
+    else:
+        sra, sdec = star_ra, star_dec
+        sub_factor = 1.0
+
+    for ax, x, y, title, factor in [
+        (axes[0], sra, sdec, f"Star density (subsampled to {sra.size:,}; full = {star_ra.size:,})", sub_factor),
+        (axes[1], quad_ra, quad_dec, f"Quad-centroid density (N = {quad_ra.size:,})", 1.0),
+    ]:
+        hb = ax.hexbin(
+            x, y,
+            gridsize=(120, 60),
+            mincnt=1,
+            cmap="viridis",
+            norm=LogNorm(),
+        )
+        ax.set_title(title)
+        ax.set_xticklabels([])  # default ticks overlap with the projection edges
+        cbar = fig.colorbar(hb, ax=ax, fraction=0.025, pad=0.02)
+        cbar.set_label(f"count / hex (×{factor:.1f} for full-set scaling)")
+        ax.grid(True, alpha=0.3, color="white", linewidth=0.4)
+
+    return fig
+
+
+def fig_code_space(z: ZdclV3, n_max: int = 250_000) -> Figure:
+    codes = z.codes
+    if codes.shape[0] > n_max:
+        idx = np.random.default_rng(1).choice(codes.shape[0], size=n_max, replace=False)
+        codes_sub = codes[idx]
+    else:
+        codes_sub = codes
+
+    fig, axes = plt.subplots(4, 4, figsize=(11, 10))
+    fig.suptitle(
+        f"Quad code distribution (4-D corner plot, {codes_sub.shape[0]:,} samples)",
+        fontsize=13, weight="bold",
+    )
+
+    labels = [r"$c_x$", r"$c_y$", r"$d_x$", r"$d_y$"]
+    for i in range(4):
+        for j in range(4):
+            ax = axes[i, j]
+            ax.grid(True, alpha=0.2)
+            if i == j:
+                ax.hist(codes_sub[:, i], bins=80, color="#4c72b0", edgecolor="white", linewidth=0.2)
+                ax.set_yticklabels([])
+                if i == 3:
+                    ax.set_xlabel(labels[i])
+            elif i > j:
+                ax.hexbin(
+                    codes_sub[:, j], codes_sub[:, i],
+                    gridsize=40, cmap="magma", mincnt=1, norm=LogNorm(),
+                )
+                if j == 0:
+                    ax.set_ylabel(labels[i])
+                if i == 3:
+                    ax.set_xlabel(labels[j])
+            else:
+                ax.set_visible(False)
+    fig.text(
+        0.6, 0.92,
+        "Codes should fill the unit interval roughly uniformly.\n"
+        "Hot spots near corners or along axes indicate the canonical\n"
+        "ordering is biased — bad for matching robustness.",
+        fontsize=9, color="#444", ha="left", va="top",
+    )
+    return fig
+
+
+def fig_star_reuse(z: ZdclV3) -> Figure:
+    counts = star_reuse_counts(z)
+    fig, axes = plt.subplots(1, 2, figsize=(13, 4.4))
+    fig.suptitle("Star reuse across quads", fontsize=13, weight="bold")
+
+    used = counts[counts > 0]
+    unused = int(np.sum(counts == 0))
+    fraction_unused = unused / len(counts) if len(counts) else 0.0
+
+    ax = axes[0]
+    bin_cap = 200  # Beyond this, switch to outlier annotation; otherwise
+                   # an extreme reuse value (e.g. 250 k+ for an
+                   # un-uniformized index) makes matplotlib draw
+                   # hundreds of thousands of bars.
+    p99_used = int(np.percentile(used, 99)) if used.size else 0
+    n_outliers = int(np.sum(used > bin_cap))
+    if used.size:
+        max_used = int(used.max())
+        bins = np.arange(0.5, min(max_used, bin_cap) + 1.5)
+        ax.hist(np.minimum(used, bin_cap), bins=bins, color="#937860", edgecolor="white", linewidth=0.3)
+        if n_outliers > 0:
+            ax.axvline(bin_cap, color="#c44", ls="--", lw=1)
+            ax.text(
+                bin_cap, ax.get_ylim()[1] * 0.4,
+                f"  {n_outliers:,} outliers > {bin_cap}\n"
+                f"  (max = {max_used:,})",
+                color="#c44", fontsize=8, va="top",
+            )
+    ax.set_xlabel("quads referencing a given star (clipped at 200)")
+    ax.set_ylabel("stars")
+    ax.set_yscale("log")
+    median_used = float(np.median(used)) if used.size else 0.0
+    ax.set_title(
+        f"Reuse histogram (used stars only)\n"
+        f"unused = {unused:,} ({fraction_unused*100:.1f} %), median = {median_used:.0f}, p99 = {p99_used}"
+    )
+
+    ax = axes[1]
+    top_n = min(20, len(counts))
+    if top_n:
+        top_idx = np.argpartition(counts, -top_n)[-top_n:]
+        top_idx = top_idx[np.argsort(counts[top_idx])[::-1]]
+        cids = z.stars["catalog_id"][top_idx]
+        mags = z.stars["mag"][top_idx]
+        vals = counts[top_idx]
+        y = np.arange(top_n)
+        bars = ax.barh(y, vals, color="#937860")
+        labels = [f"G={m:.1f}" for m in mags]
+        ax.set_yticks(y)
+        ax.set_yticklabels(labels, fontsize=8)
+        ax.invert_yaxis()
+        for bar, val in zip(bars, vals):
+            ax.text(bar.get_width(), bar.get_y() + bar.get_height() / 2,
+                    f" {val:,}", va="center", fontsize=7, color="#444")
+        ax.set_xlim(0, vals.max() * 1.18)
+    ax.set_xlabel("quads referencing this star")
+    ax.set_title(f"Top {top_n} most-reused stars (by Gaia G mag)")
+    return fig
+
+
+def fig_fov_coverage(z: ZdclV3, fov_radius_deg: float = 0.5) -> Figure:
+    counts = fov_quad_count(z, n_samples=2000, fov_radius_deg=fov_radius_deg)
+    sky_area_sqdeg = 4 * math.pi * (180 / math.pi) ** 2  # ≈ 41,253
+    fov_area_sqdeg = math.pi * fov_radius_deg ** 2
+
+    fig, axes = plt.subplots(1, 2, figsize=(13, 4.4))
+    fig.suptitle(
+        f"FOV quad coverage  ({fov_radius_deg}° radius ≈ {fov_area_sqdeg:.2f} sq.deg, "
+        f"2000 random pointings)",
+        fontsize=12, weight="bold",
+    )
+
+    ax = axes[0]
+    # Use log y so the empty-FOV bar (often dominant for non-uniform indexes)
+    # doesn't squash the rest of the distribution.
+    cap = max(int(np.percentile(counts, 99) + 1), 20)
+    bins = np.arange(0, cap + 2)
+    ax.hist(np.minimum(counts, cap), bins=bins, color="#4c72b0", edgecolor="white", linewidth=0.3)
+    n_outliers = int(np.sum(counts > cap))
+    if n_outliers > 0:
+        ax.axvline(cap, color="#c44", ls="--", lw=1)
+        ax.text(cap, ax.get_ylim()[1] * 0.5, f"  {n_outliers} > {cap}\n  (max {int(counts.max())})",
+                color="#c44", fontsize=8, va="top")
+    median_c = int(np.median(counts))
+    n_empty = int(np.sum(counts == 0))
+    ax.set_yscale("log")
+    ax.set_xlabel("quads in FOV")
+    ax.set_ylabel("samples (log)")
+    ax.set_title(
+        f"Per-pointing quad count\n"
+        f"empty FOVs = {n_empty:,} / {len(counts):,} "
+        f"({n_empty/len(counts)*100:.1f} %), median = {median_c}"
+    )
+
+    ax = axes[1]
+    # Survival curve: P(count ≥ N).
+    sorted_counts = np.sort(counts)
+    survival = 1.0 - np.arange(len(sorted_counts)) / len(sorted_counts)
+    ax.step(sorted_counts, survival, where="post", color="#c44e52", lw=1.5)
+    for thr in (1, 5, 10, 20):
+        frac = float(np.mean(counts >= thr))
+        ax.axhline(frac, color="#444", ls=":", lw=0.7)
+        ax.text(
+            sorted_counts.max() * 0.95, frac, f"  ≥{thr}: {frac*100:.1f}%",
+            fontsize=8, color="#444", va="bottom", ha="right",
+        )
+    ax.set_ylim(0, 1)
+    ax.set_xlabel("threshold N")
+    ax.set_ylabel("P(quads in FOV ≥ N)")
+    ax.set_title("Coverage survival curve")
+    expected_density = z.header.n_quads / sky_area_sqdeg
+    fig.text(
+        0.5, -0.04,
+        f"Uniform expectation: {expected_density * fov_area_sqdeg:.1f} quads / FOV  "
+        f"(global density {expected_density:.1f} quads/sq.deg)",
+        ha="center", fontsize=9, color="#666",
+    )
+    return fig
+
+
+# --- driver -------------------------------------------------------------
+
+
+def text_summary(z: ZdclV3) -> str:
+    h = z.header
+    lo_arcsec = h.scale_lower_rad * ARCSEC_PER_RAD
+    hi_arcsec = h.scale_upper_rad * ARCSEC_PER_RAD
+    populated = int(np.sum(z.cell_table["star_count"] > 0))
+    counts = star_reuse_counts(z)
+    used = counts[counts > 0]
+    backbone = quad_backbone_arcsec(z)
+    lines = [
+        f"index file       : {z.path}",
+        f"size on disk     : {z.size_bytes/1024/1024:.1f} MB",
+        f"version          : v{h.version}  cell_depth={h.cell_depth}",
+        f"cells            : {h.n_cells:,}  ({populated:,} populated, "
+        f"{populated/h.n_cells*100:.1f} %)",
+        f"stars            : {h.n_stars:,}",
+        f"quads            : {h.n_quads:,}",
+        f"scale band       : [{lo_arcsec:.1f}″, {hi_arcsec:.1f}″]",
+        f"backbone p10/p50/p90 : "
+        f"{np.percentile(backbone, 10):.1f}″ / {np.percentile(backbone, 50):.1f}″ / "
+        f"{np.percentile(backbone, 90):.1f}″",
+        f"star magnitudes  : "
+        f"min {z.stars['mag'].min():.2f}, "
+        f"median {np.median(z.stars['mag']):.2f}, "
+        f"max {z.stars['mag'].max():.2f}",
+        f"unused stars     : "
+        f"{int(np.sum(counts == 0)):,} ({np.mean(counts == 0)*100:.1f} %)",
+        f"used-star reuse  : "
+        f"min {int(used.min()) if used.size else 0}, "
+        f"median {int(np.median(used)) if used.size else 0}, "
+        f"max {int(used.max()) if used.size else 0}",
+        f"metadata         : {h.metadata}",
+    ]
+    return "\n".join(lines)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("zdcl_path", type=Path, help="path to a .zdcl v3 index")
+    p.add_argument("--out-dir", type=Path, default=None,
+                   help="output directory (default: scripts/out/<index-stem>/)")
+    p.add_argument("--fov-deg", type=float, default=0.5, help="FOV radius for coverage plot")
+    p.add_argument("--no-plots", action="store_true", help="skip figure generation, print summary only")
+    args = p.parse_args()
+
+    if not args.zdcl_path.exists():
+        sys.exit(f"no such file: {args.zdcl_path}")
+
+    setup_style()
+
+    out = args.out_dir or Path(__file__).resolve().parent / "out" / args.zdcl_path.stem
+    out.mkdir(parents=True, exist_ok=True)
+
+    t0 = time.time()
+    z = ZdclV3(args.zdcl_path)
+    t_load = time.time() - t0
+
+    summary = text_summary(z)
+    print(summary)
+    print(f"\n(load + summary: {t_load:.2f}s)")
+
+    summary_path = out / "summary.txt"
+    summary_path.write_text(summary + "\n")
+
+    if args.no_plots:
+        return
+
+    figs = [
+        ("scale_coverage.png", lambda: fig_scale_coverage(z)),
+        ("sky_density.png", lambda: fig_sky_density(z)),
+        ("code_space.png", lambda: fig_code_space(z)),
+        ("star_reuse.png", lambda: fig_star_reuse(z)),
+        ("fov_coverage.png", lambda: fig_fov_coverage(z, fov_radius_deg=args.fov_deg)),
+    ]
+    for name, builder in figs:
+        t0 = time.time()
+        fig = builder()
+        fig.savefig(out / name)
+        plt.close(fig)
+        print(f"  wrote {out/name} ({time.time()-t0:.1f}s)")
+
+    print(f"\noutputs: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze_index.py
+++ b/scripts/analyze_index.py
@@ -500,6 +500,132 @@ def fig_star_reuse(z: ZdclV3) -> Figure:
     return fig
 
 
+def per_cell_max_used_mag(z: ZdclV3) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """For every populated HEALPix cell, return (cell_ra_rad, cell_dec_rad,
+    max_used_mag, used_count) — one entry per cell that has at least one
+    star in the index.
+
+    `max_used_mag` is the dimmest (highest-mag) star in the cell that
+    appears in at least one quad — the depth the index reaches in that
+    cell. NaN for cells whose stars are all unused. The cell center is
+    the unit-vector centroid of its stars.
+    """
+    counts = star_reuse_counts(z)  # quads-using-star, indexed by star id
+    mags = z.stars["mag"]
+    ras = z.stars["ra"]
+    decs = z.stars["dec"]
+
+    cell_offsets = z.cell_table["star_offset"].astype(np.int64)
+    cell_counts = z.cell_table["star_count"].astype(np.int64)
+
+    # Pre-compute unit vectors so cell centroids are correct across the
+    # RA=0 wrap.
+    cos_d = np.cos(decs)
+    x = cos_d * np.cos(ras)
+    y = cos_d * np.sin(ras)
+    zc = np.sin(decs)
+
+    n_cells = len(z.cell_table)
+    cell_ra = np.empty(n_cells)
+    cell_dec = np.empty(n_cells)
+    cell_max_mag = np.full(n_cells, np.nan)
+    cell_used = np.zeros(n_cells, dtype=np.int64)
+
+    for i in range(n_cells):
+        off = cell_offsets[i]
+        n = cell_counts[i]
+        if n == 0:
+            cell_ra[i] = np.nan
+            cell_dec[i] = np.nan
+            continue
+        sl = slice(off, off + n)
+        sx = x[sl].mean()
+        sy = y[sl].mean()
+        sz = zc[sl].mean()
+        norm = math.sqrt(sx * sx + sy * sy + sz * sz)
+        if norm > 0:
+            sx /= norm; sy /= norm; sz /= norm
+        ra = math.atan2(sy, sx)
+        if ra < 0:
+            ra += 2 * math.pi
+        dec = math.asin(max(-1.0, min(1.0, sz)))
+        cell_ra[i] = ra
+        cell_dec[i] = dec
+
+        used_mask = counts[sl] > 0
+        n_used = int(used_mask.sum())
+        cell_used[i] = n_used
+        if n_used > 0:
+            cell_max_mag[i] = float(mags[sl][used_mask].max())
+
+    keep = ~np.isnan(cell_ra)
+    return cell_ra[keep], cell_dec[keep], cell_max_mag[keep], cell_used[keep]
+
+
+def fig_per_cell_depth(z: ZdclV3) -> Figure:
+    """Two-panel sky map: the dimmest (highest-magnitude) used star
+    per HEALPix cell, plus a histogram of those values.
+
+    The dimmest used star in a cell tells you how deep into the catalog
+    the index actually reached there — bright values mean the cell only
+    used the few brightest stars; dim values mean the index pulled in
+    fainter stars to build out quads.
+    """
+    cell_ra, cell_dec, max_mag, used = per_cell_max_used_mag(z)
+
+    # Wrap RA to (-π, π) for Mollweide.
+    ra_proj = np.where(cell_ra > np.pi, cell_ra - 2 * np.pi, cell_ra)
+    has_used = used > 0
+
+    fig = plt.figure(figsize=(16, 7))
+    fig.suptitle(
+        f"Index depth per HEALPix cell  "
+        f"(depth {z.header.cell_depth}, {int(np.sum(has_used)):,} of {len(max_mag):,} cells contain quads)",
+        fontsize=13, weight="bold", y=0.98,
+    )
+    gs = fig.add_gridspec(1, 3, width_ratios=[2.4, 1.0, 0.05], wspace=0.25)
+    ax_map = fig.add_subplot(gs[0, 0], projection="mollweide")
+    ax_hist = fig.add_subplot(gs[0, 1])
+    cax = fig.add_subplot(gs[0, 2])
+
+    if has_used.any():
+        sc = ax_map.scatter(
+            ra_proj[has_used], cell_dec[has_used],
+            c=max_mag[has_used],
+            s=42, cmap="viridis",  # bright (low mag) → dark; faint (high mag) → yellow
+            vmin=float(np.nanpercentile(max_mag, 1)),
+            vmax=float(np.nanpercentile(max_mag, 99)),
+            edgecolors="#222", linewidths=0.3,
+        )
+        cbar = fig.colorbar(sc, cax=cax)
+        cbar.set_label("dimmest used G mag (higher = deeper index)")
+
+    ax_map.grid(True, alpha=0.3)
+    ax_map.set_xticklabels([])
+    ax_map.set_title(
+        f"Mollweide sky map  "
+        f"({len(max_mag) - int(np.sum(has_used)):,} populated cells with no quads omitted)"
+    )
+
+    used_max = max_mag[has_used]
+    ax_hist.hist(used_max, bins=60, color="#4c72b0", edgecolor="white", linewidth=0.3)
+    median = float(np.median(used_max)) if used_max.size else 0.0
+    p10 = float(np.percentile(used_max, 10)) if used_max.size else 0.0
+    p90 = float(np.percentile(used_max, 90)) if used_max.size else 0.0
+    ax_hist.axvline(median, color="#444", ls=":", lw=1)
+    ax_hist.text(
+        median, ax_hist.get_ylim()[1] * 0.95,
+        f"  median = {median:.2f}", color="#444", fontsize=9, va="top",
+    )
+    ax_hist.set_xlabel("dimmest used G mag in cell")
+    ax_hist.set_ylabel("cells")
+    ax_hist.set_title(
+        f"Distribution across {used_max.size:,} cells with quads\n"
+        f"p10 / median / p90 = {p10:.2f} / {median:.2f} / {p90:.2f}"
+    )
+    return fig
+
+
 def fig_fov_coverage(z: ZdclV3, fov_radius_deg: float = 0.5) -> Figure:
     counts = fov_quad_count(z, n_samples=2000, fov_radius_deg=fov_radius_deg)
     sky_area_sqdeg = 4 * math.pi * (180 / math.pi) ** 2  # ≈ 41,253
@@ -634,6 +760,7 @@ def main():
         ("sky_density.png", lambda: fig_sky_density(z)),
         ("code_space.png", lambda: fig_code_space(z)),
         ("star_reuse.png", lambda: fig_star_reuse(z)),
+        ("per_cell_depth.png", lambda: fig_per_cell_depth(z)),
         ("fov_coverage.png", lambda: fig_fov_coverage(z, fov_radius_deg=args.fov_deg)),
     ]
     for name, builder in figs:

--- a/src/index/build_manifest.rs
+++ b/src/index/build_manifest.rs
@@ -1,0 +1,295 @@
+//! Crash-safe manifest for resumable index builds.
+//!
+//! A `BuildManifest` is the durable record of "which HEALPix cells have
+//! been committed to the work directory". The cell-driven builder
+//! consults it on resume to skip already-completed cells, and updates
+//! it after every successful per-cell commit.
+//!
+//! Writes are atomic: the manifest is serialized to a sibling
+//! `.partial` file, fsynced, and renamed into place. A crash during
+//! the rename leaves either the old manifest or no manifest — never a
+//! truncated one. The pattern mirrors `starfield-datasources`'s
+//! `Manifest` writer (issue #65 refers).
+//!
+//! Layout: a single JSON file in the build's scratch directory. The
+//! file is small (a few KB at level 5, a few hundred KB at level 12),
+//! so re-serializing the whole document on every cell commit is fine.
+
+use std::collections::BTreeSet;
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Filename the manifest lives under inside the scratch dir.
+pub const MANIFEST_FILENAME: &str = "build-manifest.json";
+
+/// On-disk schema version. Bump when adding non-trivially-decodable fields.
+pub const MANIFEST_VERSION: u32 = 1;
+
+/// Per-cell statistics committed alongside the cell's chunk file.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct CellStats {
+    pub n_stars: u64,
+    pub n_quads: u64,
+}
+
+/// Crash-safe build manifest. Tracks which cells have been committed,
+/// plus running totals so a resumed run can verify on-disk state
+/// matches the manifest's claims.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BuildManifest {
+    pub version: u32,
+    /// Cell IDs that have been fully committed to the work dir.
+    /// `BTreeSet` for deterministic JSON output and O(log n) membership.
+    pub completed_cells: BTreeSet<u32>,
+    /// Optional per-cell statistics, keyed by cell_id.
+    /// Stored as a `Vec<(cell_id, stats)>` so JSON keys stay numeric
+    /// and reading order is stable.
+    pub cell_stats: Vec<(u32, CellStats)>,
+    /// Running totals; redundant with `cell_stats` but cheap to maintain
+    /// and avoids a sum on resume.
+    pub n_stars: u64,
+    pub n_quads: u64,
+}
+
+impl Default for BuildManifest {
+    fn default() -> Self {
+        Self {
+            version: MANIFEST_VERSION,
+            completed_cells: BTreeSet::new(),
+            cell_stats: Vec::new(),
+            n_stars: 0,
+            n_quads: 0,
+        }
+    }
+}
+
+impl BuildManifest {
+    /// Path of the manifest file inside `scratch_dir`.
+    pub fn path_in(scratch_dir: &Path) -> PathBuf {
+        scratch_dir.join(MANIFEST_FILENAME)
+    }
+
+    /// Path of the `.partial` sibling used during atomic writes.
+    pub fn tmp_path_in(scratch_dir: &Path) -> PathBuf {
+        let mut s = Self::path_in(scratch_dir).into_os_string();
+        s.push(".partial");
+        PathBuf::from(s)
+    }
+
+    /// Load an existing manifest from `scratch_dir`. Returns
+    /// `Ok(None)` if the file does not exist; an error on parse
+    /// failure or version mismatch.
+    pub fn load(scratch_dir: &Path) -> io::Result<Option<Self>> {
+        let path = Self::path_in(scratch_dir);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let mut buf = String::new();
+        File::open(&path)?.read_to_string(&mut buf)?;
+        let m: Self = serde_json::from_str(&buf).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to parse {}: {e}", path.display()),
+            )
+        })?;
+        if m.version != MANIFEST_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "manifest at {} has version {} but expected {}",
+                    path.display(),
+                    m.version,
+                    MANIFEST_VERSION,
+                ),
+            ));
+        }
+        Ok(Some(m))
+    }
+
+    /// Atomically persist the manifest to `scratch_dir`. Writes to a
+    /// `.partial` sibling, fsyncs, then renames into place. Safe to
+    /// call after every successful per-cell commit.
+    pub fn save(&self, scratch_dir: &Path) -> io::Result<()> {
+        std::fs::create_dir_all(scratch_dir)?;
+
+        let tmp = Self::tmp_path_in(scratch_dir);
+        let final_path = Self::path_in(scratch_dir);
+
+        let json = serde_json::to_vec_pretty(self).map_err(io::Error::other)?;
+        {
+            let mut f = File::create(&tmp)?;
+            f.write_all(&json)?;
+            f.sync_all()?;
+        }
+        std::fs::rename(&tmp, &final_path)?;
+        Ok(())
+    }
+
+    /// Mark `cell_id` complete with the given stats, update running
+    /// totals, and persist atomically.
+    ///
+    /// Idempotent: if the cell was already marked complete, the prior
+    /// stats are replaced (running totals adjusted accordingly). This
+    /// matters for resume flows where a chunk file might be re-committed
+    /// before the manifest update lands.
+    pub fn commit_cell(
+        &mut self,
+        scratch_dir: &Path,
+        cell_id: u32,
+        stats: CellStats,
+    ) -> io::Result<()> {
+        if let Some(idx) = self.cell_stats.iter().position(|(c, _)| *c == cell_id) {
+            let prev = self.cell_stats[idx].1.clone();
+            self.n_stars = self.n_stars.saturating_sub(prev.n_stars);
+            self.n_quads = self.n_quads.saturating_sub(prev.n_quads);
+            self.cell_stats[idx].1 = stats.clone();
+        } else {
+            self.cell_stats.push((cell_id, stats.clone()));
+            // Keep cell_stats stably sorted by cell_id for predictable
+            // JSON output. Cheap given expected n ≤ 12,288 (level 5).
+            self.cell_stats.sort_by_key(|(c, _)| *c);
+        }
+        self.completed_cells.insert(cell_id);
+        self.n_stars += stats.n_stars;
+        self.n_quads += stats.n_quads;
+        self.save(scratch_dir)
+    }
+
+    /// Quick membership check used by the cell-driven builder to skip
+    /// already-committed cells on resume.
+    pub fn is_complete(&self, cell_id: u32) -> bool {
+        self.completed_cells.contains(&cell_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_dir(name: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "zodiacal-build-manifest-{}-{}-{}",
+            name,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ));
+        p
+    }
+
+    #[test]
+    fn load_returns_none_when_missing() {
+        let dir = tmp_dir("missing");
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(BuildManifest::load(&dir).unwrap().is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_then_load_roundtrip() {
+        let dir = tmp_dir("rt");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut m = BuildManifest::default();
+        m.commit_cell(
+            &dir,
+            42,
+            CellStats {
+                n_stars: 1234,
+                n_quads: 567,
+            },
+        )
+        .unwrap();
+        m.commit_cell(
+            &dir,
+            7,
+            CellStats {
+                n_stars: 100,
+                n_quads: 50,
+            },
+        )
+        .unwrap();
+
+        let loaded = BuildManifest::load(&dir).unwrap().expect("manifest");
+        assert_eq!(loaded, m);
+        assert!(loaded.is_complete(42));
+        assert!(loaded.is_complete(7));
+        assert!(!loaded.is_complete(0));
+        assert_eq!(loaded.n_stars, 1334);
+        assert_eq!(loaded.n_quads, 617);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn commit_cell_is_idempotent_in_running_totals() {
+        let dir = tmp_dir("idem");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut m = BuildManifest::default();
+        m.commit_cell(
+            &dir,
+            5,
+            CellStats {
+                n_stars: 10,
+                n_quads: 4,
+            },
+        )
+        .unwrap();
+        // Re-commit the same cell with different stats — totals should
+        // reflect the new value, not the sum.
+        m.commit_cell(
+            &dir,
+            5,
+            CellStats {
+                n_stars: 20,
+                n_quads: 8,
+            },
+        )
+        .unwrap();
+        assert_eq!(m.completed_cells.len(), 1);
+        assert_eq!(m.n_stars, 20);
+        assert_eq!(m.n_quads, 8);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn version_mismatch_is_rejected() {
+        let dir = tmp_dir("ver");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = BuildManifest::path_in(&dir);
+        std::fs::write(
+            &path,
+            r#"{"version":99,"completed_cells":[],"cell_stats":[],"n_stars":0,"n_quads":0}"#,
+        )
+        .unwrap();
+
+        let err = BuildManifest::load(&dir).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_is_atomic_no_partial_left_behind() {
+        let dir = tmp_dir("atomic");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let m = BuildManifest::default();
+        m.save(&dir).unwrap();
+
+        // The .partial sibling must not survive a successful save.
+        let partial = BuildManifest::tmp_path_in(&dir);
+        assert!(!partial.exists(), "leftover partial: {}", partial.display());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/index/cell_builder.rs
+++ b/src/index/cell_builder.rs
@@ -1,0 +1,1023 @@
+//! Cell-driven, resumable index builder.
+//!
+//! Replaces the "load every shard into RAM, build all quads, write at
+//! the end" model of [`build_index`] with a cell-by-cell pipeline that
+//! commits artifacts to a working directory after every cell. Memory is
+//! bounded by the largest single cell. Crash-safe: a build interrupted
+//! mid-flight resumes from the next uncommitted cell on the next run.
+//!
+//! The orchestrator is parameterized over a [`CellStarSource`] trait —
+//! the concrete adapter for `LazyLoadingCatalog<Dr3>::entries_in_cell`
+//! (issue #65, upstream-in-flight) lives in `zodiacal-tools`.
+//!
+//! [`build_index`]: super::builder::build_index
+//!
+//! ## Per-cell artifacts
+//!
+//! For each cell, three durable artifacts are written under `work_dir`:
+//!
+//! - `cell_artifacts/cell_NNNNN.idx-tmp` — the cell's stars, quads, and
+//!   codes. Quads reference stars by `catalog_id` so the artifact is
+//!   self-contained; index remapping happens at finalize time.
+//! - `sidecar_chunks/chunk_NNNN.sidecar-tmp` — the cell's sidecar
+//!   records, sorted by `source_id` (managed by [`SidecarStreamWriter`]).
+//! - `build-manifest.json` — committed cell IDs + running totals
+//!   (managed by [`BuildManifest`]). Updated atomically after each
+//!   per-cell commit.
+//!
+//! At finalize, the orchestrator concatenates per-cell artifacts into
+//! the final `.zdcl` (via the existing v3 writer) and invokes
+//! `SidecarStreamWriter::finalize` to produce the `.zdcl.gaia`.
+//!
+//! ## What this builder does *not* do (yet)
+//!
+//! Per-cell quad construction here uses *only* the focus cell's stars,
+//! mirroring issue #65's pseudocode. Quads whose backbones straddle a
+//! HEALPix-cell boundary at the source's depth are dropped. At level 5
+//! (cells ~1.8°) this loss is small for typical quad scales (30″–30′)
+//! but non-zero. Adding neighbor context is a follow-up.
+
+use std::collections::{HashMap, HashSet};
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+use crate::geom::sphere::{angular_distance, radec_to_xyz, star_midpoint};
+use crate::quads::{Code, DIMCODES, DIMQUADS, Quad, compute_canonical_code};
+use crate::refinement::{SidecarRecord, SidecarStreamWriter};
+
+use super::{IndexStar};
+use super::build_manifest::{BuildManifest, CellStats};
+
+/// One star produced by a [`CellStarSource`]. Carries everything the
+/// builder needs (index tuple + sidecar payload) so the caller doesn't
+/// need to thread two parallel collections.
+#[derive(Debug, Clone)]
+pub struct CellStar {
+    pub catalog_id: u64,
+    /// Right ascension, radians. Used for the index file.
+    pub ra_rad: f64,
+    /// Declination, radians.
+    pub dec_rad: f64,
+    pub mag: f64,
+    /// Full astrometric record for the refinement sidecar. Note: the
+    /// sidecar stores RA/Dec in degrees per the existing on-disk
+    /// schema; the source is expected to populate `sidecar.ra/dec` in
+    /// degrees.
+    pub sidecar: SidecarRecord,
+}
+
+/// Per-cell read interface. Implementations must be `Sync` because the
+/// orchestrator may dispatch parallel cell loads in a future revision.
+pub trait CellStarSource: Sync {
+    /// Total cell count. Cell IDs are `0..cell_count`.
+    fn cell_count(&self) -> u32;
+
+    /// Load every star whose HEALPix cell at the source's depth equals
+    /// `cell_id`, after applying any source-side magnitude/quality
+    /// filters. Order is irrelevant — the builder sorts.
+    fn stars_in_cell(&self, cell_id: u32) -> io::Result<Vec<CellStar>>;
+}
+
+/// Configuration for [`build_index_cell_driven`].
+#[derive(Debug, Clone)]
+pub struct CellBuildConfig {
+    /// Lower angular size of quad backbones, radians.
+    pub scale_lower: f64,
+    /// Upper angular size of quad backbones, radians.
+    pub scale_upper: f64,
+    /// Quads to emit per HEALPix cell at the source's depth.
+    pub quads_per_cell: usize,
+    /// Max times any one star may be referenced across the cell's
+    /// emitted quads. Tracked locally per cell.
+    pub max_reuse: usize,
+    /// HEALPix `cell_depth` for the *final* `.zdcl` v3 cell table.
+    /// Independent of the source's read-time depth.
+    pub final_cell_depth: u8,
+    /// Stride for the sidecar pivot table. Use
+    /// [`crate::refinement::DEFAULT_PIVOT_STRIDE`] for the standard
+    /// 4096.
+    pub pivot_stride: u32,
+}
+
+/// Filesystem layout for the build.
+#[derive(Debug, Clone)]
+pub struct BuildPaths {
+    /// Holds the manifest, chunk temp files, and cell artifact temp
+    /// files. Created if missing. Cleaned up on successful finalize.
+    pub work_dir: PathBuf,
+    /// Final `.zdcl` destination. Written atomically.
+    pub final_index: PathBuf,
+    /// Final `.zdcl.gaia` destination. Written atomically.
+    pub final_sidecar: PathBuf,
+}
+
+/// Summary returned by [`build_index_cell_driven`].
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct BuildSummary {
+    /// Cells processed in this invocation (excludes those skipped via
+    /// resume).
+    pub n_cells_processed: u32,
+    /// Cells already complete on entry, skipped via the manifest.
+    pub n_cells_resumed: u32,
+    /// Cells whose sources returned zero stars after filtering.
+    pub n_cells_empty: u32,
+    /// Final star count (sum across all cells, including resumed ones).
+    pub n_stars: u64,
+    /// Final quad count.
+    pub n_quads: u64,
+}
+
+const CELL_ARTIFACTS_SUBDIR: &str = "cell_artifacts";
+const SIDECAR_CHUNKS_SUBDIR: &str = "sidecar_chunks";
+const CELL_ARTIFACT_MAGIC: &[u8; 8] = b"ZDCLCELL";
+
+fn cell_artifact_path(work_dir: &Path, cell_id: u32) -> PathBuf {
+    work_dir
+        .join(CELL_ARTIFACTS_SUBDIR)
+        .join(format!("cell_{cell_id:05}.idx-tmp"))
+}
+
+/// Top-level orchestrator. Iterates `0..source.cell_count()`, builds
+/// per-cell artifacts, and finalizes both index and sidecar.
+///
+/// Resume semantics: any cells already listed in the manifest are
+/// skipped. Their per-cell artifacts and sidecar chunks must still
+/// exist on disk in `work_dir` (the manifest + on-disk artifacts are
+/// the durable state).
+///
+/// Cells are processed sequentially. Parallelism is a follow-up — the
+/// per-cell artifact writer + manifest are designed to allow it.
+pub fn build_index_cell_driven<S: CellStarSource + ?Sized>(
+    source: &S,
+    config: &CellBuildConfig,
+    paths: &BuildPaths,
+) -> io::Result<BuildSummary> {
+    if config.scale_lower <= 0.0 || config.scale_upper <= config.scale_lower {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "invalid scale range: [{}, {}] rad",
+                config.scale_lower, config.scale_upper
+            ),
+        ));
+    }
+    if config.pivot_stride == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "pivot_stride must be positive",
+        ));
+    }
+
+    let work_dir = &paths.work_dir;
+    let cell_artifacts_dir = work_dir.join(CELL_ARTIFACTS_SUBDIR);
+    let sidecar_chunks_dir = work_dir.join(SIDECAR_CHUNKS_SUBDIR);
+    std::fs::create_dir_all(&cell_artifacts_dir)?;
+    std::fs::create_dir_all(&sidecar_chunks_dir)?;
+
+    let mut manifest = BuildManifest::load(work_dir)?.unwrap_or_default();
+    let mut sidecar_writer = if manifest.completed_cells.is_empty() {
+        SidecarStreamWriter::new(&sidecar_chunks_dir)?
+    } else {
+        SidecarStreamWriter::resume(&sidecar_chunks_dir)?
+    };
+
+    let cell_count = source.cell_count();
+    let mut summary = BuildSummary::default();
+
+    for cell_id in 0..cell_count {
+        if manifest.is_complete(cell_id) {
+            summary.n_cells_resumed += 1;
+            continue;
+        }
+
+        let stars = source.stars_in_cell(cell_id)?;
+        if stars.is_empty() {
+            // Mark complete (with zero stats) so a subsequent rerun
+            // doesn't re-query an empty cell.
+            manifest.commit_cell(work_dir, cell_id, CellStats::default())?;
+            summary.n_cells_empty += 1;
+            continue;
+        }
+
+        let (cell_quads, cell_codes) = build_quads_for_cell(&stars, config);
+
+        // Persist per-cell index artifact.
+        let artifact_path = cell_artifact_path(work_dir, cell_id);
+        write_cell_artifact(&artifact_path, &stars, &cell_quads, &cell_codes)?;
+
+        // Append sidecar chunk (records sorted internally by the writer).
+        let sidecar_records: Vec<SidecarRecord> = stars.iter().map(|s| s.sidecar).collect();
+        sidecar_writer.append_chunk(sidecar_records)?;
+
+        // Atomically commit the cell to the manifest. From here, a
+        // crash can resume cleanly because the artifact + chunk + this
+        // manifest update are all durable.
+        let stats = CellStats {
+            n_stars: stars.len() as u64,
+            n_quads: cell_quads.len() as u64,
+        };
+        manifest.commit_cell(work_dir, cell_id, stats)?;
+
+        summary.n_cells_processed += 1;
+    }
+
+    // Finalize: assemble the .zdcl from per-cell artifacts.
+    summary.n_stars = manifest.n_stars;
+    summary.n_quads = manifest.n_quads;
+    finalize_index(&manifest, work_dir, paths, config)?;
+
+    // Finalize the sidecar.
+    sidecar_writer.finalize(&paths.final_sidecar, config.pivot_stride)?;
+
+    // Clean up: remove manifest + artifact dir + chunk dir on success.
+    // Do *not* remove until both finals are in place — a crash after
+    // the index finalize but before the sidecar finalize must still be
+    // resumable, and a crash here is harmless.
+    let _ = std::fs::remove_file(BuildManifest::path_in(work_dir));
+    let _ = std::fs::remove_dir_all(&cell_artifacts_dir);
+    // SidecarStreamWriter::finalize removes its own scratch contents
+    // and tries to rmdir; if the dir is already gone, that's fine.
+    let _ = std::fs::remove_dir(&sidecar_chunks_dir);
+    let _ = std::fs::remove_dir(work_dir);
+
+    Ok(summary)
+}
+
+/// Build quads for one cell using only the cell's own stars. Stars are
+/// sorted by magnitude (brightest first); quad indices in the returned
+/// `Quad` values are positions in the *sorted* per-cell list.
+fn build_quads_for_cell(stars: &[CellStar], config: &CellBuildConfig) -> (Vec<Quad>, Vec<Code>) {
+    if stars.len() < DIMQUADS {
+        return (Vec::new(), Vec::new());
+    }
+
+    // Sort indices by magnitude (brightest first) so use_count limits
+    // bias toward the brightest stars.
+    let mut order: Vec<usize> = (0..stars.len()).collect();
+    order.sort_by(|&a, &b| {
+        stars[a]
+            .mag
+            .partial_cmp(&stars[b].mag)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let xyzs: Vec<[f64; 3]> = order
+        .iter()
+        .map(|&i| radec_to_xyz(stars[i].ra_rad, stars[i].dec_rad))
+        .collect();
+
+    let mut quads: Vec<Quad> = Vec::new();
+    let mut codes: Vec<Code> = Vec::new();
+    let mut seen: HashSet<[usize; DIMQUADS]> = HashSet::new();
+    let mut use_count: Vec<usize> = vec![0; xyzs.len()];
+
+    let chord_sq_upper = 2.0 * (1.0 - config.scale_upper.cos());
+
+    'outer: for a_idx in 0..xyzs.len() {
+        if quads.len() >= config.quads_per_cell {
+            break;
+        }
+        if use_count[a_idx] >= config.max_reuse {
+            continue;
+        }
+
+        let a_xyz = xyzs[a_idx];
+        for b_idx in (a_idx + 1)..xyzs.len() {
+            if use_count[b_idx] >= config.max_reuse {
+                continue;
+            }
+            let b_xyz = xyzs[b_idx];
+            let ab_dist = angular_distance(a_xyz, b_xyz);
+            if ab_dist < config.scale_lower || ab_dist > config.scale_upper {
+                continue;
+            }
+
+            let mid = star_midpoint(a_xyz, b_xyz);
+            let cd_radius_sq = 2.0 * (1.0 - ab_dist.cos());
+
+            // Linear scan for candidates near the midpoint. At
+            // per-cell granularity n_stars is small (tens to a few
+            // hundred typically), so an O(n) scan beats a KD-tree
+            // construction. The chord_sq_upper outer guard avoids
+            // computing midpoints on too-distant pairs.
+            let _ = chord_sq_upper;
+
+            let mut candidates: Vec<usize> = Vec::new();
+            for (c_idx, c) in xyzs.iter().enumerate() {
+                if c_idx == a_idx || c_idx == b_idx {
+                    continue;
+                }
+                let dx = c[0] - mid[0];
+                let dy = c[1] - mid[1];
+                let dz = c[2] - mid[2];
+                if dx * dx + dy * dy + dz * dz < cd_radius_sq {
+                    candidates.push(c_idx);
+                }
+            }
+
+            for ci in 0..candidates.len() {
+                if quads.len() >= config.quads_per_cell {
+                    break 'outer;
+                }
+                for di in (ci + 1)..candidates.len() {
+                    let c_idx = candidates[ci];
+                    let d_idx = candidates[di];
+
+                    let mut key = [a_idx, b_idx, c_idx, d_idx];
+                    key.sort();
+                    if !seen.insert(key) {
+                        continue;
+                    }
+
+                    if use_count[c_idx] >= config.max_reuse
+                        || use_count[d_idx] >= config.max_reuse
+                    {
+                        continue;
+                    }
+
+                    let raw_xyz = [a_xyz, b_xyz, xyzs[c_idx], xyzs[d_idx]];
+                    let raw_ids = [a_idx, b_idx, c_idx, d_idx];
+                    let (ordered_xyz, ordered_ids) = canonical_quad_order(&raw_xyz, raw_ids);
+                    let (code, canonical_ids, _) =
+                        compute_canonical_code(&ordered_xyz, ordered_ids);
+
+                    for &idx in &canonical_ids {
+                        use_count[idx] += 1;
+                    }
+
+                    // Translate canonical_ids (positions in the sorted
+                    // local list) back to positions in the *input*
+                    // `stars` slice so the caller can look up
+                    // `catalog_id` directly.
+                    let star_ids_input: [usize; DIMQUADS] =
+                        std::array::from_fn(|i| order[canonical_ids[i]]);
+                    quads.push(Quad {
+                        star_ids: star_ids_input,
+                    });
+                    codes.push(code);
+
+                    if quads.len() >= config.quads_per_cell {
+                        break 'outer;
+                    }
+                }
+            }
+        }
+    }
+
+    (quads, codes)
+}
+
+/// Local copy of `builder::canonical_quad_order` — exposing the original
+/// would widen its visibility. Identical behaviour: order quad members
+/// so the longest backbone is at indices `[0]` and `[1]`.
+fn canonical_quad_order(
+    star_xyz: &[[f64; 3]; DIMQUADS],
+    star_ids: [usize; DIMQUADS],
+) -> ([[f64; 3]; DIMQUADS], [usize; DIMQUADS]) {
+    let mut best_pair = (0, 1);
+    let mut best_dist = 0.0f64;
+    for i in 0..DIMQUADS {
+        for j in (i + 1)..DIMQUADS {
+            let d = angular_distance(star_xyz[i], star_xyz[j]);
+            if d > best_dist {
+                best_dist = d;
+                best_pair = (i, j);
+            }
+        }
+    }
+    let (ai, bi) = best_pair;
+    let mut others: Vec<usize> = (0..DIMQUADS).filter(|&i| i != ai && i != bi).collect();
+    others.sort_by_key(|&i| star_ids[i]);
+    let order = [ai, bi, others[0], others[1]];
+    let new_xyz: [[f64; 3]; DIMQUADS] = std::array::from_fn(|i| star_xyz[order[i]]);
+    let new_ids: [usize; DIMQUADS] = std::array::from_fn(|i| star_ids[order[i]]);
+    (new_xyz, new_ids)
+}
+
+// --- Per-cell artifact format -------------------------------------------
+//
+//   8B   magic       "ZDCLCELL"
+//   4B   version     u32 = 1
+//   4B   reserved
+//   8B   n_stars     u64
+//   8B   n_quads     u64
+//   stars × n_stars   (40 B each: u64 catalog_id, 3 × f64 ra/dec/mag)
+//   quads × n_quads   (32 B each: 4 × u64 catalog_id)
+//   codes × n_quads   (32 B each: 4 × f64)
+//
+// Star records here use catalog_id rather than a local index so the
+// artifact is self-contained for the finalize-time remap.
+
+const CELL_ARTIFACT_VERSION: u32 = 1;
+
+fn write_cell_artifact(
+    path: &Path,
+    stars: &[CellStar],
+    quads: &[Quad],
+    codes: &[Code],
+) -> io::Result<()> {
+    assert_eq!(quads.len(), codes.len());
+
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".partial");
+    let tmp_path = PathBuf::from(tmp);
+
+    {
+        let f = File::create(&tmp_path)?;
+        let mut w = BufWriter::new(f);
+        w.write_all(CELL_ARTIFACT_MAGIC)?;
+        w.write_all(&CELL_ARTIFACT_VERSION.to_le_bytes())?;
+        w.write_all(&[0u8; 4])?; // reserved
+        w.write_all(&(stars.len() as u64).to_le_bytes())?;
+        w.write_all(&(quads.len() as u64).to_le_bytes())?;
+
+        for s in stars {
+            w.write_all(&s.catalog_id.to_le_bytes())?;
+            w.write_all(&s.ra_rad.to_le_bytes())?;
+            w.write_all(&s.dec_rad.to_le_bytes())?;
+            w.write_all(&s.mag.to_le_bytes())?;
+        }
+        for q in quads {
+            for &local_idx in &q.star_ids {
+                let cid = stars
+                    .get(local_idx)
+                    .map(|s| s.catalog_id)
+                    .unwrap_or_else(|| panic!("quad references out-of-range star {local_idx}"));
+                w.write_all(&cid.to_le_bytes())?;
+            }
+        }
+        for c in codes {
+            for &v in c {
+                w.write_all(&v.to_le_bytes())?;
+            }
+        }
+        w.flush()?;
+        w.get_ref().sync_all()?;
+    }
+    std::fs::rename(&tmp_path, path)
+}
+
+struct LoadedCellArtifact {
+    stars: Vec<IndexStar>,
+    /// Quads with members carrying catalog_id; remap to global indices
+    /// at finalize time.
+    quads_by_cid: Vec<[u64; DIMQUADS]>,
+    codes: Vec<Code>,
+}
+
+fn read_cell_artifact(path: &Path) -> io::Result<LoadedCellArtifact> {
+    let mut f = BufReader::new(OpenOptions::new().read(true).open(path)?);
+
+    let mut magic = [0u8; 8];
+    f.read_exact(&mut magic)?;
+    if &magic != CELL_ARTIFACT_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("bad cell artifact magic at {}", path.display()),
+        ));
+    }
+    let version = read_u32(&mut f)?;
+    if version != CELL_ARTIFACT_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unsupported cell artifact version {version}"),
+        ));
+    }
+    let _reserved = read_u32(&mut f)?;
+    let n_stars = read_u64(&mut f)? as usize;
+    let n_quads = read_u64(&mut f)? as usize;
+
+    let mut stars: Vec<IndexStar> = Vec::with_capacity(n_stars);
+    for _ in 0..n_stars {
+        let catalog_id = read_u64(&mut f)?;
+        let ra = read_f64(&mut f)?;
+        let dec = read_f64(&mut f)?;
+        let mag = read_f64(&mut f)?;
+        stars.push(IndexStar {
+            catalog_id,
+            ra,
+            dec,
+            mag,
+        });
+    }
+    let mut quads_by_cid: Vec<[u64; DIMQUADS]> = Vec::with_capacity(n_quads);
+    for _ in 0..n_quads {
+        let mut q = [0u64; DIMQUADS];
+        for slot in &mut q {
+            *slot = read_u64(&mut f)?;
+        }
+        quads_by_cid.push(q);
+    }
+    let mut codes: Vec<Code> = Vec::with_capacity(n_quads);
+    for _ in 0..n_quads {
+        let mut c = [0.0f64; DIMCODES];
+        for slot in &mut c {
+            *slot = read_f64(&mut f)?;
+        }
+        codes.push(c);
+    }
+    Ok(LoadedCellArtifact {
+        stars,
+        quads_by_cid,
+        codes,
+    })
+}
+
+fn read_u32(r: &mut impl Read) -> io::Result<u32> {
+    let mut b = [0u8; 4];
+    r.read_exact(&mut b)?;
+    Ok(u32::from_le_bytes(b))
+}
+fn read_u64(r: &mut impl Read) -> io::Result<u64> {
+    let mut b = [0u8; 8];
+    r.read_exact(&mut b)?;
+    Ok(u64::from_le_bytes(b))
+}
+fn read_f64(r: &mut impl Read) -> io::Result<f64> {
+    let mut b = [0u8; 8];
+    r.read_exact(&mut b)?;
+    Ok(f64::from_le_bytes(b))
+}
+
+/// Read every per-cell artifact, remap catalog_id → global star index,
+/// and write the final `.zdcl` v3 file.
+fn finalize_index(
+    manifest: &BuildManifest,
+    work_dir: &Path,
+    paths: &BuildPaths,
+    config: &CellBuildConfig,
+) -> io::Result<()> {
+    let mut all_stars: Vec<IndexStar> = Vec::with_capacity(manifest.n_stars as usize);
+    let mut quads: Vec<Quad> = Vec::with_capacity(manifest.n_quads as usize);
+    let mut codes: Vec<Code> = Vec::with_capacity(manifest.n_quads as usize);
+    let mut cid_to_global: HashMap<u64, usize> = HashMap::with_capacity(manifest.n_stars as usize);
+
+    for &cell_id in &manifest.completed_cells {
+        let stats = manifest
+            .cell_stats
+            .iter()
+            .find(|(c, _)| *c == cell_id)
+            .map(|(_, s)| s.clone())
+            .unwrap_or_default();
+        if stats.n_stars == 0 {
+            continue;
+        }
+        let path = cell_artifact_path(work_dir, cell_id);
+        let loaded = read_cell_artifact(&path)?;
+
+        let base = all_stars.len();
+        for (i, s) in loaded.stars.iter().enumerate() {
+            let prior = cid_to_global.insert(s.catalog_id, base + i);
+            if prior.is_some() {
+                // Same catalog_id appearing in two cells means the
+                // upstream source's cell partitioning is broken — this
+                // builder assumes each star lives in exactly one cell.
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "catalog_id {} appears in multiple cells; source's cell partitioning is broken",
+                        s.catalog_id
+                    ),
+                ));
+            }
+        }
+        all_stars.extend(loaded.stars);
+
+        for (q_cids, code) in loaded.quads_by_cid.into_iter().zip(loaded.codes) {
+            let mut star_ids = [0usize; DIMQUADS];
+            let mut all_resolved = true;
+            for (i, cid) in q_cids.iter().enumerate() {
+                match cid_to_global.get(cid) {
+                    Some(&global) => star_ids[i] = global,
+                    None => {
+                        all_resolved = false;
+                        break;
+                    }
+                }
+            }
+            if all_resolved {
+                quads.push(Quad { star_ids });
+                codes.push(code);
+            }
+            // Quads with unresolved members are dropped. This shouldn't
+            // happen for the per-cell-only quad builder (every member
+            // is from the same cell, so it's been added above), but we
+            // leave the guard for future neighbor-aware builders.
+        }
+    }
+
+    let _ = codes; // codes are recomputed by write_v3 from star positions
+
+    write_index_to_path(
+        &paths.final_index,
+        &all_stars,
+        &quads,
+        config.scale_lower,
+        config.scale_upper,
+        config.final_cell_depth,
+    )
+}
+
+fn write_index_to_path(
+    path: &Path,
+    stars: &[IndexStar],
+    quads: &[Quad],
+    scale_lower: f64,
+    scale_upper: f64,
+    cell_depth: u8,
+) -> io::Result<()> {
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".partial");
+    let tmp_path = PathBuf::from(tmp);
+
+    {
+        let f = File::create(&tmp_path)?;
+        let mut w = BufWriter::new(f);
+        super::source::write_v3(
+            &mut w,
+            None,
+            stars,
+            quads,
+            scale_lower,
+            scale_upper,
+            cell_depth,
+        )?;
+        w.flush()?;
+        w.get_ref().sync_all()?;
+    }
+    std::fs::rename(&tmp_path, path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::{Index, IndexFragment, IndexSource};
+    use crate::refinement::{SidecarReader, SidecarRecord};
+
+    fn tmp_dir(name: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "zodiacal-cell-builder-{}-{}-{}",
+            name,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn make_cell_star(catalog_id: u64, ra_rad: f64, dec_rad: f64, mag: f64) -> CellStar {
+        CellStar {
+            catalog_id,
+            ra_rad,
+            dec_rad,
+            mag,
+            sidecar: SidecarRecord {
+                source_id: catalog_id,
+                ref_epoch: 2016.0,
+                ra: ra_rad.to_degrees(),
+                dec: dec_rad.to_degrees(),
+                pmra: 0.0,
+                pmdec: 0.0,
+                parallax: 0.0,
+                radial_velocity: f64::NAN,
+                sigma_ra: 0.1,
+                sigma_dec: 0.1,
+                sigma_pmra: 0.01,
+                sigma_pmdec: 0.01,
+                sigma_parallax: 0.02,
+                flags: 0,
+            },
+        }
+    }
+
+    /// Synthetic cell source: places `stars_per_cell` deterministically
+    /// inside a small patch around each cell's nominal center. Cell IDs
+    /// here are abstract — we don't bother computing real HEALPix
+    /// neighbours for the test, just exercise the orchestrator's
+    /// per-cell flow.
+    struct SyntheticSource {
+        n_cells: u32,
+        stars_per_cell: usize,
+    }
+
+    impl CellStarSource for SyntheticSource {
+        fn cell_count(&self) -> u32 {
+            self.n_cells
+        }
+
+        fn stars_in_cell(&self, cell_id: u32) -> io::Result<Vec<CellStar>> {
+            // Stars laid out in a small patch unique to each cell.
+            // RA/Dec are *real* radians so the v3 cell-table writer
+            // can hash them without complaint.
+            let base_ra = 0.5 + (cell_id as f64) * 0.1; // radians; spread across the sky
+            let base_dec = 0.0;
+            let mut out = Vec::with_capacity(self.stars_per_cell);
+            for i in 0..self.stars_per_cell {
+                let dra = (i as f64) * 0.001;
+                let ddec = (i as f64) * 0.0007;
+                // Catalog IDs are unique across cells (encoded as
+                // cell_id * 1000 + i) so the cross-cell-uniqueness
+                // assertion in finalize_index passes.
+                let catalog_id = (cell_id as u64) * 1000 + (i as u64) + 1;
+                out.push(make_cell_star(
+                    catalog_id,
+                    base_ra + dra,
+                    base_dec + ddec,
+                    (i as f64) * 0.5,
+                ));
+            }
+            Ok(out)
+        }
+    }
+
+    fn make_paths(name: &str) -> BuildPaths {
+        let work = tmp_dir(name);
+        let final_index = work.parent().unwrap().join(format!("{name}-final.zdcl"));
+        let final_sidecar = work.parent().unwrap().join(format!("{name}-final.zdcl.gaia"));
+        BuildPaths {
+            work_dir: work,
+            final_index,
+            final_sidecar,
+        }
+    }
+
+    fn default_config() -> CellBuildConfig {
+        CellBuildConfig {
+            scale_lower: 0.0001,
+            scale_upper: 0.05,
+            quads_per_cell: 200,
+            max_reuse: 8,
+            final_cell_depth: 5,
+            pivot_stride: 16,
+        }
+    }
+
+    #[test]
+    fn end_to_end_synthetic_build() {
+        let paths = make_paths("e2e");
+        let source = SyntheticSource {
+            n_cells: 4,
+            stars_per_cell: 8,
+        };
+        let cfg = default_config();
+
+        let summary = build_index_cell_driven(&source, &cfg, &paths).unwrap();
+        assert_eq!(summary.n_cells_processed, 4);
+        assert_eq!(summary.n_cells_resumed, 0);
+        assert_eq!(summary.n_stars, 32);
+        assert!(summary.n_quads > 0, "expected some quads");
+
+        // Final files must exist and be readable.
+        assert!(paths.final_index.exists());
+        assert!(paths.final_sidecar.exists());
+
+        let zdcl = crate::index::ZdclFile::open(&paths.final_index).unwrap();
+        assert_eq!(zdcl.star_count(), 32);
+        assert_eq!(zdcl.quad_count() as u64, summary.n_quads);
+
+        let sidecar = SidecarReader::open(&paths.final_sidecar).unwrap();
+        assert_eq!(sidecar.len(), 32);
+        // Spot-check a known catalog_id (cell 2, star 3 → id = 2*1000+3+1 = 2004).
+        let r = sidecar.get(2004).expect("missing record");
+        assert_eq!(r.source_id, 2004);
+
+        // Work dir should be fully cleaned up on success.
+        assert!(
+            !paths.work_dir.exists()
+                || std::fs::read_dir(&paths.work_dir)
+                    .map(|d| d.count() == 0)
+                    .unwrap_or(true),
+            "work_dir not cleaned: {:?}",
+            paths.work_dir
+        );
+
+        std::fs::remove_file(&paths.final_index).ok();
+        std::fs::remove_file(&paths.final_sidecar).ok();
+    }
+
+    #[test]
+    fn empty_cells_are_recorded_and_finalize_succeeds() {
+        struct Source;
+        impl CellStarSource for Source {
+            fn cell_count(&self) -> u32 {
+                3
+            }
+            fn stars_in_cell(&self, cell_id: u32) -> io::Result<Vec<CellStar>> {
+                if cell_id == 1 {
+                    return Ok(Vec::new());
+                }
+                Ok(vec![make_cell_star(
+                    (cell_id as u64) + 1,
+                    0.5 + (cell_id as f64) * 0.1,
+                    0.0,
+                    1.0,
+                )])
+            }
+        }
+
+        let paths = make_paths("empty-cells");
+        let cfg = default_config();
+        let summary = build_index_cell_driven(&Source, &cfg, &paths).unwrap();
+        assert_eq!(summary.n_cells_processed, 2);
+        assert_eq!(summary.n_cells_empty, 1);
+        assert_eq!(summary.n_stars, 2);
+
+        let zdcl = crate::index::ZdclFile::open(&paths.final_index).unwrap();
+        assert_eq!(zdcl.star_count(), 2);
+
+        std::fs::remove_file(&paths.final_index).ok();
+        std::fs::remove_file(&paths.final_sidecar).ok();
+    }
+
+    /// Crash-resume simulation: a `CellStarSource` that panics on the
+    /// first attempt to load the second cell, then on retry succeeds
+    /// for every cell. Verifies the manifest survived the crash and
+    /// the resumed run produces the same final output as a clean run.
+    #[test]
+    fn resumes_after_simulated_crash() {
+        use std::cell::Cell;
+
+        struct CrashOnce {
+            crashed: Cell<bool>,
+            crash_at_cell: u32,
+            n_cells: u32,
+            stars_per_cell: usize,
+        }
+
+        // SAFETY: tests are single-threaded; Cell is sufficient. The
+        // trait requires Sync, so wrap in a stub Sync impl.
+        unsafe impl Sync for CrashOnce {}
+
+        impl CellStarSource for CrashOnce {
+            fn cell_count(&self) -> u32 {
+                self.n_cells
+            }
+            fn stars_in_cell(&self, cell_id: u32) -> io::Result<Vec<CellStar>> {
+                if cell_id == self.crash_at_cell && !self.crashed.get() {
+                    self.crashed.set(true);
+                    return Err(io::Error::other("simulated crash"));
+                }
+                let mut out = Vec::with_capacity(self.stars_per_cell);
+                for i in 0..self.stars_per_cell {
+                    let catalog_id = (cell_id as u64) * 1000 + (i as u64) + 1;
+                    out.push(make_cell_star(
+                        catalog_id,
+                        0.5 + (cell_id as f64) * 0.1 + (i as f64) * 0.001,
+                        0.0 + (i as f64) * 0.0007,
+                        (i as f64) * 0.5,
+                    ));
+                }
+                Ok(out)
+            }
+        }
+
+        let paths = make_paths("resume");
+        let cfg = default_config();
+
+        // Phase 1: crash partway. Source crashes on cell 2, so cells
+        // 0 and 1 should already be committed when we abort.
+        let source = CrashOnce {
+            crashed: Cell::new(false),
+            crash_at_cell: 2,
+            n_cells: 4,
+            stars_per_cell: 6,
+        };
+        let err = build_index_cell_driven(&source, &cfg, &paths).unwrap_err();
+        assert!(err.to_string().contains("simulated crash"));
+
+        // Manifest should record the committed cells.
+        let manifest = BuildManifest::load(&paths.work_dir)
+            .unwrap()
+            .expect("manifest must persist after crash");
+        assert_eq!(manifest.completed_cells.len(), 2, "{:?}", manifest);
+        assert!(manifest.is_complete(0));
+        assert!(manifest.is_complete(1));
+        assert!(!manifest.is_complete(2));
+
+        // Phase 2: resume — same paths, fresh `crashed` flag so the
+        // source doesn't crash again.
+        let source = CrashOnce {
+            crashed: Cell::new(true), // already "crashed once"
+            crash_at_cell: 2,
+            n_cells: 4,
+            stars_per_cell: 6,
+        };
+        let summary = build_index_cell_driven(&source, &cfg, &paths).unwrap();
+        assert_eq!(summary.n_cells_resumed, 2);
+        assert_eq!(summary.n_cells_processed, 2);
+        assert_eq!(summary.n_stars, 24);
+
+        // Verify resumed final output matches a clean rebuild byte-for-byte.
+        let resumed_index_bytes = std::fs::read(&paths.final_index).unwrap();
+        let resumed_sidecar_bytes = std::fs::read(&paths.final_sidecar).unwrap();
+        std::fs::remove_file(&paths.final_index).ok();
+        std::fs::remove_file(&paths.final_sidecar).ok();
+
+        let clean_paths = make_paths("resume-clean");
+        let clean_source = CrashOnce {
+            crashed: Cell::new(true),
+            crash_at_cell: u32::MAX,
+            n_cells: 4,
+            stars_per_cell: 6,
+        };
+        build_index_cell_driven(&clean_source, &cfg, &clean_paths).unwrap();
+        let clean_index_bytes = std::fs::read(&clean_paths.final_index).unwrap();
+        let clean_sidecar_bytes = std::fs::read(&clean_paths.final_sidecar).unwrap();
+        std::fs::remove_file(&clean_paths.final_index).ok();
+        std::fs::remove_file(&clean_paths.final_sidecar).ok();
+
+        assert_eq!(resumed_sidecar_bytes, clean_sidecar_bytes);
+        // Index bytes may differ if iteration order differed across
+        // runs, but the cell-driven builder is deterministic, so
+        // expect equality.
+        assert_eq!(resumed_index_bytes, clean_index_bytes);
+    }
+
+    #[test]
+    fn duplicate_catalog_id_across_cells_is_rejected() {
+        struct DupSource;
+        impl CellStarSource for DupSource {
+            fn cell_count(&self) -> u32 {
+                2
+            }
+            fn stars_in_cell(&self, cell_id: u32) -> io::Result<Vec<CellStar>> {
+                // Both cells expose the same catalog_id 42 — the
+                // finalize step must catch it.
+                Ok(vec![make_cell_star(
+                    42,
+                    0.5 + (cell_id as f64) * 0.1,
+                    0.0,
+                    1.0,
+                )])
+            }
+        }
+
+        let paths = make_paths("dup");
+        let cfg = default_config();
+        let err = build_index_cell_driven(&DupSource, &cfg, &paths).unwrap_err();
+        assert!(err.to_string().contains("multiple cells"), "got: {err}");
+
+        // Cleanup left-over artifacts.
+        let _ = std::fs::remove_dir_all(&paths.work_dir);
+        let _ = std::fs::remove_file(&paths.final_index);
+        let _ = std::fs::remove_file(&paths.final_sidecar);
+    }
+
+    #[test]
+    fn invalid_scale_range_is_rejected() {
+        let paths = make_paths("bad-scale");
+        let mut cfg = default_config();
+        cfg.scale_lower = 0.05;
+        cfg.scale_upper = 0.01;
+        let source = SyntheticSource {
+            n_cells: 1,
+            stars_per_cell: 4,
+        };
+        let err = build_index_cell_driven(&source, &cfg, &paths).unwrap_err();
+        assert!(err.to_string().contains("scale range"));
+        let _ = std::fs::remove_dir_all(&paths.work_dir);
+    }
+
+    /// Loading the final v3 file via `IndexSource::load_cells` over the
+    /// full sky should return all stars and all quads — proves that the
+    /// finalize step's catalog_id remap produced indices the v3 reader
+    /// can resolve.
+    #[test]
+    fn final_v3_load_full_returns_everything() {
+        let paths = make_paths("v3-full");
+        let source = SyntheticSource {
+            n_cells: 3,
+            stars_per_cell: 6,
+        };
+        let cfg = default_config();
+        build_index_cell_driven(&source, &cfg, &paths).unwrap();
+
+        let zdcl = crate::index::ZdclFile::open(&paths.final_index).unwrap();
+        let cells: Vec<_> = (0..(12u64 << (2 * cfg.final_cell_depth as u64)))
+            .map(|id| crate::index::HealpixCell {
+                depth: cfg.final_cell_depth,
+                id,
+            })
+            .collect();
+        // Touch only the cells that actually contain stars; load_cells
+        // skips empty ones internally.
+        let frag: IndexFragment = zdcl.load_cells(&cells).unwrap();
+        assert_eq!(frag.stars.len(), 18);
+        // Every quad must reference a valid star index in the fragment.
+        for q in &frag.quads {
+            for &sid in &q.star_ids {
+                assert!(sid < frag.stars.len(), "quad sid {sid} out of range");
+            }
+        }
+        // Reconstruct an Index to make sure tree-build succeeds.
+        let _idx: Index = frag.into();
+
+        std::fs::remove_file(&paths.final_index).ok();
+        std::fs::remove_file(&paths.final_sidecar).ok();
+    }
+}

--- a/src/index/cell_builder.rs
+++ b/src/index/cell_builder.rs
@@ -46,7 +46,7 @@ use crate::geom::sphere::{angular_distance, radec_to_xyz, star_midpoint};
 use crate::quads::{Code, DIMCODES, DIMQUADS, Quad, compute_canonical_code};
 use crate::refinement::{SidecarRecord, SidecarStreamWriter};
 
-use super::{IndexStar};
+use super::IndexStar;
 use super::build_manifest::{BuildManifest, CellStats};
 
 /// One star produced by a [`CellStarSource`]. Carries everything the
@@ -330,8 +330,7 @@ fn build_quads_for_cell(stars: &[CellStar], config: &CellBuildConfig) -> (Vec<Qu
                         continue;
                     }
 
-                    if use_count[c_idx] >= config.max_reuse
-                        || use_count[d_idx] >= config.max_reuse
+                    if use_count[c_idx] >= config.max_reuse || use_count[d_idx] >= config.max_reuse
                     {
                         continue;
                     }
@@ -738,7 +737,10 @@ mod tests {
     fn make_paths(name: &str) -> BuildPaths {
         let work = tmp_dir(name);
         let final_index = work.parent().unwrap().join(format!("{name}-final.zdcl"));
-        let final_sidecar = work.parent().unwrap().join(format!("{name}-final.zdcl.gaia"));
+        let final_sidecar = work
+            .parent()
+            .unwrap()
+            .join(format!("{name}-final.zdcl.gaia"));
         BuildPaths {
             work_dir: work,
             final_index,

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1,4 +1,6 @@
+pub mod build_manifest;
 pub mod builder;
+pub mod cell_builder;
 pub mod live;
 pub mod source;
 pub mod store;

--- a/src/refinement/mod.rs
+++ b/src/refinement/mod.rs
@@ -18,7 +18,9 @@ mod tests;
 
 pub use apparent::apparent_radec;
 pub use refine::refine_solution;
-pub use sidecar::{DEFAULT_PIVOT_STRIDE, SidecarReader, SidecarRecord, write_sidecar};
+pub use sidecar::{
+    DEFAULT_PIVOT_STRIDE, SidecarReader, SidecarRecord, SidecarStreamWriter, write_sidecar,
+};
 pub use types::{
     GaiaAstrometry, ObservationContext, ObserverState, RefinedMatch, RefinedSolution,
     RefinementCatalog, RefinementConfig, RefinementError,

--- a/src/refinement/sidecar.rs
+++ b/src/refinement/sidecar.rs
@@ -11,9 +11,10 @@
 //! spatial clustering on disk, and compression doesn't help enough to
 //! justify parquet's decompression cost on the query path.
 
-use std::fs::File;
-use std::io::{self, BufWriter, Write};
-use std::path::Path;
+use std::collections::BinaryHeap;
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
 
 use memmap2::Mmap;
 
@@ -111,6 +112,396 @@ where
 
     w.flush()?;
     Ok(())
+}
+
+/// Streaming sidecar writer with bounded peak memory.
+///
+/// Each call to [`SidecarStreamWriter::append_chunk`] sorts the chunk
+/// internally by `source_id` and dumps it to a numbered temp file under
+/// the scratch directory. [`SidecarStreamWriter::finalize`] then performs
+/// an external k-way merge across the temp files, building the pivot
+/// table on the fly, and writes the final sorted-and-pivoted sidecar.
+///
+/// Peak memory is bounded by the largest chunk (callers typically size
+/// chunks to one cell's worth of records — tens of MB at HEALPix level
+/// 5). Disk usage is bounded by the total record count: each record is
+/// written once to a temp file and once to the final output.
+///
+/// Crash semantics: temp files live under `scratch_dir`. If the writer
+/// is dropped before `finalize`, partial chunks remain on disk so a
+/// caller-managed manifest can resume from the next chunk. `finalize`
+/// removes all temp files only after the final atomic rename succeeds.
+pub struct SidecarStreamWriter {
+    scratch_dir: PathBuf,
+    /// (chunk_path, n_records) — appended in the order chunks were
+    /// committed. Order doesn't matter for the merge (records are sorted
+    /// by source_id inside each file), but stable order helps debugging.
+    chunks: Vec<(PathBuf, u64)>,
+    next_chunk_idx: u64,
+}
+
+impl SidecarStreamWriter {
+    /// Create a new streaming writer. `scratch_dir` will be created if
+    /// missing; chunk temp files are written there as
+    /// `chunk_NNNN.sidecar-tmp`.
+    ///
+    /// The writer is independent of the final output path until
+    /// [`Self::finalize`] is called, which lets the caller pick a
+    /// final destination only after all chunks have been committed
+    /// successfully (a useful split for crash-resume flows).
+    pub fn new(scratch_dir: impl Into<PathBuf>) -> io::Result<Self> {
+        let scratch_dir = scratch_dir.into();
+        std::fs::create_dir_all(&scratch_dir)?;
+        Ok(Self {
+            scratch_dir,
+            chunks: Vec::new(),
+            next_chunk_idx: 0,
+        })
+    }
+
+    /// Resume a writer from a scratch directory previously populated by
+    /// `append_chunk` calls. The discovered chunks contribute to the
+    /// final merge but are not re-sorted.
+    ///
+    /// Resume scans the directory for `chunk_NNNN.sidecar-tmp` files,
+    /// reads each one's record count from its header, and seeds the
+    /// internal chunk list. Chunks the caller already committed in a
+    /// prior run will round-trip into the final sidecar without rework.
+    pub fn resume(scratch_dir: impl Into<PathBuf>) -> io::Result<Self> {
+        let scratch_dir = scratch_dir.into();
+        std::fs::create_dir_all(&scratch_dir)?;
+
+        let mut found: Vec<(u64, PathBuf, u64)> = Vec::new();
+        for entry in std::fs::read_dir(&scratch_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n,
+                None => continue,
+            };
+            let idx = match name
+                .strip_prefix("chunk_")
+                .and_then(|s| s.strip_suffix(".sidecar-tmp"))
+                .and_then(|s| s.parse::<u64>().ok())
+            {
+                Some(i) => i,
+                None => continue,
+            };
+            let n_records = read_chunk_header(&path)?;
+            found.push((idx, path, n_records));
+        }
+        found.sort_by_key(|(i, _, _)| *i);
+
+        let next_chunk_idx = found.last().map(|(i, _, _)| i + 1).unwrap_or(0);
+        let chunks: Vec<(PathBuf, u64)> = found.into_iter().map(|(_, p, n)| (p, n)).collect();
+
+        Ok(Self {
+            scratch_dir,
+            chunks,
+            next_chunk_idx,
+        })
+    }
+
+    /// Write a chunk of records to a numbered temp file, sorted by
+    /// `source_id`. Returns the chunk's index and on-disk path.
+    ///
+    /// Empty chunks are accepted but produce no temp file — the caller
+    /// can use the returned index to drive a manifest without special-casing.
+    pub fn append_chunk(&mut self, mut records: Vec<SidecarRecord>) -> io::Result<u64> {
+        let idx = self.next_chunk_idx;
+        self.next_chunk_idx += 1;
+
+        if records.is_empty() {
+            return Ok(idx);
+        }
+
+        records.sort_by_key(|r| r.source_id);
+
+        let path = self.chunk_path(idx);
+        let tmp_path = {
+            let mut s = path.as_os_str().to_owned();
+            s.push(".partial");
+            PathBuf::from(s)
+        };
+
+        let n_records = records.len() as u64;
+        {
+            let file = File::create(&tmp_path)?;
+            let mut w = BufWriter::new(file);
+            w.write_all(&n_records.to_le_bytes())?;
+            // Records bytes (88 B each, repr(C)).
+            let bytes: &[u8] = unsafe {
+                std::slice::from_raw_parts(
+                    records.as_ptr() as *const u8,
+                    records.len() * RECORD_SIZE as usize,
+                )
+            };
+            w.write_all(bytes)?;
+            w.flush()?;
+            w.get_ref().sync_all()?;
+        }
+        std::fs::rename(&tmp_path, &path)?;
+
+        self.chunks.push((path, n_records));
+        Ok(idx)
+    }
+
+    /// Number of chunks committed so far.
+    pub fn chunk_count(&self) -> usize {
+        self.chunks.len()
+    }
+
+    /// Total records committed across all chunks (sum of chunk sizes).
+    pub fn total_records(&self) -> u64 {
+        self.chunks.iter().map(|(_, n)| *n).sum()
+    }
+
+    /// Merge all committed chunks into `final_path`, build the pivot
+    /// table, and remove the scratch directory's temp files. The final
+    /// file is written atomically (tmp file + rename).
+    ///
+    /// Dropping the writer without calling `finalize` deliberately
+    /// leaves the chunk temp files in place — the on-disk chunks plus
+    /// a sibling [`crate::index::build_manifest::BuildManifest`] are
+    /// the durable resume state.
+    ///
+    /// `pivot_stride` controls the in-file pivot density; pass
+    /// [`DEFAULT_PIVOT_STRIDE`] for the standard 4096.
+    pub fn finalize(self, final_path: &Path, pivot_stride: u32) -> io::Result<()> {
+        assert!(pivot_stride > 0, "pivot_stride must be positive");
+
+        let n_records: u64 = self.chunks.iter().map(|(_, n)| *n).sum();
+        let pivot_count = if n_records == 0 {
+            0u32
+        } else {
+            ((n_records - 1) / pivot_stride as u64 + 1) as u32
+        };
+
+        // Final file is written to a sibling .partial first so a crash
+        // mid-write doesn't leave a half-formed `.zdcl.gaia` in place.
+        let tmp_final = match final_path.extension() {
+            Some(ext) => {
+                let mut s = ext.to_owned();
+                s.push(".partial");
+                final_path.with_extension(s)
+            }
+            None => final_path.with_extension("partial"),
+        };
+
+        // Open chunk readers; collect first-record peeks for the heap.
+        let mut readers: Vec<ChunkReader> = Vec::with_capacity(self.chunks.len());
+        for (path, n) in &self.chunks {
+            if *n == 0 {
+                continue;
+            }
+            readers.push(ChunkReader::open(path)?);
+        }
+
+        // Min-heap keyed by current head record's source_id.
+        let mut heap: BinaryHeap<HeapEntry> = BinaryHeap::with_capacity(readers.len());
+        for (i, r) in readers.iter_mut().enumerate() {
+            if let Some(rec) = r.next()? {
+                heap.push(HeapEntry {
+                    source_id: rec.source_id,
+                    reader_idx: i,
+                    record: rec,
+                });
+            }
+        }
+
+        let file = File::create(&tmp_final)?;
+        let mut w = BufWriter::new(file);
+
+        // --- Header ---
+        w.write_all(MAGIC)?;
+        w.write_all(&VERSION.to_le_bytes())?;
+        w.write_all(&RECORD_SIZE.to_le_bytes())?;
+        w.write_all(&n_records.to_le_bytes())?;
+        w.write_all(&pivot_stride.to_le_bytes())?;
+        w.write_all(&pivot_count.to_le_bytes())?;
+        w.write_all(&[0u8; 32])?;
+
+        // --- Reserve pivot table region; we'll overwrite it after the
+        // merge pass once we know each pivot's source_id. We can't emit
+        // pivots inline because the file layout puts the pivot table
+        // BEFORE the records.
+        let pivots_offset = HEADER_SIZE as u64;
+        let pivots_size = (pivot_count as usize) * 8;
+        if pivots_size > 0 {
+            w.write_all(&vec![0u8; pivots_size])?;
+        }
+
+        let pre_padding = HEADER_SIZE + pivots_size;
+        let records_offset = (pre_padding + 7) & !7;
+        let pad = records_offset - pre_padding;
+        if pad > 0 {
+            w.write_all(&vec![0u8; pad])?;
+        }
+
+        // --- Merge pass ---
+        let mut pivots: Vec<u64> = Vec::with_capacity(pivot_count as usize);
+        let stride = pivot_stride as u64;
+        let mut written: u64 = 0;
+        let mut prev_source_id: Option<u64> = None;
+        while let Some(top) = heap.pop() {
+            // Validate sort: streaming merge requires monotonically
+            // non-decreasing source_id across the merged stream.
+            if let Some(prev) = prev_source_id
+                && top.source_id < prev
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "merge stream out of order: prev={prev} next={} (chunks must be sorted)",
+                        top.source_id,
+                    ),
+                ));
+            }
+
+            if written.is_multiple_of(stride) && pivots.len() < pivot_count as usize {
+                pivots.push(top.source_id);
+            }
+
+            let bytes: &[u8] = unsafe {
+                std::slice::from_raw_parts(
+                    &top.record as *const SidecarRecord as *const u8,
+                    RECORD_SIZE as usize,
+                )
+            };
+            w.write_all(bytes)?;
+            written += 1;
+            prev_source_id = Some(top.source_id);
+
+            // Refill from this reader.
+            let r = &mut readers[top.reader_idx];
+            if let Some(rec) = r.next()? {
+                heap.push(HeapEntry {
+                    source_id: rec.source_id,
+                    reader_idx: top.reader_idx,
+                    record: rec,
+                });
+            }
+        }
+
+        if written != n_records {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "merged {written} records but chunk headers reported {n_records}; \
+                     a chunk file may be truncated"
+                ),
+            ));
+        }
+
+        w.flush()?;
+
+        // Rewind, overwrite the pivot table region with real pivots, and
+        // sync. `BufWriter::seek` flushes its buffer first.
+        if pivot_count > 0 {
+            assert_eq!(pivots.len(), pivot_count as usize);
+            w.seek(SeekFrom::Start(pivots_offset))?;
+            for p in &pivots {
+                w.write_all(&p.to_le_bytes())?;
+            }
+            w.flush()?;
+        }
+        w.get_ref().sync_all()?;
+        drop(w);
+
+        std::fs::rename(&tmp_final, final_path)?;
+
+        // Clean up chunk temp files; only after the rename succeeds so
+        // a crashed finalize stays resumable.
+        for (path, _) in &self.chunks {
+            let _ = std::fs::remove_file(path);
+        }
+        // Best-effort: remove scratch dir if empty. Caller may share it
+        // with a sibling manifest, in which case rmdir is harmless on
+        // EEXIST/ENOTEMPTY.
+        let _ = std::fs::remove_dir(&self.scratch_dir);
+
+        Ok(())
+    }
+
+    fn chunk_path(&self, idx: u64) -> PathBuf {
+        self.scratch_dir
+            .join(format!("chunk_{idx:04}.sidecar-tmp"))
+    }
+}
+
+/// Read the n_records header from a chunk temp file without loading
+/// records.
+fn read_chunk_header(path: &Path) -> io::Result<u64> {
+    let mut f = File::open(path)?;
+    let mut buf = [0u8; 8];
+    f.read_exact(&mut buf)?;
+    Ok(u64::from_le_bytes(buf))
+}
+
+/// Buffered reader over a single sidecar chunk temp file. Yields
+/// records in the file's stored (already-sorted) order.
+struct ChunkReader {
+    inner: BufReader<File>,
+    remaining: u64,
+}
+
+impl ChunkReader {
+    fn open(path: &Path) -> io::Result<Self> {
+        let mut f = OpenOptions::new().read(true).open(path)?;
+        let mut hdr = [0u8; 8];
+        f.read_exact(&mut hdr)?;
+        let remaining = u64::from_le_bytes(hdr);
+        Ok(Self {
+            inner: BufReader::new(f),
+            remaining,
+        })
+    }
+
+    fn next(&mut self) -> io::Result<Option<SidecarRecord>> {
+        if self.remaining == 0 {
+            return Ok(None);
+        }
+        let mut buf = [0u8; RECORD_SIZE as usize];
+        self.inner.read_exact(&mut buf)?;
+        self.remaining -= 1;
+        // Safe: SidecarRecord is repr(C), the buffer is RECORD_SIZE
+        // bytes, and we copy out (no aliasing the buffer).
+        let rec = unsafe { std::ptr::read_unaligned(buf.as_ptr() as *const SidecarRecord) };
+        Ok(Some(rec))
+    }
+}
+
+/// Heap entry for the k-way merge. `BinaryHeap` is a max-heap, so we
+/// invert `cmp` to get min-on-source_id behavior.
+struct HeapEntry {
+    source_id: u64,
+    reader_idx: usize,
+    record: SidecarRecord,
+}
+
+impl PartialEq for HeapEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.source_id == other.source_id && self.reader_idx == other.reader_idx
+    }
+}
+impl Eq for HeapEntry {}
+impl PartialOrd for HeapEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for HeapEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Min-heap on source_id, ties broken by reader_idx for
+        // deterministic output across runs.
+        other
+            .source_id
+            .cmp(&self.source_id)
+            .then(other.reader_idx.cmp(&self.reader_idx))
+    }
 }
 
 /// Mmap-backed random-access reader over a sidecar file.
@@ -506,5 +897,159 @@ mod tests {
         assert!(results.iter().all(|r| r.is_some()));
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    fn tmp_dir(name: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "zodiacal-sidecar-stream-{}-{}-{}",
+            name,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ));
+        p
+    }
+
+    fn collect_records(reader: &SidecarReader) -> Vec<SidecarRecord> {
+        (0..reader.len()).map(|i| *reader.record_at(i)).collect()
+    }
+
+    #[test]
+    fn stream_writer_roundtrip_matches_in_ram_writer() {
+        // Same records via both writers should produce byte-identical
+        // contents, since the on-disk format is fixed and both paths
+        // sort by source_id deterministically.
+        let scratch = tmp_dir("rt-scratch");
+        let final_stream = tmp_dir("rt-final-stream");
+        let final_inram = tmp_dir("rt-final-inram");
+
+        let mut records: Vec<SidecarRecord> = (0..1000u64)
+            .map(|i| rec(7919 * (i + 1), i as f64 * 0.001, -(i as f64) * 0.0005))
+            .collect();
+        // Shuffle to exercise the writer's sort.
+        records.swap(0, 999);
+        records.swap(123, 456);
+
+        // In-RAM baseline.
+        write_sidecar(&final_inram, records.clone(), 64).unwrap();
+
+        // Streaming writer: chunk into 7 pieces of varying sizes, with
+        // overlapping source_id ranges to mimic cell ordering.
+        let mut writer = SidecarStreamWriter::new(&scratch).unwrap();
+        let chunks: Vec<Vec<SidecarRecord>> = (0..7)
+            .map(|c| {
+                records
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| i % 7 == c)
+                    .map(|(_, r)| *r)
+                    .collect()
+            })
+            .collect();
+        for ch in chunks {
+            writer.append_chunk(ch).unwrap();
+        }
+        assert_eq!(writer.total_records(), 1000);
+        writer.finalize(&final_stream, 64).unwrap();
+
+        // Compare byte streams.
+        let a = std::fs::read(&final_inram).unwrap();
+        let b = std::fs::read(&final_stream).unwrap();
+        assert_eq!(a, b, "stream and in-RAM writers diverged");
+
+        // Reader-level equivalence as a belt-and-suspenders check.
+        let r_in = SidecarReader::open(&final_inram).unwrap();
+        let r_st = SidecarReader::open(&final_stream).unwrap();
+        assert_eq!(collect_records(&r_in), collect_records(&r_st));
+
+        let _ = std::fs::remove_file(&final_inram);
+        let _ = std::fs::remove_file(&final_stream);
+    }
+
+    #[test]
+    fn stream_writer_empty_input() {
+        let scratch = tmp_dir("empty-scratch");
+        let final_path = tmp_dir("empty-final");
+
+        let writer = SidecarStreamWriter::new(&scratch).unwrap();
+        writer.finalize(&final_path, 64).unwrap();
+
+        let reader = SidecarReader::open(&final_path).unwrap();
+        assert_eq!(reader.len(), 0);
+
+        let _ = std::fs::remove_file(&final_path);
+    }
+
+    #[test]
+    fn stream_writer_resume_replays_committed_chunks() {
+        // Simulate a crashed builder that committed some chunks but
+        // never finalized; resume should pick them up and merge them
+        // alongside new chunks.
+        let scratch = tmp_dir("resume-scratch");
+        let final_path = tmp_dir("resume-final");
+
+        let all_records: Vec<SidecarRecord> = (0..500u64).map(|i| rec(i * 11 + 3, 0.1, 0.2)).collect();
+        let split = 300;
+
+        // Phase 1: writer crashes after committing the first 3 chunks.
+        {
+            let mut writer = SidecarStreamWriter::new(&scratch).unwrap();
+            for c in 0..3 {
+                let lo = c * 100;
+                let hi = lo + 100;
+                writer.append_chunk(all_records[lo..hi].to_vec()).unwrap();
+            }
+            assert_eq!(writer.chunk_count(), 3);
+            // Drop without finalize — chunks remain on disk.
+        }
+
+        // Phase 2: resume, add the remaining chunks, finalize.
+        {
+            let mut writer = SidecarStreamWriter::resume(&scratch).unwrap();
+            assert_eq!(writer.chunk_count(), 3);
+            assert_eq!(writer.total_records(), split as u64);
+            for c in 3..5 {
+                let lo = c * 100;
+                let hi = lo + 100;
+                writer.append_chunk(all_records[lo..hi].to_vec()).unwrap();
+            }
+            writer.finalize(&final_path, 32).unwrap();
+        }
+
+        // Final file should contain every record exactly once.
+        let reader = SidecarReader::open(&final_path).unwrap();
+        assert_eq!(reader.len(), all_records.len());
+        for r in &all_records {
+            let got = reader.get(r.source_id).expect("missing record after resume");
+            assert_eq!(got.source_id, r.source_id);
+        }
+
+        let _ = std::fs::remove_file(&final_path);
+    }
+
+    #[test]
+    fn stream_writer_skips_empty_chunks() {
+        // A cell with zero stars (e.g. a high-galactic-latitude void at
+        // a very tight mag cap) should produce a noop append, not a
+        // zero-byte temp file that confuses the merge.
+        let scratch = tmp_dir("skip-scratch");
+        let final_path = tmp_dir("skip-final");
+
+        let mut writer = SidecarStreamWriter::new(&scratch).unwrap();
+        writer.append_chunk(Vec::new()).unwrap();
+        writer.append_chunk(vec![rec(42, 0.0, 0.0)]).unwrap();
+        writer.append_chunk(Vec::new()).unwrap();
+        writer.append_chunk(vec![rec(43, 0.0, 0.0)]).unwrap();
+        writer.finalize(&final_path, 32).unwrap();
+
+        let reader = SidecarReader::open(&final_path).unwrap();
+        assert_eq!(reader.len(), 2);
+        assert!(reader.get(42).is_some());
+        assert!(reader.get(43).is_some());
+
+        let _ = std::fs::remove_file(&final_path);
     }
 }

--- a/src/refinement/sidecar.rs
+++ b/src/refinement/sidecar.rs
@@ -427,8 +427,7 @@ impl SidecarStreamWriter {
     }
 
     fn chunk_path(&self, idx: u64) -> PathBuf {
-        self.scratch_dir
-            .join(format!("chunk_{idx:04}.sidecar-tmp"))
+        self.scratch_dir.join(format!("chunk_{idx:04}.sidecar-tmp"))
     }
 }
 
@@ -991,7 +990,8 @@ mod tests {
         let scratch = tmp_dir("resume-scratch");
         let final_path = tmp_dir("resume-final");
 
-        let all_records: Vec<SidecarRecord> = (0..500u64).map(|i| rec(i * 11 + 3, 0.1, 0.2)).collect();
+        let all_records: Vec<SidecarRecord> =
+            (0..500u64).map(|i| rec(i * 11 + 3, 0.1, 0.2)).collect();
         let split = 300;
 
         // Phase 1: writer crashes after committing the first 3 chunks.
@@ -1023,7 +1023,9 @@ mod tests {
         let reader = SidecarReader::open(&final_path).unwrap();
         assert_eq!(reader.len(), all_records.len());
         for r in &all_records {
-            let got = reader.get(r.source_id).expect("missing record after resume");
+            let got = reader
+                .get(r.source_id)
+                .expect("missing record after resume");
             assert_eq!(got.source_id, r.source_id);
         }
 


### PR DESCRIPTION
## Summary

Lands the zodiacal-side scaffolding for #65 — a cell-driven, resumable index builder — without depending on the `LazyLoadingCatalog::entries_in_cell` work in flight on `starfield-datasources`. The lazy-catalog adapter drops in as one `impl CellStarSource for ...` block in `zodiacal-tools` once upstream merges.

Adds three primitives plus an analysis script:

- **`SidecarStreamWriter`** (`src/refinement/sidecar.rs`): chunked-in, external-k-way-merged-out replacement for `write_sidecar`. Lifts the in-RAM `Vec<SidecarRecord>` cap that hard-blocks `build-from-shards` at G ≤ 17. Round-trip equivalence with the in-RAM writer is verified byte-for-byte. Drop without `finalize` keeps chunk temp files around as durable resume state.
- **`BuildManifest`** (`src/index/build_manifest.rs`): JSON manifest with `completed_cells: BTreeSet<u32>`, per-cell stats, and running totals. Atomic tmp+rename writes; idempotent `commit_cell`.
- **`build_index_cell_driven`** (`src/index/cell_builder.rs`): orchestrator parameterized over a `CellStarSource` trait. Walks `0..cell_count`, spills per-cell artifacts (stars + quads-by-catalog-id + codes) and per-cell sidecar chunks, updates the manifest after every commit, and finalizes by remapping catalog_ids to global indices and calling the existing v3 writer.

## Diagnostics: `scripts/analyze_index.py`

Mmap-backed numpy parser for `.zdcl` v3, emits 6 figures + a text summary characterising scale coverage, sky density (Mollweide), 4-D code-space density, star reuse, per-cell index depth, and FOV coverage at random pointings. ~13 s on `scratch/gaia_g14.zdcl` (1 M quads, 16.8 M stars).

Surfaced these structural problems with the current G ≤ 14 production index (separate from this PR's scope, useful as motivation):
- Only **133 of 12,288 HEALPix cells (1.1 %)** hold any quads.
- The most-reused star (G = 7.6) appears in **257,870 quads**.
- A 0.5° random pointing hits **zero quads in 99.8 % of cases** (uniform expectation: 19 quads / FOV).
- In the cells that *do* hold quads, depth saturates at G ≈ 14 — so where reached, reach is fine; the problem is purely sky coverage.

These are caused by `build-from-shards` calling the brightness-first `build_index` direct path instead of the HEALPix-uniformized `build_index_from_catalog` path. PR #69 removes the silent 1 M `--max-quads` default that hid the issue. Switching paths is a follow-up.

## What's deliberately *not* in this PR

- **No `LazyLoadingCatalog` adapter.** The upstream `entries_in_cell` API isn't merged yet; the cell-source trait is designed so the eventual adapter is a thin `impl` block in `zodiacal-tools`.
- **No neighbour context for per-cell quads.** Per #65's pseudocode, `build_quads_for_cell` uses only the focus cell's stars. Quads whose backbones straddle a HEALPix boundary at the source's depth are dropped. At level 5 (cells ~1.8°) this loss is small for typical quad scales (30″–30′) but non-zero. Documented in the module-level rustdoc.
- **No parallelism.** Cells are processed sequentially. The artifact + manifest layout is designed to allow it as a follow-up.

## File format / reader compatibility

`.zdcl` v3 file format and `IndexSource` reader path are unchanged. Sidecar v1 on-disk layout is unchanged — `SidecarStreamWriter` produces byte-identical output to `write_sidecar` for the same input.

## Tests

- 192 zodiacal lib tests (was 177) + 4 zodiacal-tools tests, all green.
- New tests covering: streaming-writer round-trip vs in-RAM writer, resume-after-drop replay, manifest atomic writes + idempotent commit, cell-driven end-to-end synthetic build, simulated crash with byte-for-byte equivalence to a clean rebuild, duplicate-catalog-id cross-cell rejection, and v3 reader round-trip on the assembled output.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Once upstream `entries_in_cell` lands: a `LazyLoadingCatalog` adapter + a `build-from-excerpt` subcommand exercising the orchestrator on real Gaia DR3 data.
- [ ] Follow-up issue: switch `build-from-shards` (and any other consumers) to a uniformized path so the 99.8 % empty-FOV pathology goes away.

## Related

- Issue: #65
- Sidecar layout follow-up: #66
- `--max-quads` default removal: #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)