### PR TITLE
bundle: BundleManifest schema + per-band BuildManifest extension (PR2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3740,6 +3740,7 @@ version = "0.4.1"
 dependencies = [
  "bytemuck",
  "cdshealpix",
+ "chrono",
  "clap",
  "fitsio-pure",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ indicatif = { version = "0.18.3", optional = true }
 ndarray = { version = "0.17.2", optional = true }
 bytemuck = { version = "1", features = ["derive"] }
 cdshealpix = "0.9.1"
+chrono = { version = "0.4", features = ["serde"] }
 memmap2 = "0.9"
 nalgebra = "0.32"
 rayon = "1.11.0"

--- a/src/bundle/manifest.rs
+++ b/src/bundle/manifest.rs
@@ -1,0 +1,438 @@
+//! `BundleManifest` — the JSON `manifest.json` shape that ships inside a
+//! finalized `.zdcl.bundle`.
+//!
+//! The manifest is the **commit point** of a bundle: a bundle is considered
+//! finalized iff its `manifest.json` parses and passes [`BundleManifest::load`]'s
+//! schema validation. See `docs/bundle-format.md` for the full specification.
+//!
+//! This file implements the typed schema, atomic write, and validating load.
+//! It does **not** implement the build pipeline that writes one of these — the
+//! cell-driven builder + tidy phase produce the manifest as their final step.
+//!
+//! # Schema
+//!
+//! ```text
+//! BundleManifest
+//! ├── format            "zdcl-bundle"     (validated on load)
+//! ├── format_version    1                 (validated on load)
+//! ├── cell_depth        u8
+//! ├── n_cells           u32
+//! ├── experiment        free-text human ops note
+//! ├── build_metadata
+//! │   ├── tool                            "zodiacal-tools 0.2.0"
+//! │   ├── build_started_utc               RFC3339
+//! │   ├── build_finished_utc              RFC3339
+//! │   └── source { kind, release, path }
+//! ├── gaia
+//! │   ├── n_total                u64
+//! │   ├── record_size            u32 = 104   (validated on load)
+//! │   ├── schema_version         u32
+//! │   ├── max_stars_per_cell     u32
+//! │   ├── mag_limit              f64
+//! │   └── populated_cells        u32
+//! └── bands [BandInfo]
+//!     ├── label                  "band_NN"
+//!     ├── band_idx               u32         (array position == band_idx)
+//!     ├── scale_lower_arcsec     f64
+//!     ├── scale_upper_arcsec     f64
+//!     ├── quads_per_cell         u32
+//!     ├── max_reuse              u32
+//!     ├── n_quads_total          u64
+//!     └── populated_cells        u32
+//! ```
+
+use std::fs::File;
+use std::io::{self, Read as _, Write as _};
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Magic string for the bundle format. A manifest with any other value is
+/// rejected by [`BundleManifest::load`].
+pub const FORMAT_MAGIC: &str = "zdcl-bundle";
+
+/// Current on-disk schema version. `load` rejects manifests with a different
+/// version (forward-compat is opt-in via a future match arm).
+pub const FORMAT_VERSION: u32 = 1;
+
+/// Required `gaia.record_size` for a v1 bundle. Mismatches are rejected by
+/// `load` to prevent accidentally reading a 96 B-record bundle as 104 B (or
+/// vice versa).
+pub const GAIA_RECORD_SIZE: u32 = 104;
+
+/// Top-level `manifest.json` schema for a finalized `.zdcl.bundle`.
+///
+/// Field order in the struct definition matches the JSON output order
+/// produced by `serde_json::to_writer_pretty` — keep them aligned with the
+/// spec example so a diff against `docs/bundle-format.md` stays cheap.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BundleManifest {
+    /// Always `"zdcl-bundle"` for this format.
+    pub format: String,
+    /// On-disk schema version. `1` today.
+    pub format_version: u32,
+    /// HEALPix nested-scheme depth used for the bundle's cell sharding.
+    pub cell_depth: u8,
+    /// Total number of cells at `cell_depth` (`12 * 4^depth`). Stored
+    /// redundantly so a reader doesn't have to derive it.
+    pub n_cells: u32,
+    /// Free-text human ops note. Tooling that needs structured params
+    /// should look at `build_metadata` and the per-band entries.
+    pub experiment: String,
+    /// Structured build provenance.
+    pub build_metadata: BuildMetadata,
+    /// Per-cell Gaia-shard summary stats.
+    pub gaia: GaiaBlock,
+    /// One entry per scale band, in `band_idx` order. Array position must
+    /// equal `band_idx` (validated by `load`).
+    pub bands: Vec<BandInfo>,
+}
+
+/// Tooling-facing build provenance block.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BuildMetadata {
+    /// Builder identifier, typically `"<crate-name> <version>"` (e.g.
+    /// `"zodiacal-tools 0.2.0"`).
+    pub tool: String,
+    /// UTC timestamp at which the build phase started. RFC3339 in JSON.
+    pub build_started_utc: DateTime<Utc>,
+    /// UTC timestamp at which the tidy phase finished and the manifest
+    /// was written. RFC3339 in JSON.
+    pub build_finished_utc: DateTime<Utc>,
+    /// What the build was sourced from.
+    pub source: BuildSource,
+}
+
+/// Description of the input data source the build consumed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BuildSource {
+    /// Source-kind tag, e.g. `"starfield-datasources-bycell"`.
+    pub kind: String,
+    /// Catalog release identifier, e.g. `"Dr3"`.
+    pub release: String,
+    /// Resolved on-disk path the build read from. Stringly-typed for
+    /// portability across platforms.
+    pub path: String,
+}
+
+/// Gaia per-cell-shard summary block.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GaiaBlock {
+    /// Total number of Gaia records across all populated cells.
+    pub n_total: u64,
+    /// Per-record byte size. Must equal [`GAIA_RECORD_SIZE`] for v1.
+    pub record_size: u32,
+    /// Per-record schema version (covaries with the bit layout described
+    /// in `docs/bundle-format.md` § "Per-cell file formats").
+    pub schema_version: u32,
+    /// Brightness-truncation cap applied during the build.
+    pub max_stars_per_cell: u32,
+    /// Faintest G-magnitude included in the build.
+    pub mag_limit: f64,
+    /// How many `cell_NNNNN.zga` files the bundle actually carries
+    /// (empty cells are absent on disk).
+    pub populated_cells: u32,
+}
+
+/// One scale-band entry in `BundleManifest::bands`.
+///
+/// `band_idx` is stored explicitly even though it equals the array position;
+/// keeping it in the manifest means consumers don't have to derive it from
+/// position. The on-disk band table inside each `cell_NNNNN.zqd` carries the
+/// same `band_idx`, so `manifest.bands[k].band_idx == on-disk band-table k`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BandInfo {
+    /// Human label, conventionally `"band_NN"` zero-padded.
+    pub label: String,
+    /// Zero-based band index. Array position == band_idx == on-disk
+    /// band-table band_idx (validated by `load`).
+    pub band_idx: u32,
+    /// Lower scale bound for this band's quads, in arcseconds (between
+    /// the closest two stars of the quad).
+    pub scale_lower_arcsec: f64,
+    /// Upper scale bound for this band's quads, in arcseconds.
+    pub scale_upper_arcsec: f64,
+    /// Per-cell quad count cap configured for this band.
+    pub quads_per_cell: u32,
+    /// Per-cell star-reuse cap configured for this band.
+    pub max_reuse: u32,
+    /// Total quads emitted across all populated cells in this band.
+    pub n_quads_total: u64,
+    /// Cells that committed at least one quad in this band.
+    pub populated_cells: u32,
+}
+
+impl BundleManifest {
+    /// Atomic write: serialize to `path.with_extension("json.partial")` (or
+    /// a `.partial` sibling for non-`.json` paths), fsync, then rename
+    /// onto `path`.
+    ///
+    /// On crash mid-write the only on-disk artifact is the orphaned
+    /// `.partial` file; the canonical `path` is untouched. The next
+    /// `save` (or the tidy-phase rerun) overwrites the partial
+    /// idempotently.
+    pub fn save(&self, path: &Path) -> io::Result<()> {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+        let tmp = partial_path_for(path);
+
+        let json = serde_json::to_vec_pretty(self).map_err(io::Error::other)?;
+        {
+            let mut f = File::create(&tmp)?;
+            f.write_all(&json)?;
+            f.sync_all()?;
+        }
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    /// Load and validate a manifest from `path`.
+    ///
+    /// Validates:
+    /// - `format == "zdcl-bundle"`
+    /// - `format_version == 1`
+    /// - `gaia.record_size == 104`
+    /// - `bands` is sorted by `band_idx` ascending and dense from
+    ///   `0..bands.len()` (no gaps, no duplicates, array position equals
+    ///   `band_idx`)
+    ///
+    /// Other invariants (e.g. `n_cells == 12 * 4^cell_depth`,
+    /// per-band `populated_cells <= n_cells`) are not checked here — they
+    /// belong to the consumer that wires the manifest up to actual data.
+    pub fn load(path: &Path) -> io::Result<Self> {
+        let mut buf = String::new();
+        File::open(path)?.read_to_string(&mut buf)?;
+        let m: Self = serde_json::from_str(&buf).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to parse {}: {e}", path.display()),
+            )
+        })?;
+
+        if m.format != FORMAT_MAGIC {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "unexpected bundle format string {:?} (expected {:?})",
+                    m.format, FORMAT_MAGIC
+                ),
+            ));
+        }
+
+        match m.format_version {
+            FORMAT_VERSION => {}
+            other => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "unsupported bundle format_version {other} (this build supports {FORMAT_VERSION})",
+                    ),
+                ));
+            }
+        }
+
+        if m.gaia.record_size != GAIA_RECORD_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "gaia.record_size = {} but this build expects {GAIA_RECORD_SIZE}",
+                    m.gaia.record_size
+                ),
+            ));
+        }
+
+        for (pos, band) in m.bands.iter().enumerate() {
+            if band.band_idx as usize != pos {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "bands[{pos}].band_idx = {} (expected dense 0..{} layout, position {pos})",
+                        band.band_idx,
+                        m.bands.len(),
+                    ),
+                ));
+            }
+        }
+
+        Ok(m)
+    }
+}
+
+/// Compute the `.partial` sibling path used for atomic writes.
+fn partial_path_for(path: &Path) -> std::path::PathBuf {
+    let mut s = path.as_os_str().to_owned();
+    s.push(".partial");
+    std::path::PathBuf::from(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn band(idx: u32) -> BandInfo {
+        // Use a non-SQRT_2 multiplier to avoid clippy::approx_constant on
+        // 1.4142; the exact value doesn't matter for round-trip tests.
+        let factor: f64 = 1.5_f64.powi(idx as i32);
+        BandInfo {
+            label: format!("band_{idx:02}"),
+            band_idx: idx,
+            scale_lower_arcsec: 10.0 * factor,
+            scale_upper_arcsec: 15.0 * factor,
+            quads_per_cell: 100,
+            max_reuse: 8,
+            n_quads_total: 1_228_800 - 100 * idx as u64,
+            populated_cells: 12_288 - idx,
+        }
+    }
+
+    fn sample_manifest(n_bands: u32) -> BundleManifest {
+        // Use an explicit fixed timestamp so JSON output is deterministic
+        // across test machines / clocks.
+        let started: DateTime<Utc> = "2026-05-05T01:08:57Z".parse().unwrap();
+        let finished: DateTime<Utc> = "2026-05-05T02:18:42Z".parse().unwrap();
+        BundleManifest {
+            format: FORMAT_MAGIC.to_string(),
+            format_version: FORMAT_VERSION,
+            cell_depth: 5,
+            n_cells: 12_288,
+            experiment: "test fixture".to_string(),
+            build_metadata: BuildMetadata {
+                tool: "zodiacal-tools 0.2.0".to_string(),
+                build_started_utc: started,
+                build_finished_utc: finished,
+                source: BuildSource {
+                    kind: "starfield-datasources-bycell".to_string(),
+                    release: "Dr3".to_string(),
+                    path: "/cache/dr3-mag20-bycell".to_string(),
+                },
+            },
+            gaia: GaiaBlock {
+                n_total: 112_080_742,
+                record_size: GAIA_RECORD_SIZE,
+                schema_version: 1,
+                max_stars_per_cell: 10_000,
+                mag_limit: 20.0,
+                populated_cells: 12_288,
+            },
+            bands: (0..n_bands).map(band).collect(),
+        }
+    }
+
+    fn tmp_path(name: &str) -> std::path::PathBuf {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let p = dir.path().join(name);
+        // Leak the tempdir's drop guard for test simplicity — the OS
+        // tmp dir will be cleaned by the system, and tests don't share
+        // names. We keep the dir alive for the duration of the test
+        // body by leaking the handle.
+        std::mem::forget(dir);
+        p
+    }
+
+    #[test]
+    fn roundtrip_minimal() {
+        let m = sample_manifest(1);
+        let path = tmp_path("manifest_min.json");
+        m.save(&path).unwrap();
+        let loaded = BundleManifest::load(&path).unwrap();
+        assert_eq!(loaded, m);
+    }
+
+    #[test]
+    fn roundtrip_multi_band() {
+        let m = sample_manifest(12);
+        let path = tmp_path("manifest_multi.json");
+        m.save(&path).unwrap();
+        let loaded = BundleManifest::load(&path).unwrap();
+        assert_eq!(loaded, m);
+        assert_eq!(loaded.bands.len(), 12);
+        for (i, b) in loaded.bands.iter().enumerate() {
+            assert_eq!(b.band_idx as usize, i);
+            assert_eq!(b.label, format!("band_{i:02}"));
+        }
+    }
+
+    #[test]
+    fn load_rejects_bad_format() {
+        let mut m = sample_manifest(1);
+        m.format = "wrong".to_string();
+        let path = tmp_path("manifest_badfmt.json");
+        m.save(&path).unwrap();
+        let err = BundleManifest::load(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("format string"));
+    }
+
+    #[test]
+    fn load_rejects_bad_format_version() {
+        let mut m = sample_manifest(1);
+        m.format_version = 99;
+        let path = tmp_path("manifest_badver.json");
+        m.save(&path).unwrap();
+        let err = BundleManifest::load(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("format_version"));
+    }
+
+    #[test]
+    fn load_rejects_bad_record_size() {
+        let mut m = sample_manifest(1);
+        m.gaia.record_size = 88;
+        let path = tmp_path("manifest_badrec.json");
+        m.save(&path).unwrap();
+        let err = BundleManifest::load(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("record_size"));
+    }
+
+    #[test]
+    fn load_rejects_band_idx_gap() {
+        let mut m = sample_manifest(2);
+        // Skip 1: bands[0] = 0, bands[1] = 2 (gap at 1).
+        m.bands[1].band_idx = 2;
+        m.bands[1].label = "band_02".to_string();
+        let path = tmp_path("manifest_gap.json");
+        m.save(&path).unwrap();
+        let err = BundleManifest::load(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("band_idx"));
+    }
+
+    #[test]
+    fn save_is_atomic() {
+        let m = sample_manifest(3);
+        let path = tmp_path("manifest_atomic.json");
+        m.save(&path).unwrap();
+
+        let partial = partial_path_for(&path);
+        assert!(
+            !partial.exists(),
+            "leftover partial sibling: {}",
+            partial.display()
+        );
+        assert!(path.exists());
+        // And the file parses cleanly.
+        let _loaded = BundleManifest::load(&path).unwrap();
+    }
+
+    #[test]
+    fn save_overwrites_atomically() {
+        let m1 = sample_manifest(1);
+        let m2 = sample_manifest(4);
+        let path = tmp_path("manifest_overwrite.json");
+
+        m1.save(&path).unwrap();
+        m2.save(&path).unwrap();
+
+        // No partial residue; second save's content fully replaced first.
+        let partial = partial_path_for(&path);
+        assert!(!partial.exists());
+        let loaded = BundleManifest::load(&path).unwrap();
+        assert_eq!(loaded, m2);
+        assert_eq!(loaded.bands.len(), 4);
+    }
+}

--- a/src/bundle/mod.rs
+++ b/src/bundle/mod.rs
@@ -3,10 +3,11 @@
 //! See `docs/bundle-format.md` for the full specification.
 //!
 //! This module currently provides the storage abstraction
-//! (`accessor::SubfileAccessor`) used by the bundle reader and the
-//! per-cell shard formats; the higher-level `ZdclBundle` reader is
-//! added in follow-up PRs.
+//! (`accessor::SubfileAccessor`) used by the bundle reader, the
+//! per-cell shard formats, and the manifest schema; the higher-level
+//! `ZdclBundle` reader is added in follow-up PRs.
 
 pub mod accessor;
 pub mod gaia_shard;
+pub mod manifest;
 pub mod quad_shard;

--- a/src/index/build_manifest.rs
+++ b/src/index/build_manifest.rs
@@ -52,6 +52,21 @@ pub struct BuildManifest {
     /// and avoids a sum on resume.
     pub n_stars: u64,
     pub n_quads: u64,
+    /// Per-scale-band per-cell completion tracking for the multi-band
+    /// cell-driven builder.
+    ///
+    /// `completed_per_band[k]` is the set of cells that have committed
+    /// quads for band `k` to the work-dir's per-cell `.zqd` file. A
+    /// build that crashed after committing bands `[0..3]` for a cell
+    /// but before band `4` resumes only band `4` for that cell.
+    ///
+    /// Empty when the build is single-band (legacy compat). The
+    /// `#[serde(default)]` makes manifests written by the OLD code
+    /// (without this field) still parse cleanly under the new code.
+    /// Multi-band builders call [`BuildManifest::ensure_per_band`] at
+    /// start to size this to `n_bands` empty sets.
+    #[serde(default)]
+    pub completed_per_band: Vec<BTreeSet<u32>>,
 }
 
 impl Default for BuildManifest {
@@ -62,6 +77,7 @@ impl Default for BuildManifest {
             cell_stats: Vec::new(),
             n_stars: 0,
             n_quads: 0,
+            completed_per_band: Vec::new(),
         }
     }
 }
