### PR TITLE
bundle: sweep follow-ups (#83 #85 #86 #87 #88)

### DIFF
--- a/src/bundle/accessor.rs
+++ b/src/bundle/accessor.rs
@@ -648,6 +648,112 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 
+    /// Empty bundle directory: list_prefix("") returns [], exists()
+    /// returns false for any name.
+    #[test]
+    fn fs_empty_bundle_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let acc = FsAccessor::open(tmp.path()).expect("open FsAccessor");
+        let listed = acc.list_prefix("").expect("list_prefix");
+        assert!(listed.is_empty(), "expected empty listing, got {listed:?}");
+        assert!(!acc.exists("anything"));
+        assert!(!acc.exists("manifest.json"));
+    }
+
+    /// A zero-byte file in the bundle: read_entry returns an empty
+    /// EntryBytes without panicking from the mmap path.
+    #[test]
+    fn fs_zero_byte_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("empty.bin");
+        File::create(&path).expect("create empty file");
+        let acc = FsAccessor::open(tmp.path()).expect("open FsAccessor");
+        let bytes = acc.read_entry("empty.bin").expect("read empty");
+        assert_eq!(&bytes[..], b"");
+    }
+
+    /// Many entries (≥ 100) round-trip via FsAccessor.
+    #[test]
+    fn fs_many_entries_roundtrip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let n: u32 = 128;
+        for i in 0..n {
+            let path = tmp.path().join(format!("entry_{i:04}.bin"));
+            std::fs::write(&path, i.to_le_bytes()).expect("write entry");
+        }
+        let acc = FsAccessor::open(tmp.path()).expect("open FsAccessor");
+        let listed = acc.list_prefix("").expect("list_prefix");
+        assert_eq!(listed.len(), n as usize);
+        for i in 0..n {
+            let rel = format!("entry_{i:04}.bin");
+            let got = acc.read_entry(&rel).expect("read entry");
+            assert_eq!(&got[..], &i.to_le_bytes()[..]);
+        }
+    }
+
+    /// FsAccessor must be able to read a hidden file (`.foo`).
+    #[test]
+    fn fs_hidden_file_reachable() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join(".foo"), b"hidden").expect("write hidden");
+        let acc = FsAccessor::open(tmp.path()).expect("open FsAccessor");
+        assert!(acc.exists(".foo"));
+        let got = acc.read_entry(".foo").expect("read hidden");
+        assert_eq!(&got[..], b"hidden");
+    }
+
+    /// ZipAccessor on a zip with a single zero-byte stored entry must
+    /// round-trip cleanly.
+    #[test]
+    fn zip_zero_byte_stored_entry() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let zip_path = tmp.path().join("empty.zip");
+        let f = File::create(&zip_path).expect("create zip");
+        let mut zw = zip::write::ZipWriter::new(f);
+        let opts =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        zw.start_file("empty.bin", opts).expect("start zip entry");
+        // No bytes written.
+        zw.finish().expect("finish zip");
+
+        let acc = ZipAccessor::open(&zip_path).expect("open ZipAccessor");
+        assert!(acc.exists("empty.bin"));
+        let got = acc.read_entry("empty.bin").expect("read empty zip entry");
+        assert_eq!(&got[..], b"");
+    }
+
+    /// ZipAccessor must handle a single archive that mixes Stored and
+    /// Deflated compression methods.
+    #[test]
+    fn zip_mixed_stored_and_deflated() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let zip_path = tmp.path().join("mixed.zip");
+        let f = File::create(&zip_path).expect("create zip");
+        let mut zw = zip::write::ZipWriter::new(f);
+
+        let stored =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        zw.start_file("stored.bin", stored).expect("start stored");
+        zw.write_all(b"raw bytes").expect("write stored");
+
+        let deflated =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        zw.start_file("deflated.bin", deflated)
+            .expect("start deflated");
+        // Use a payload that compresses well so the stored and deflated
+        // sizes diverge — confirms the reader actually decompresses.
+        let payload: Vec<u8> = std::iter::repeat_n(b'a', 2048).collect();
+        zw.write_all(&payload).expect("write deflated");
+
+        zw.finish().expect("finish zip");
+
+        let acc = ZipAccessor::open(&zip_path).expect("open ZipAccessor");
+        let stored_got = acc.read_entry("stored.bin").expect("read stored");
+        assert_eq!(&stored_got[..], b"raw bytes");
+        let deflated_got = acc.read_entry("deflated.bin").expect("read deflated");
+        assert_eq!(&deflated_got[..], &payload[..]);
+    }
+
     /// A symlink that lives *inside* the bundle root but points to a
     /// file *outside* the root is the canonical case the canonicalize
     /// step has to catch (lexical checks alone won't notice).

--- a/src/bundle/gaia_shard.rs
+++ b/src/bundle/gaia_shard.rs
@@ -16,6 +16,11 @@ use std::io::{self, Write};
 
 use bytemuck::{Pod, Zeroable};
 
+#[cfg(target_endian = "big")]
+compile_error!(
+    "GaiaRecord on-disk layout assumes little-endian; big-endian targets are not supported."
+);
+
 /// Magic bytes at the start of every `.zga` file.
 pub const MAGIC: &[u8; 8] = b"ZDCLGAIA";
 
@@ -189,6 +194,21 @@ pub fn write_gaia_shard<W: Write>(
 ) -> io::Result<()> {
     records.sort_by_key(|r| r.source_id);
 
+    // After sorting, duplicate source_ids are necessarily adjacent. The
+    // reader uses binary search by source_id; duplicates would silently
+    // shadow one another, so reject them at write time.
+    for pair in records.windows(2) {
+        if pair[0].source_id == pair[1].source_id {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "duplicate source_id {} in gaia shard input",
+                    pair[0].source_id
+                ),
+            ));
+        }
+    }
+
     // Header: 32 bytes, all little-endian.
     let n_records: u32 = records
         .len()
@@ -216,7 +236,6 @@ pub fn write_gaia_shard<W: Write>(
 /// `parse` is O(1) modulo the alignment + bounds checks.
 #[derive(Debug)]
 pub struct GaiaShard<'a> {
-    raw: &'a [u8],
     cell_id: u64,
     records: &'a [GaiaRecord],
 }
@@ -304,11 +323,7 @@ impl<'a> GaiaShard<'a> {
             ))
         })?;
 
-        Ok(Self {
-            raw: bytes,
-            cell_id,
-            records,
-        })
+        Ok(Self { cell_id, records })
     }
 
     /// HEALPix cell id this shard covers (defensive duplication of the
@@ -352,12 +367,6 @@ impl<'a> GaiaShard<'a> {
     #[inline]
     pub fn records(&self) -> &[GaiaRecord] {
         self.records
-    }
-
-    /// Raw underlying bytes (header + records).
-    #[inline]
-    pub fn raw(&self) -> &[u8] {
-        self.raw
     }
 }
 