@@ -162,6 +178,50 @@ impl BuildManifest {
     /// already-committed cells on resume.
     pub fn is_complete(&self, cell_id: u32) -> bool {
         self.completed_cells.contains(&cell_id)
+    }
+
+    /// Initialize `completed_per_band` to `n_bands` empty sets, *if* it
+    /// is currently empty. Idempotent: calling this once at the start
+    /// of a multi-band build is safe; calling it again on resume with
+    /// the same `n_bands` is a no-op.
+    ///
+    /// This intentionally does **not** truncate or grow a non-empty
+    /// `completed_per_band`. A multi-band build that wants to rebuild
+    /// at a different band count must clear `completed_per_band`
+    /// explicitly first; otherwise resume would silently change band
+    /// semantics.
+    pub fn ensure_per_band(&mut self, n_bands: usize) {
+        if self.completed_per_band.is_empty() && n_bands > 0 {
+            self.completed_per_band.resize_with(n_bands, BTreeSet::new);
+        }
+    }
+
+    /// True if cell `cell_id`'s band `band_idx` has been committed.
+    ///
+    /// Returns `false` for any `band_idx` outside the current
+    /// `completed_per_band` length (including the legacy empty-vec
+    /// case), so single-band call sites that never call
+    /// `ensure_per_band` get a sensible default.
+    pub fn is_band_complete(&self, cell_id: u32, band_idx: u32) -> bool {
+        self.completed_per_band
+            .get(band_idx as usize)
+            .is_some_and(|set| set.contains(&cell_id))
+    }
+
+    /// Mark cell `cell_id`'s band `band_idx` as committed.
+    ///
+    /// Idempotent: marking the same `(cell, band)` twice is a no-op.
+    /// If `completed_per_band` is shorter than `band_idx + 1` it is
+    /// extended with empty sets to fit. This means callers that build
+    /// without an explicit `ensure_per_band` still get correct
+    /// per-band tracking, just with a `completed_per_band.len()` that
+    /// reflects only the bands actually marked.
+    pub fn mark_band_complete(&mut self, cell_id: u32, band_idx: u32) {
+        let needed = band_idx as usize + 1;
+        if self.completed_per_band.len() < needed {
+            self.completed_per_band.resize_with(needed, BTreeSet::new);
+        }
+        self.completed_per_band[band_idx as usize].insert(cell_id);
     }
 }
 