@@ -687,6 +696,122 @@ mod tests {
         // And non-NaN fields survived too.
         assert_eq!(got.source_id, 42);
         assert_eq!(got.phot_g_mean_mag, 12.5);
+    }
+
+    #[test]
+    fn duplicate_source_id_rejected() {
+        // Two records with the same source_id must be rejected at write
+        // time — readers binary-search by source_id and a duplicate would
+        // silently shadow one of them.
+        let mut records = vec![make_record(42, 12.0), make_record(42, 13.0)];
+        let mut buf = Vec::new();
+        let err = write_gaia_shard(&mut buf, 0, &mut records).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("duplicate"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_rejects_misaligned_slice() {
+        // GaiaRecord requires 8-byte alignment. Build a valid shard, then
+        // hand the parser a sub-slice starting one byte in: the records
+        // region is no longer 8-aligned and parse must error rather than
+        // panic from inside bytemuck.
+        let mut records = vec![make_record(1, 12.0), make_record(2, 12.0)];
+        let mut prefixed = vec![0u8]; // one stray byte to misalign the rest
+        write_gaia_shard(&mut prefixed, 0, &mut records).unwrap();
+        let mis = &prefixed[1..];
+        // Header parses fine; the bytemuck cast must fail when records
+        // start at an offset that puts them on a 1-mod-8 byte boundary.
+        // We can't predict alignment of `prefixed`'s allocation, so retry
+        // on an explicitly-aligned buffer if the first attempt happens
+        // to land aligned.
+        let err = match GaiaShard::parse(mis) {
+            Ok(_) => {
+                // Allocator gave an unlucky address; rebuild with a wider
+                // prefix to force misalignment relative to the
+                // allocation base.
+                let mut records2 = vec![make_record(1, 12.0), make_record(2, 12.0)];
+                let mut prefixed2 = vec![0u8; 3];
+                write_gaia_shard(&mut prefixed2, 0, &mut records2).unwrap();
+                let off = (prefixed2.as_ptr() as usize) & 7;
+                // Pick a slice start such that records (at HEADER_SIZE
+                // bytes in) land on an odd byte from the underlying
+                // allocation.
+                let skew = if off == 0 { 1 } else { 8 - off + 1 };
+                assert!(
+                    skew < prefixed2.len(),
+                    "could not construct a misaligned slice"
+                );
+                let mis2 = &prefixed2[skew..];
+                GaiaShard::parse(mis2).expect_err("misaligned slice must error")
+            }
+            Err(e) => e,
+        };
+        // Bytemuck reports an alignment error via io::Error::other,
+        // which has kind `Other`.
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert!(err.to_string().contains("misaligned"), "got: {err}");
+    }
+
+    #[test]
+    fn header_byte_layout() {
+        // Pin the exact 32-byte header layout. Empty shard for simplicity
+        // (the header is identical regardless of n_records).
+        let mut records: Vec<GaiaRecord> = Vec::new();
+        let mut buf = Vec::new();
+        write_gaia_shard(&mut buf, 0x0123_4567_89AB_CDEF, &mut records).unwrap();
+        assert_eq!(buf.len(), HEADER_SIZE);
+
+        let expected: [u8; 32] = [
+            // magic "ZDCLGAIA"
+            b'Z', b'D', b'C', b'L', b'G', b'A', b'I', b'A', // version = 1 (u32 LE)
+            0x01, 0x00, 0x00, 0x00, // record_size = 104 (u32 LE)
+            0x68, 0x00, 0x00, 0x00, // cell_id = 0x0123_4567_89AB_CDEF (u64 LE)
+            0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01, // n_records = 0 (u32 LE)
+            0x00, 0x00, 0x00, 0x00, // reserved padding
+            0x00, 0x00, 0x00, 0x00,
+        ];
+        assert_eq!(&buf[..], &expected[..]);
+    }
+
+    #[test]
+    fn edge_source_ids_roundtrip() {
+        // 0 and u64::MAX coexist as source_ids.
+        let mut records = vec![make_record(0, 12.0), make_record(u64::MAX, 13.0)];
+        let mut buf = Vec::new();
+        write_gaia_shard(&mut buf, 1, &mut records).unwrap();
+        let shard = GaiaShard::parse(&buf).unwrap();
+        assert_eq!(shard.len(), 2);
+        assert_eq!(shard.find(0).unwrap().source_id, 0);
+        assert_eq!(shard.find(u64::MAX).unwrap().source_id, u64::MAX);
+
+        // A supplement-bit-set id (bit 63 set) coexists with a normal id.
+        let supplement_id = 1u64 << 63;
+        let mut records2 = vec![make_record(100, 12.0), make_record(supplement_id, 5.0)];
+        let mut buf2 = Vec::new();
+        write_gaia_shard(&mut buf2, 2, &mut records2).unwrap();
+        let shard2 = GaiaShard::parse(&buf2).unwrap();
+        assert_eq!(shard2.len(), 2);
+        let normal = shard2.find(100).expect("normal id");
+        assert_eq!(normal.hip_number(), None);
+        let supp = shard2.find(supplement_id).expect("supplement id");
+        // hip_number recovers the low 31 bits (zero in this case).
+        assert_eq!(supp.hip_number(), Some(0));
+    }
+
+    #[test]
+    fn parse_rejects_inflated_n_records() {
+        // Write a valid 2-record shard, then patch n_records up to a value
+        // larger than the slice can hold. Parse must reject rather than
+        // walk off the end of the buffer.
+        let mut records = vec![make_record(1, 12.0), make_record(2, 13.0)];
+        let mut buf = Vec::new();
+        write_gaia_shard(&mut buf, 0, &mut records).unwrap();
+        let bogus: u32 = 1_000_000;
+        buf[24..28].copy_from_slice(&bogus.to_le_bytes());
+        let err = GaiaShard::parse(&buf).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("truncated"), "got: {err}");
     }
 
     #[test]

--- a/src/bundle/manifest.rs
+++ b/src/bundle/manifest.rs
@@ -166,12 +166,15 @@ pub struct BandInfo {
 impl BundleManifest {
     /// Atomic write: serialize to `path.with_extension("json.partial")` (or
     /// a `.partial` sibling for non-`.json` paths), fsync, then rename
-    /// onto `path`.
+    /// onto `path`. After the rename, fsync the parent directory so the
+    /// rename is durable across power loss.
     ///
     /// On crash mid-write the only on-disk artifact is the orphaned
     /// `.partial` file; the canonical `path` is untouched. The next
     /// `save` (or the tidy-phase rerun) overwrites the partial
-    /// idempotently.
+    /// idempotently. If serialization or write fails before the rename,
+    /// the partial file is removed before this function returns the
+    /// error so the on-disk tree stays clean.
     pub fn save(&self, path: &Path) -> io::Result<()> {
         if let Some(parent) = path.parent()
             && !parent.as_os_str().is_empty()
@@ -180,13 +183,38 @@ impl BundleManifest {
         }
         let tmp = partial_path_for(path);
 
-        let json = serde_json::to_vec_pretty(self).map_err(io::Error::other)?;
-        {
+        // Wrap pre-rename work in a closure so any failure path can fall
+        // through to the cleanup step. Rust has no try/finally, so we
+        // match on the result and remove the partial on error.
+        let result: io::Result<()> = (|| {
+            let json = serde_json::to_vec_pretty(self).map_err(io::Error::other)?;
             let mut f = File::create(&tmp)?;
             f.write_all(&json)?;
             f.sync_all()?;
+            Ok(())
+        })();
+        if let Err(e) = result {
+            // Best-effort cleanup of the partial; ignore NotFound (the
+            // File::create may have failed before the file was created).
+            match std::fs::remove_file(&tmp) {
+                Ok(()) => {}
+                Err(rm_err) if rm_err.kind() == io::ErrorKind::NotFound => {}
+                Err(_) => {}
+            }
+            return Err(e);
         }
+
         std::fs::rename(&tmp, path)?;
+
+        // fsync the parent directory so the rename's directory-entry
+        // change is durable. Unix-only; we don't support Windows.
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            // Read-only handle is sufficient for sync_all on a directory.
+            let dir = File::open(parent)?;
+            dir.sync_all()?;
+        }
         Ok(())
     }
 
@@ -417,6 +445,33 @@ mod tests {
         assert!(path.exists());
         // And the file parses cleanly.
         let _loaded = BundleManifest::load(&path).unwrap();
+    }
+
+    #[test]
+    fn save_with_missing_parent_errors_and_leaves_no_partial() {
+        // Point the save at a path whose parent directory does not
+        // exist. The save must error and must not leave a stray
+        // `.partial` file behind.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let nonexistent_parent = dir.path().join("does_not_exist");
+        let path = nonexistent_parent.join("nope").join("manifest.json");
+
+        let m = sample_manifest(1);
+        // Force the parent-dir failure by making the intermediate path
+        // *not creatable*: pre-create a regular file at the spot where
+        // create_dir_all would need a directory.
+        std::fs::write(&nonexistent_parent, b"i am not a directory").expect("seed blocking file");
+        let err = m.save(&path).expect_err("save should fail");
+        let _ = err.kind();
+
+        // No `.partial` should have been created at the canonical path
+        // (which itself does not exist) or alongside the blocking file.
+        let partial = partial_path_for(&path);
+        assert!(
+            !partial.exists(),
+            "leftover partial after failed save: {}",
+            partial.display()
+        );
     }
 
     #[test]

--- a/src/bundle/quad_shard.rs
+++ b/src/bundle/quad_shard.rs
@@ -44,6 +44,11 @@ use std::io::{self, Write};
 
 use crate::quads::{Code, DIMCODES, DIMQUADS, Quad};
 
+#[cfg(target_endian = "big")]
+compile_error!(
+    "Quad shard on-disk layout assumes little-endian; big-endian targets are not supported."
+);
+
 /// 8-byte file magic identifying a per-cell quad shard.
 pub const QUAD_SHARD_MAGIC: &[u8; 8] = b"ZDCLQUAD";
 
@@ -365,9 +370,9 @@ impl<'a> QuadShard<'a> {
                     ),
                 ));
             }
-            // Empty bands are allowed (n_quads == 0); the offsets must
-            // still land inside the file but the blocks have zero length.
             if nq > 0 {
+                // Populated bands' offsets must clear the header +
+                // band-table region.
                 if (quads_offset as usize) < band_table_end {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
@@ -386,6 +391,32 @@ impl<'a> QuadShard<'a> {
                         ),
                     ));
                 }
+            } else {
+                // Invariant for empty bands (n_quads == 0): the writer
+                // emits zero bytes between the quads_offset and
+                // codes_offset bookmarks, so the two must compare equal
+                // and must point at a valid in-slice byte (at or beyond
+                // the band table, at or before the slice end).
+                if quads_offset != codes_offset {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "empty band {band_idx} has quads_offset={quads_offset} != \
+                             codes_offset={codes_offset}; expected equal offsets"
+                        ),
+                    ));
+                }
+                if (quads_offset as usize) < band_table_end || (quads_offset as usize) > bytes.len()
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "empty band {band_idx} offset {quads_offset} outside data \
+                             region [{band_table_end}, {})",
+                            bytes.len()
+                        ),
+                    ));
+                }
             }
 
             band_table.push(BandEntry {
@@ -396,8 +427,9 @@ impl<'a> QuadShard<'a> {
             });
         }
 