@@ -291,5 +351,84 @@ mod tests {
         assert!(!partial.exists(), "leftover partial: {}", partial.display());
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn per_band_legacy_compat() {
+        // A manifest written by the OLD code (pre-`completed_per_band`)
+        // must round-trip through the NEW deserializer with an empty
+        // `completed_per_band`. The `#[serde(default)]` attribute is
+        // what makes this work.
+        let dir = tmp_dir("legacy");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = BuildManifest::path_in(&dir);
+        // Hand-rolled JSON without the new field. Mirrors what the
+        // pre-PR2 code would have written.
+        std::fs::write(
+            &path,
+            r#"{"version":1,"completed_cells":[3,7],"cell_stats":[[3,{"n_stars":10,"n_quads":4}],[7,{"n_stars":5,"n_quads":2}]],"n_stars":15,"n_quads":6}"#,
+        )
+        .unwrap();
+
+        let loaded = BuildManifest::load(&dir).unwrap().expect("manifest");
+        assert!(loaded.completed_per_band.is_empty());
+        // Existing fields still populate from the legacy JSON.
+        assert_eq!(loaded.completed_cells.len(), 2);
+        assert!(loaded.is_complete(3));
+        assert!(loaded.is_complete(7));
+        assert_eq!(loaded.n_stars, 15);
+        assert_eq!(loaded.n_quads, 6);
+        // And band queries on the legacy manifest answer false (no
+        // band tracking yet).
+        assert!(!loaded.is_band_complete(3, 0));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn mark_band_complete_grows_set() {
+        let mut m = BuildManifest::default();
+        m.ensure_per_band(3);
+        assert_eq!(m.completed_per_band.len(), 3);
+        for set in &m.completed_per_band {
+            assert!(set.is_empty());
+        }
+
+        m.mark_band_complete(5, 1);
+        assert!(m.is_band_complete(5, 1));
+        assert!(!m.is_band_complete(5, 0));
+        assert!(!m.is_band_complete(5, 2));
+        // Out-of-range bands answer false rather than panicking.
+        assert!(!m.is_band_complete(5, 99));
+        // Other cells unaffected.
+        assert!(!m.is_band_complete(4, 1));
+    }
+
+    #[test]
+    fn mark_band_complete_idempotent() {
+        let mut m = BuildManifest::default();
+        m.ensure_per_band(2);
+
+        m.mark_band_complete(7, 0);
+        m.mark_band_complete(7, 0);
+        m.mark_band_complete(7, 0);
+
+        assert!(m.is_band_complete(7, 0));
+        // BTreeSet membership is set semantics — len stays 1.
+        assert_eq!(m.completed_per_band[0].len(), 1);
+    }
+
+    #[test]
+    fn ensure_per_band_is_idempotent() {
+        // Two calls in a row must not clobber per-band state. This is
+        // the "resume of a multi-band build" path.
+        let mut m = BuildManifest::default();
+        m.ensure_per_band(4);
+        m.mark_band_complete(11, 2);
+
+        m.ensure_per_band(4);
+        assert_eq!(m.completed_per_band.len(), 4);
+        assert!(m.is_band_complete(11, 2));
     }
 }


### PR DESCRIPTION
## Summary

Final foundation piece of the bundle-format roadmap. Two distinct types in one PR (they share the spec section and naturally co-evolve):

1. **`BundleManifest`** (NEW) — the on-disk `manifest.json` schema for finalized bundles. Atomic save (tmp + fsync + rename), validated load.
2. **`BuildManifest` extension** — the existing in-build resume primitive (#70) gains per-band-per-cell completion tracking, so a build that crashed after committing bands [0..3] but before band 4 can resume exactly band 4 instead of redoing all bands.

See `docs/bundle-format.md` § "Manifest" for the JSON shape and the roadmap's PR 2 entry for scope.

## What lands

### `src/bundle/manifest.rs` — `BundleManifest`

Serde-derived struct matching the spec's JSON shape exactly:

```rust
pub struct BundleManifest {
    pub format: String,                  // "zdcl-bundle"
    pub format_version: u32,             // 1
    pub cell_depth: u8,
    pub n_cells: u32,
    pub experiment: String,              // free-text human ops note
    pub build_metadata: BuildMetadata,
    pub gaia: GaiaBlock,
    pub bands: Vec<BandInfo>,
}
```

with sub-types `BuildMetadata` / `BuildSource` / `GaiaBlock` / `BandInfo`. `BandInfo` carries an explicit `band_idx: u32` so consumers don't have to derive it from array position; doc clarifies the convention "array position == band_idx == on-disk band-table band_idx" per the spec's request.

API:

- `BundleManifest::save(&self, path)` — atomic write via `.partial` sibling + fsync + rename. Idempotent.
- `BundleManifest::load(path)` — read JSON, validate `format == "zdcl-bundle"`, `format_version == 1`, `gaia.record_size == 104`, bands sorted ascending with no `band_idx` gaps from 0. Each rejection has a clear error message.

### `src/index/build_manifest.rs` — extension

Existing `BuildManifest` (from PR #70) gains:

```rust
/// One entry per scale band. Each entry is the set of cells that have
/// committed quads for that band. Empty when the build is single-band.
#[serde(default)]
pub completed_per_band: Vec<BTreeSet<u32>>,
```

`#[serde(default)]` is the magic that makes "old manifests read by new code" parse cleanly — verified explicitly by `per_band_legacy_compat` test that constructs an old-format JSON string without the field and asserts it round-trips.

Plus three helpers: `is_band_complete`, `mark_band_complete`, `ensure_per_band(n_bands)`.

## Tests (12 / 12 passing)

`bundle::manifest` (8):
- `roundtrip_minimal`, `roundtrip_multi_band` — write → load parity for 1 band and 12 bands
- `load_rejects_bad_format`, `load_rejects_bad_format_version`, `load_rejects_bad_record_size` — validation rejects malformed inputs
- `load_rejects_band_idx_gap` — non-dense `band_idx` values rejected
- `save_is_atomic` — no `.partial` sibling left on success; rerun overwrites cleanly
- `save_overwrites_atomically` — second save is observably atomic

`index::build_manifest` (4 new + 5 pre-existing all green):
- `per_band_legacy_compat` — old-format JSON parses, defaults `completed_per_band` to empty
- `mark_band_complete_grows_set` — set growth is correct
- `mark_band_complete_idempotent` — double calls don't double-count or panic
- `ensure_per_band_is_idempotent` — bonus, since the doc advertises idempotence

Full lib suite at 204/204. `cargo clippy --lib --all-targets -- -D warnings` clean. `cargo fmt --all` no-op.

## Cargo deps added

- `chrono = { version = "0.4", features = ["serde"] }` — for the UTC timestamp fields in `BuildMetadata`.
- `tempfile = "3.10"` as a dev-dep (the agents converged on the same version).

## Design choices worth review

1. **Explicit `band_idx` in `BandInfo`** even though it could be derived from array position. The on-disk band table inside per-cell `.zqd` files (see `bundle/quad-shard`, [#77](https://github.com/OrbitalCommons/zodiacal/pull/77)) carries `band_idx` per entry; keeping the manifest authoritative means a consumer reading both never has to cross-check derived vs stored values.
2. **`#[serde(default)]` for `completed_per_band`** is the cross-version compat lever. Old PR #70 manifests still parse with the new code, treated as "single-band build."
3. **Strict load-time validation** (format, format_version, record_size, band_idx denseness) up-front to catch corruption / drift early rather than letting downstream code fail mysteriously.

## Roadmap

PR 2 of [#74](https://github.com/OrbitalCommons/zodiacal/pull/74)'s 7-PR plan. Companions:

- PR 1 piece A: [#75](https://github.com/OrbitalCommons/zodiacal/pull/75) (SubfileAccessor)
- PR 1 piece B: [#77](https://github.com/OrbitalCommons/zodiacal/pull/77) (`.zqd`)
- PR 1 piece C: [#76](https://github.com/OrbitalCommons/zodiacal/pull/76) (`.zga` + `GaiaRecord`)

This + the three above land the full PR1+PR2 foundation. Next up: PR 3 multi-band cell-driven builder, which consumes the band table from this manifest plus the file formats in #76 / #77.

## Test plan

- [x] `cargo test --lib bundle::manifest:: index::build_manifest::` — 12/12
- [x] `cargo test --lib` — 204/204
- [x] `cargo clippy --lib --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] CI check on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)