-        // The on-disk band table is required to be monotonic (the writer
-        // sorts; readers rely on that for binary-search lookup).
+        // The on-disk band table is required to be strictly monotonic in
+        // band_idx (the writer sorts; readers rely on that for
+        // binary-search lookup).
         for pair in band_table.windows(2) {
             if pair[0].band_idx >= pair[1].band_idx {
                 return Err(io::Error::new(
@@ -406,6 +438,40 @@ impl<'a> QuadShard<'a> {
                         "band table not strictly ascending by band_idx: \
                          {} followed by {}",
                         pair[0].band_idx, pair[1].band_idx
+                    ),
+                ));
+            }
+        }
+
+        // Validate that no two band data regions overlap. Each populated
+        // band contributes two regions (quads block, codes block); empty
+        // bands contribute none. We collect, sort by start, then walk
+        // pairwise.
+        let mut regions: Vec<(usize, usize, u32, &'static str)> =
+            Vec::with_capacity(band_table.len() * 2);
+        for entry in &band_table {
+            let nq = entry.n_quads as usize;
+            if nq == 0 {
+                continue;
+            }
+            let q_start = entry.quads_offset as usize;
+            let q_end = q_start + nq * QUAD_RECORD_SIZE;
+            let c_start = entry.codes_offset as usize;
+            let c_end = c_start + nq * CODE_RECORD_SIZE;
+            regions.push((q_start, q_end, entry.band_idx, "quads"));
+            regions.push((c_start, c_end, entry.band_idx, "codes"));
+        }
+        regions.sort_by_key(|r| r.0);
+        for w in regions.windows(2) {
+            let (a_start, a_end, a_band, a_kind) = w[0];
+            let (b_start, b_end, b_band, b_kind) = w[1];
+            if a_end > b_start {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "band data regions overlap: band {a_band} {a_kind} \
+                         [{a_start}, {a_end}) vs band {b_band} {b_kind} \
+                         [{b_start}, {b_end})"
                     ),
                 ));
             }
@@ -852,6 +918,215 @@ mod tests {
         )
         .expect_err("mismatch must reject");
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn header_and_first_band_byte_layout() {
+        // Pin the exact 32-byte header + first 24-byte band-table entry.
+        // Single band, 1 quad, so the resulting offsets are determinate.
+        let q: Vec<Quad> = vec![make_quad(0xDEAD_BEEF, 1, 2, 3)];
+        let c: Vec<Code> = vec![[1.0_f64, 2.0, 3.0, 4.0]];
+        let bytes = write_to_vec(
+            0x0123_4567_89AB_CDEF,
+            &[BandEmit {
+                band_idx: 7,
+                quads: &q,
+                codes: &c,
+            }],
+        );
+
+        // Expected header (32 B):
+        let expected_head: [u8; 32] = [
+            // magic "ZDCLQUAD"
+            b'Z', b'D', b'C', b'L', b'Q', b'U', b'A', b'D', // version = 1 (u32 LE)
+            0x01, 0x00, 0x00, 0x00, // reserved
+            0x00, 0x00, 0x00, 0x00, // cell_id (u64 LE)
+            0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01, // n_bands = 1
+            0x01, 0x00, 0x00, 0x00, // reserved (pad)
+            0x00, 0x00, 0x00, 0x00,
+        ];
+        assert_eq!(&bytes[..HEADER_SIZE], &expected_head[..]);
+
+        // First band entry: 24 B at byte 32.
+        // band_idx = 7, n_quads = 1.
+        // quads_offset = HEADER_SIZE + BAND_ENTRY_SIZE = 32 + 24 = 56
+        // codes_offset = 56 + 16 = 72
+        let q_off: u64 = (HEADER_SIZE + BAND_ENTRY_SIZE) as u64;
+        let c_off: u64 = q_off + QUAD_RECORD_SIZE as u64;
+        let mut expected_entry = [0u8; BAND_ENTRY_SIZE];
+        expected_entry[0..4].copy_from_slice(&7u32.to_le_bytes());
+        expected_entry[4..8].copy_from_slice(&1u32.to_le_bytes());
+        expected_entry[8..16].copy_from_slice(&q_off.to_le_bytes());
+        expected_entry[16..24].copy_from_slice(&c_off.to_le_bytes());
+        assert_eq!(
+            &bytes[HEADER_SIZE..HEADER_SIZE + BAND_ENTRY_SIZE],
+            &expected_entry[..]
+        );
+    }
+
+    #[test]
+    fn roundtrip_many_bands() {
+        // Twelve bands with varying quad counts, including a mid-table
+        // empty band, to exercise band-table indexing under load.
+        let mut bands_data: Vec<(u32, Vec<Quad>, Vec<Code>)> = Vec::new();
+        for k in 0..12u32 {
+            let n = if k == 5 { 0 } else { (k as usize) + 1 };
+            let qs: Vec<Quad> = (0..n)
+                .map(|i| make_quad(k as usize * 100 + i, i + 1, i + 2, i + 3))
+                .collect();
+            let cs: Vec<Code> = (0..n)
+                .map(|i| make_code((k as f64) * 10.0 + i as f64))
+                .collect();
+            bands_data.push((k, qs, cs));
+        }
+        let bands: Vec<BandEmit<'_>> = bands_data
+            .iter()
+            .map(|(idx, qs, cs)| BandEmit {
+                band_idx: *idx,
+                quads: qs,
+                codes: cs,
+            })
+            .collect();
+
+        let bytes = write_to_vec(0xABCD, &bands);
+        let shard = QuadShard::parse(&bytes).expect("parse 12-band shard");
+        assert_eq!(shard.n_bands(), 12);
+
+        for (idx, qs, cs) in &bands_data {
+            let view = shard.band(*idx).expect("band exists");
+            let got_q: Vec<Quad> = view.quads_iter().collect();
+            let got_c: Vec<Code> = view.codes_iter().collect();
+            assert_eq!(got_q.len(), qs.len(), "band {idx} quad count");
+            for (g, w) in got_q.iter().zip(qs.iter()) {
+                assert_eq!(g.star_ids, w.star_ids);
+            }
+            assert_eq!(got_c, *cs, "band {idx} codes");
+        }
+    }
+
+    #[test]
+    fn nan_and_infinity_codes_roundtrip_bitwise() {
+        // Codes carry arbitrary f64s including NaN/Inf. The on-disk
+        // format is "raw bits" so these must round-trip bit-for-bit
+        // (PartialEq on NaN would lie).
+        let q: Vec<Quad> = vec![make_quad(1, 2, 3, 4), make_quad(5, 6, 7, 8)];
+        let c: Vec<Code> = vec![
+            [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, 1.5],
+            // A signaling-NaN-ish payload: pin it via from_bits.
+            [
+                f64::from_bits(0x7FF0_0000_0000_0001),
+                f64::from_bits(0xFFF8_0000_DEAD_BEEF),
+                0.0,
+                -0.0,
+            ],
+        ];
+        let bytes = write_to_vec(
+            1,
+            &[BandEmit {
+                band_idx: 0,
+                quads: &q,
+                codes: &c,
+            }],
+        );
+        let shard = QuadShard::parse(&bytes).expect("parse");
+        let got: Vec<Code> = shard.band(0).unwrap().codes_iter().collect();
+        assert_eq!(got.len(), c.len());
+        for (g, w) in got.iter().zip(c.iter()) {
+            for (gi, wi) in g.iter().zip(w.iter()) {
+                assert_eq!(
+                    gi.to_bits(),
+                    wi.to_bits(),
+                    "f64 bit pattern mismatch in code"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn overlapping_band_regions_rejected() {
+        // Hand-craft a shard with two bands whose quad blocks overlap.
+        // Both bands carry n_quads = 1 (16 B for quads, 32 B for codes),
+        // but we point both at the same quads_offset. The codes_offset
+        // values are non-overlapping so only the quads regions clash.
+        let header_size = HEADER_SIZE;
+        let n_bands: u32 = 2;
+        let band_table_size = (n_bands as usize) * BAND_ENTRY_SIZE;
+        let body_start = header_size + band_table_size;
+        // Layout in the body:
+        //   [body_start         .. body_start + 16)   shared quads block
+        //   [body_start + 16    .. body_start + 48)   band 0 codes
+        //   [body_start + 48    .. body_start + 80)   band 1 codes
+        let total = body_start + 16 + 32 + 32;
+        let mut bytes = vec![0u8; total];
+
+        // Header.
+        bytes[0..8].copy_from_slice(QUAD_SHARD_MAGIC);
+        bytes[8..12].copy_from_slice(&QUAD_SHARD_VERSION.to_le_bytes());
+        bytes[12..16].copy_from_slice(&0u32.to_le_bytes());
+        bytes[16..24].copy_from_slice(&0u64.to_le_bytes()); // cell_id
+        bytes[24..28].copy_from_slice(&n_bands.to_le_bytes());
+        bytes[28..32].copy_from_slice(&0u32.to_le_bytes());
+
+        let q_off = body_start as u64;
+        let c0_off = (body_start + 16) as u64;
+        let c1_off = (body_start + 48) as u64;
+
+        // Band 0.
+        let off0 = header_size;
+        bytes[off0..off0 + 4].copy_from_slice(&0u32.to_le_bytes());
+        bytes[off0 + 4..off0 + 8].copy_from_slice(&1u32.to_le_bytes());
+        bytes[off0 + 8..off0 + 16].copy_from_slice(&q_off.to_le_bytes());
+        bytes[off0 + 16..off0 + 24].copy_from_slice(&c0_off.to_le_bytes());
+
+        // Band 1 — shares the same quads_offset, which must trigger the
+        // overlap check.
+        let off1 = header_size + BAND_ENTRY_SIZE;
+        bytes[off1..off1 + 4].copy_from_slice(&1u32.to_le_bytes());
+        bytes[off1 + 4..off1 + 8].copy_from_slice(&1u32.to_le_bytes());
+        bytes[off1 + 8..off1 + 16].copy_from_slice(&q_off.to_le_bytes());
+        bytes[off1 + 16..off1 + 24].copy_from_slice(&c1_off.to_le_bytes());
+
+        let err = QuadShard::parse(&bytes).expect_err("overlapping regions must reject");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("overlap"), "got: {err}");
+    }
+
+    #[test]
+    fn out_of_order_band_idx_rejected() {
+        // Hand-craft a band table whose band_idx values are not
+        // strictly ascending. The writer always sorts, so the only way
+        // to exercise this path is to mutate the on-disk band table by
+        // hand.
+        let q0: Vec<Quad> = vec![make_quad(1, 2, 3, 4)];
+        let c0: Vec<Code> = vec![make_code(0.0)];
+        let q1: Vec<Quad> = vec![make_quad(5, 6, 7, 8)];
+        let c1: Vec<Code> = vec![make_code(1.0)];
+        let mut bytes = write_to_vec(
+            0,
+            &[
+                BandEmit {
+                    band_idx: 1,
+                    quads: &q0,
+                    codes: &c0,
+                },
+                BandEmit {
+                    band_idx: 2,
+                    quads: &q1,
+                    codes: &c1,
+                },
+            ],
+        );
+
+        // Swap the band_idx values in the on-disk band table so the
+        // table reads [2, 1] — i.e., not strictly ascending.
+        let off0 = HEADER_SIZE;
+        let off1 = HEADER_SIZE + BAND_ENTRY_SIZE;
+        bytes[off0..off0 + 4].copy_from_slice(&2u32.to_le_bytes());
+        bytes[off1..off1 + 4].copy_from_slice(&1u32.to_le_bytes());
+
+        let err = QuadShard::parse(&bytes).expect_err("out-of-order band_idx must reject");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("ascending"), "got: {err}");
     }
 
     /// Regression for issue #84: shard offsets must be slice-relative, so


### PR DESCRIPTION
## Summary

Address five small bundle/* follow-ups in one focused sweep. Hardens parse-time validation across `quad_shard` and `manifest`, plugs a duplicate-source_id hole in `gaia_shard`, fences off big-endian targets with `compile_error!`, and pads out test coverage on accessors and shard edge cases. No on-disk format changes; no API changes other than dropping the unused `GaiaShard::raw()` accessor.

### #86 — gaia/quad-shard big-endian `compile_error!`
Both shard formats are LE-only on disk; the in-memory `repr(C)` cast in `gaia_shard.rs` and the per-field `to_le_bytes` round-trip in `quad_shard.rs` would silently misbehave on a BE target. Added `#[cfg(target_endian = "big")] compile_error!` at the top of each module so the build fails loudly instead.

### #87 — gaia-shard duplicate source_id + edge tests
Writer now rejects duplicate `source_id` (adjacent after the sort-by-id pass) with `InvalidInput`; readers binary-search by id and a dup would silently shadow one record. Dropped `GaiaShard::raw()` + the `raw` field (unused crate-wide). Added tests: alignment-failure parse, exact-byte 32 B header layout, `0`/`u64::MAX` and supplement-bit (`1u64 << 63`) source_ids round-trip, manually-inflated `n_records` is rejected.

### #85 — quad-shard parse-time validation gaps
Tightened `QuadShard::parse`: now also rejects overlapping band data regions across the whole table (sort populated regions by start, walk pairwise), and pins the empty-band invariant to `quads_offset == codes_offset` pointing inside the data region (matches what the writer naturally emits). Added tests: exact-byte header + first band entry, ≥12-band round-trip, NaN/Infinity in codes round-trip bit-for-bit via `to_bits()`, hand-crafted overlapping regions rejected, hand-crafted out-of-order `band_idx` rejected.

### #88 — manifest atomic-commit hardening
`BundleManifest::save` now wraps the pre-rename work in a closure and best-effort `remove_file`s the `.partial` on any failure (ignoring `NotFound`) so a broken save leaves no stray `.partial` on disk. After a successful rename, `sync_all` is called on the parent directory handle so the directory-entry change is durable across power loss. Added a test that a save under a non-creatable parent leaves no `.partial` behind.

### #83 — accessor edge-case tests
Added FsAccessor: empty bundle dir, zero-byte file (mmap path doesn't panic), ≥100-entry round-trip, hidden file `.foo` reachable. ZipAccessor: zero-byte Stored entry, mixed Stored + Deflated archive. No overlap with the existing path-traversal tests.

## Test plan

- [x] `cargo build --quiet`
- [x] `cargo test --lib bundle --quiet` — 59 / 59 pass
- [x] `cargo test --lib --quiet` — 260 / 260 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt` applied to all touched files

Closes #83
Closes #85
Closes #86
Closes #87
Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)