### PR TITLE
bundle: build-from-excerpt-series CLI + bundle loader (PR6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,9 +3761,11 @@ dependencies = [
 name = "zodiacal-tools"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap",
  "rayon",
  "starfield-gaia",
+ "tempfile",
  "zodiacal",
 ]
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -12,6 +12,7 @@ use crate::quads::{DIMCODES, Quad};
 
 pub use live::{DropReport, EnsureReport, LiveIndex};
 pub use source::{HealpixCell, IndexFragment, IndexSource, ZdclFile};
+pub use store::load_bundle_bands;
 
 /// Metadata for a star in the index.
 #[derive(Debug, Clone)]

--- a/src/index/store.rs
+++ b/src/index/store.rs
@@ -2,6 +2,9 @@ use std::fs::File;
 use std::io::{self, BufReader, BufWriter, Read, Write};
 use std::path::Path;
 
+use starfield::Equatorial;
+
+use crate::bundle::ZdclBundle;
 use crate::geom::sphere::radec_to_xyz;
 use crate::kdtree::KdTree;
 use crate::quads::{Code, DIMCODES, DIMQUADS, Quad};
@@ -317,6 +320,44 @@ fn load_filtered(path: &Path, region_filter: Option<(&SkyRegion, f64)>) -> io::R
         scale_upper,
         metadata,
     })
+}
+
+/// Open a `.zdcl.bundle` (folder or zip) and return one runnable [`Index`]
+/// per scale band, each holding the full-sky concatenation of that band's
+/// quads/codes plus the union of every populated cell's Gaia records as
+/// [`IndexStar`]s.
+///
+/// This is the convenience entry point for callers that want a multi-band
+/// view of a bundle that fits the existing `solve(&[&Index])` signature.
+/// It deliberately does **not** dispatch through [`Index::load`] — bundles
+/// have their own path (folder or zip) and lifecycle, and silently
+/// upgrading a v1/v2 single-file load into a bundle load would be a
+/// footgun for callers that pass arbitrary user-supplied paths.
+///
+/// # Caveat — full-sky materialization
+///
+/// `load_bundle_bands` materializes every populated cell of the bundle.
+/// For region-scoped queries (FOV-sized cones, ground / space tracker
+/// loads) call [`crate::bundle::ZdclBundle::load_region_band`] directly.
+/// At depth 5 with a G ≤ 16 build the full-sky load is ~150 MB of stars
+/// per band; deeper indexes scale roughly linearly.
+pub fn load_bundle_bands(path: &Path) -> io::Result<Vec<Index>> {
+    let bundle = ZdclBundle::open(path)?;
+    let n_bands = bundle.bands().len();
+    // Center at (0, 0) with radius slightly larger than π — guarantees
+    // every populated cell falls inside the cone, regardless of where
+    // its center lies. (`cone_coverage_approx` accepts radii > π and
+    // returns the full-sky moc.)
+    let full_sky = SkyRegion {
+        center: Equatorial::new(0.0, 0.0),
+        radius_rad: 4.0,
+    };
+    let mut out = Vec::with_capacity(n_bands);
+    for band_idx in 0..n_bands {
+        let frag = bundle.load_region_band(band_idx, &full_sky)?;
+        out.push(Index::from(frag));
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -848,5 +889,184 @@ mod tests {
 
         assert_eq!(regional.stars.len(), 0);
         assert_eq!(regional.quads.len(), 0);
+    }
+
+    /// Smoke test for `load_bundle_bands` — builds a tiny 2-band synthetic
+    /// bundle in a tmpdir and asserts the loader returns one Index per
+    /// band with the expected scale ranges.
+    #[test]
+    fn load_bundle_bands_returns_one_index_per_band() {
+        use crate::bundle::manifest::{BuildMetadata, BuildSource};
+        use crate::bundle::tidy::{BandMetadata, GaiaMetadata, TidyMetadata, tidy_to_folder};
+        use crate::index::cell_builder::{CellStar, CellStarSource};
+        use crate::index::multiband_cell_builder::{
+            BundleWorkDirPaths, MultiBandCellBuildConfig, ScaleBand, build_bundle_work_dir,
+        };
+        use crate::refinement::SidecarRecord;
+        use chrono::{DateTime, Utc};
+
+        const TEST_DEPTH: u8 = 5;
+
+        struct ClusteredSource {
+            cells: Vec<u32>,
+            stars_per_cell: usize,
+        }
+
+        fn cell_center(depth: u8, cell_id: u32) -> (f64, f64) {
+            cdshealpix::nested::center(depth, cell_id as u64)
+        }
+
+        impl CellStarSource for ClusteredSource {
+            fn cell_count(&self) -> u32 {
+                // Only iterate up to one past the largest populated cell —
+                // see PR3's testing notes about full-sky cell counts.
+                self.cells.iter().copied().max().unwrap_or(0) + 1
+            }
+            fn stars_in_cell(&self, cell_id: u32) -> io::Result<Vec<CellStar>> {
+                if !self.cells.contains(&cell_id) {
+                    return Ok(Vec::new());
+                }
+                let (ra_c, dec_c) = cell_center(TEST_DEPTH, cell_id);
+                let mut out = Vec::with_capacity(self.stars_per_cell);
+                for i in 0..self.stars_per_cell {
+                    let dra = (i as f64 - 4.0) * 1e-5;
+                    let ddec = (i as f64 - 4.0) * 7e-6;
+                    let ra = ra_c + dra;
+                    let dec = dec_c + ddec;
+                    let cell_id_12: u64 = (cell_id as u64) << (2 * (12 - TEST_DEPTH as u64));
+                    let source_id: u64 = (cell_id_12 << 35) | (i as u64 + 1);
+                    let mag = 12.0 + i as f64 * 0.01;
+                    out.push(CellStar {
+                        catalog_id: source_id,
+                        ra_rad: ra,
+                        dec_rad: dec,
+                        mag,
+                        sidecar: SidecarRecord {
+                            source_id,
+                            ref_epoch: 2016.0,
+                            ra: ra.to_degrees(),
+                            dec: dec.to_degrees(),
+                            pmra: 0.0,
+                            pmdec: 0.0,
+                            parallax: 0.0,
+                            radial_velocity: f64::NAN,
+                            sigma_ra: 0.1,
+                            sigma_dec: 0.1,
+                            sigma_pmra: 0.0,
+                            sigma_pmdec: 0.0,
+                            sigma_parallax: 0.0,
+                            flags: 0,
+                        },
+                        gaia: crate::bundle::gaia_shard::GaiaRecord {
+                            source_id,
+                            ref_epoch: 2016.0,
+                            ra: ra.to_degrees(),
+                            dec: dec.to_degrees(),
+                            pmra: 0.0,
+                            pmdec: 0.0,
+                            parallax: 0.0,
+                            radial_velocity: f64::NAN,
+                            phot_g_mean_mag: mag,
+                            sigma_ra: 0.1,
+                            sigma_dec: 0.1,
+                            sigma_pmra: 0.0,
+                            sigma_pmdec: 0.0,
+                            sigma_parallax: 0.0,
+                            ra_dec_corr: f32::NAN,
+                            ruwe: f32::NAN,
+                            flags: 0,
+                        },
+                    });
+                }
+                Ok(out)
+            }
+        }
+
+        let work_tmp = tempfile::tempdir().unwrap();
+        let out_tmp = tempfile::tempdir().unwrap();
+        let cells = vec![0u32, 1, 7];
+        let source = ClusteredSource {
+            cells: cells.clone(),
+            stars_per_cell: 8,
+        };
+        let cfg = MultiBandCellBuildConfig {
+            bands: vec![
+                ScaleBand {
+                    label: "band_00".into(),
+                    band_idx: 0,
+                    scale_lower_arcsec: 1.0,
+                    scale_upper_arcsec: 50.0,
+                    quads_per_cell: 50,
+                    max_reuse: 8,
+                },
+                ScaleBand {
+                    label: "band_01".into(),
+                    band_idx: 1,
+                    scale_lower_arcsec: 50.0,
+                    scale_upper_arcsec: 500.0,
+                    quads_per_cell: 50,
+                    max_reuse: 8,
+                },
+            ],
+            max_stars_per_cell: 1_000,
+            mag_limit: 20.0,
+            cell_depth: TEST_DEPTH,
+        };
+        let paths = BundleWorkDirPaths {
+            work_dir: work_tmp.path().to_path_buf(),
+        };
+        build_bundle_work_dir(&source, &cfg, &paths).expect("build work dir");
+
+        let bundle_path = out_tmp.path().join("index.zdcl.bundle");
+        let metadata = TidyMetadata {
+            cell_depth: TEST_DEPTH,
+            experiment: "load_bundle_bands smoke".into(),
+            build_metadata: BuildMetadata {
+                tool: "zodiacal test".into(),
+                build_started_utc: "2026-05-05T00:00:00Z".parse::<DateTime<Utc>>().unwrap(),
+                build_finished_utc: "2026-05-05T01:00:00Z".parse::<DateTime<Utc>>().unwrap(),
+                source: BuildSource {
+                    kind: "test-fixture".into(),
+                    release: "test".into(),
+                    path: "/tmp".into(),
+                },
+            },
+            gaia: GaiaMetadata {
+                max_stars_per_cell: 1_000,
+                mag_limit: 20.0,
+                schema_version: 1,
+            },
+            bands: vec![
+                BandMetadata {
+                    label: "band_00".into(),
+                    scale_lower_arcsec: 1.0,
+                    scale_upper_arcsec: 50.0,
+                    quads_per_cell: 50,
+                    max_reuse: 8,
+                },
+                BandMetadata {
+                    label: "band_01".into(),
+                    scale_lower_arcsec: 50.0,
+                    scale_upper_arcsec: 500.0,
+                    quads_per_cell: 50,
+                    max_reuse: 8,
+                },
+            ],
+        };
+        tidy_to_folder(work_tmp.path(), &bundle_path, &metadata).expect("tidy_to_folder");
+
+        let bands = super::load_bundle_bands(&bundle_path).expect("load bundle bands");
+        assert_eq!(bands.len(), 2, "expected 2 bands");
+        // Each band carries the union of populated-cell stars (3 cells * 8).
+        for (i, idx) in bands.iter().enumerate() {
+            assert_eq!(
+                idx.stars.len(),
+                cells.len() * 8,
+                "band {i} star count mismatch"
+            );
+        }
+        // Scale ranges round-trip through arcsec → radians conversion.
+        let one_arcsec_rad = 1.0_f64.to_radians() / 3600.0;
+        assert!((bands[0].scale_lower - one_arcsec_rad).abs() < 1e-12);
     }
 }

--- a/zodiacal-tools/Cargo.toml
+++ b/zodiacal-tools/Cargo.toml
@@ -15,5 +15,9 @@ path = "src/main.rs"
 [dependencies]
 zodiacal = { path = "..", version = "0.4" }
 starfield-gaia = { git = "https://github.com/OrbitalCommons/starfield-datasources" }
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 rayon = "1.11"
+
+[dev-dependencies]
+tempfile = "3.10"

--- a/zodiacal-tools/src/build_from_excerpt_series.rs
+++ b/zodiacal-tools/src/build_from_excerpt_series.rs
@@ -1,0 +1,798 @@
+//! `build-from-excerpt-series`: drive the multi-band `.zdcl.bundle`
+//! build pipeline from a `starfield-gaia` "bycell" excerpt directory.
+//!
+//! This is the user-facing CLI surface for PR6 of the bundle-format
+//! roadmap. It glues PR3's `build_bundle_work_dir` (parallel cell-driven
+//! shard build into a work_dir) and PR4's `tidy_to_folder` /
+//! `tidy_to_zip` (single-threaded finalize into a folder or zip
+//! artifact) behind a single subcommand that consumes a bycell excerpt
+//! directory laid out as `shard_NNNN.csv.gz` files (one per HEALPix
+//! cell at the excerpt's depth).
+//!
+//! ## Source-depth constraint (PR6 v1)
+//!
+//! The CLI only supports the **fast path** where the excerpt's HEALPix
+//! depth equals the bundle's `--cell-depth`. Cross-depth resharding (a
+//! bundle built deeper or shallower than its source excerpt) is a
+//! follow-up and rejected with a clear error today.
+//!
+//! ## Scale-band derivation
+//!
+//! The user supplies `--scale-lower`, `--scale-upper`, `--bands`. The
+//! per-band scale factor is derived as
+//! `(scale_upper / scale_lower)^(1/bands)` so band edges are
+//! geometrically spaced. There is intentionally no `--scale-factor`
+//! flag — over-specifying invites inconsistent inputs.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use chrono::Utc;
+use starfield_gaia::download::Downloader;
+use starfield_gaia::{Dr3, Dr3Catalog, Dr3Entry};
+
+use zodiacal::bundle::ZdclBundle;
+use zodiacal::bundle::gaia_shard::GaiaRecord;
+use zodiacal::bundle::manifest::{BuildMetadata, BuildSource};
+use zodiacal::bundle::tidy::{
+    BandMetadata, GaiaMetadata, TidyMetadata, prune_work_dir, tidy_to_folder, tidy_to_zip,
+};
+use zodiacal::index::cell_builder::{CellStar, CellStarSource};
+use zodiacal::index::multiband_cell_builder::{
+    BundleWorkDirPaths, MultiBandCellBuildConfig, ScaleBand, build_bundle_work_dir,
+};
+use zodiacal::refinement::SidecarRecord;
+
+/// Hard cap on the magnitude limit; deeper than this is rejected up
+/// front to mirror `build-from-shards`'s ceiling. Bundles store records
+/// per-cell so memory pressure scales differently, but a G ≤ 17 cap
+/// keeps individual cells bounded at typical depths.
+pub const MAX_MAG_LIMIT: f64 = 17.0;
+
+/// Output format selector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    /// Folder bundle (`<prefix>.zdcl.bundle/`).
+    Dir,
+    /// Zip-archive bundle (`<prefix>.zdcl.bundle.zip`).
+    Zip,
+    /// Both forms: emit folder first, then zip.
+    Both,
+}
+
+/// Parsed CLI configuration for the `build-from-excerpt-series`
+/// subcommand. The CLI layer in `main.rs` parses these from clap and
+/// invokes [`run`].
+#[derive(Debug, Clone)]
+pub struct BuildFromExcerptSeriesConfig {
+    /// Bycell excerpt directory containing `shard_NNNN.csv.gz` files
+    /// (one per HEALPix cell at the excerpt's depth). `None` falls back
+    /// to the starfield-managed cache directory.
+    pub excerpt_dir: Option<PathBuf>,
+    /// Build scratch directory. Survives across runs to support
+    /// resume-from-crash; only deleted if `--prune-work-dir` is set.
+    pub work_dir: PathBuf,
+    /// Output target prefix; final artifact is `<prefix>.zdcl.bundle/`
+    /// or `<prefix>.zdcl.bundle.zip` (or both, per `output_format`).
+    pub output_prefix: PathBuf,
+    /// Which form(s) to emit.
+    pub output_format: OutputFormat,
+    /// G-band magnitude cutoff for the source excerpt. Stars fainter
+    /// than this are discarded as the CSVs are read.
+    pub mag_limit: f64,
+    /// Per-cell brightness-truncation cap (applied after the per-cell
+    /// stars are loaded but before quad emission).
+    pub max_stars_per_cell: usize,
+    /// HEALPix nested-scheme depth at which the bundle is sharded. Must
+    /// match the source excerpt's depth (PR6 v1 constraint).
+    pub cell_depth: u8,
+    /// Number of scale bands to emit.
+    pub bands: usize,
+    /// Lower edge of band 0, in arcseconds.
+    pub scale_lower_arcsec: f64,
+    /// Upper edge of band `bands - 1`, in arcseconds.
+    pub scale_upper_arcsec: f64,
+    /// Per-band quad-count cap.
+    pub quads_per_cell: usize,
+    /// Per-cell, per-band cap on how many times a single star may be
+    /// referenced across emitted quads.
+    pub max_reuse: u32,
+    /// Free-text experiment label embedded into the manifest.
+    pub experiment: String,
+    /// Rayon thread pool size; pass `None` to use rayon's default
+    /// (one worker per logical core).
+    pub threads: Option<usize>,
+    /// If true, [`prune_work_dir`] is called after a successful tidy.
+    pub prune_work_dir: bool,
+}
+
+/// Top-level entry point.
+pub fn run(cfg: &BuildFromExcerptSeriesConfig) -> Result<(), String> {
+    if !cfg.mag_limit.is_finite() || cfg.mag_limit > MAX_MAG_LIMIT {
+        return Err(format!(
+            "--mag-limit {} exceeds hard cap {}; tighten the limit or run a deeper build with a streaming sidecar.",
+            cfg.mag_limit, MAX_MAG_LIMIT,
+        ));
+    }
+    if cfg.scale_lower_arcsec <= 0.0 || cfg.scale_upper_arcsec <= cfg.scale_lower_arcsec {
+        return Err(format!(
+            "invalid scale range: lower={}\" upper={}\" (must satisfy 0 < lower < upper)",
+            cfg.scale_lower_arcsec, cfg.scale_upper_arcsec,
+        ));
+    }
+    if cfg.bands == 0 {
+        return Err("--bands must be > 0".to_string());
+    }
+    if cfg.quads_per_cell == 0 {
+        return Err("--quads-per-cell must be > 0".to_string());
+    }
+    if cfg.max_stars_per_cell == 0 {
+        return Err("--max-stars-per-cell must be > 0".to_string());
+    }
+
+    let started = Utc::now();
+    let t0 = Instant::now();
+
+    if let Some(n) = cfg.threads {
+        let _ = rayon::ThreadPoolBuilder::new()
+            .num_threads(n)
+            .build_global();
+    }
+
+    // Resolve excerpt source. `None` → starfield-gaia's cached dir.
+    let (excerpt_dir, source_label) = match cfg.excerpt_dir.as_ref() {
+        Some(d) => (d.clone(), format!("directory {}", d.display())),
+        None => {
+            let cached = Downloader::<Dr3>::list_cached().map_err(|e| {
+                format!(
+                    "failed to list starfield-gaia cached shards: {e}; \
+                     pass --excerpt-dir to override"
+                )
+            })?;
+            // The cached list returns CSV(.gz) file paths; their parent
+            // dir is the excerpt root.
+            let parent = cached
+                .first()
+                .and_then(|p| p.parent())
+                .map(|p| p.to_path_buf())
+                .ok_or_else(|| "starfield-gaia cache is empty; pass --excerpt-dir".to_string())?;
+            (
+                parent.clone(),
+                format!("starfield-gaia cache {}", parent.display()),
+            )
+        }
+    };
+    eprintln!("Excerpt source: {source_label}");
+
+    let source = BycellExcerptSource::open(&excerpt_dir, cfg.cell_depth, cfg.mag_limit)?;
+    eprintln!(
+        "Indexed {} populated shard(s); cell_count={} (one past largest populated)",
+        source.populated_count(),
+        source.cell_count(),
+    );
+
+    let bands = derive_scale_bands(
+        cfg.bands,
+        cfg.scale_lower_arcsec,
+        cfg.scale_upper_arcsec,
+        cfg.quads_per_cell,
+        cfg.max_reuse as usize,
+    );
+    eprintln!(
+        "Building {} band(s): scale=[{:.2}\",{:.2}\"], quads/cell={}, max_reuse={}",
+        bands.len(),
+        cfg.scale_lower_arcsec,
+        cfg.scale_upper_arcsec,
+        cfg.quads_per_cell,
+        cfg.max_reuse,
+    );
+
+    let multi_cfg = MultiBandCellBuildConfig {
+        bands: bands.clone(),
+        max_stars_per_cell: cfg.max_stars_per_cell,
+        mag_limit: cfg.mag_limit,
+        cell_depth: cfg.cell_depth,
+    };
+    let paths = BundleWorkDirPaths {
+        work_dir: cfg.work_dir.clone(),
+    };
+
+    let summary = build_bundle_work_dir(&source, &multi_cfg, &paths)
+        .map_err(|e| format!("build_bundle_work_dir failed: {e}"))?;
+    let build_elapsed = t0.elapsed();
+    eprintln!(
+        "Build phase done in {:.1}s: processed={}, resumed={}, empty={}, n_stars={}",
+        build_elapsed.as_secs_f64(),
+        summary.n_cells_processed,
+        summary.n_cells_resumed,
+        summary.n_cells_empty,
+        summary.n_stars,
+    );
+
+    // Tidy phase.
+    let finished = Utc::now();
+    let metadata = TidyMetadata {
+        cell_depth: cfg.cell_depth,
+        experiment: cfg.experiment.clone(),
+        build_metadata: BuildMetadata {
+            tool: format!("zodiacal-tools {}", env!("CARGO_PKG_VERSION")),
+            build_started_utc: started,
+            build_finished_utc: finished,
+            source: BuildSource {
+                kind: "starfield-datasources-bycell".to_string(),
+                release: "Dr3".to_string(),
+                path: excerpt_dir.display().to_string(),
+            },
+        },
+        gaia: GaiaMetadata {
+            max_stars_per_cell: cfg.max_stars_per_cell as u32,
+            mag_limit: cfg.mag_limit,
+            schema_version: 1,
+        },
+        bands: bands
+            .iter()
+            .map(|b| BandMetadata {
+                label: b.label.clone(),
+                scale_lower_arcsec: b.scale_lower_arcsec,
+                scale_upper_arcsec: b.scale_upper_arcsec,
+                quads_per_cell: b.quads_per_cell as u32,
+                max_reuse: b.max_reuse as u32,
+            })
+            .collect(),
+    };
+
+    let folder_path = with_suffix(&cfg.output_prefix, "zdcl.bundle");
+    let zip_path = with_suffix(&cfg.output_prefix, "zdcl.bundle.zip");
+
+    match cfg.output_format {
+        OutputFormat::Dir => {
+            tidy_to_folder(&cfg.work_dir, &folder_path, &metadata)
+                .map_err(|e| format!("tidy_to_folder failed: {e}"))?;
+            eprintln!("Folder bundle written: {}", folder_path.display());
+        }
+        OutputFormat::Zip => {
+            tidy_to_zip(&cfg.work_dir, &zip_path, &metadata)
+                .map_err(|e| format!("tidy_to_zip failed: {e}"))?;
+            eprintln!("Zip bundle written: {}", zip_path.display());
+        }
+        OutputFormat::Both => {
+            tidy_to_folder(&cfg.work_dir, &folder_path, &metadata)
+                .map_err(|e| format!("tidy_to_folder failed: {e}"))?;
+            eprintln!("Folder bundle written: {}", folder_path.display());
+            tidy_to_zip(&cfg.work_dir, &zip_path, &metadata)
+                .map_err(|e| format!("tidy_to_zip failed: {e}"))?;
+            eprintln!("Zip bundle written: {}", zip_path.display());
+        }
+    }
+
+    if cfg.prune_work_dir {
+        prune_work_dir(&cfg.work_dir).map_err(|e| format!("prune_work_dir failed: {e}"))?;
+        eprintln!("Pruned work dir {}", cfg.work_dir.display());
+    } else {
+        eprintln!(
+            "Work dir preserved at {} (pass --prune-work-dir to remove)",
+            cfg.work_dir.display(),
+        );
+    }
+
+    eprintln!();
+    eprintln!("=== Summary ===");
+    eprintln!("Bands:         {}", bands.len());
+    eprintln!("Cells built:   {}", summary.n_cells_processed);
+    eprintln!("Cells resumed: {}", summary.n_cells_resumed);
+    eprintln!("Total stars:   {}", summary.n_stars);
+    for (k, b) in bands.iter().enumerate() {
+        let q = summary
+            .per_band_quad_counts
+            .get(k)
+            .copied()
+            .unwrap_or_default();
+        let pop = summary
+            .per_band_populated_cells
+            .get(k)
+            .copied()
+            .unwrap_or_default();
+        eprintln!(
+            "  band {k:02} [{:.2}\",{:.2}\"]: n_quads={q}, populated_cells={pop}",
+            b.scale_lower_arcsec, b.scale_upper_arcsec,
+        );
+    }
+    eprintln!("Elapsed:       {:.1}s", t0.elapsed().as_secs_f64());
+
+    // Final sanity check: confirm the produced bundle opens.
+    let opened_path: &Path = match cfg.output_format {
+        OutputFormat::Dir | OutputFormat::Both => &folder_path,
+        OutputFormat::Zip => &zip_path,
+    };
+    let _b = ZdclBundle::open(opened_path).map_err(|e| {
+        format!(
+            "post-tidy ZdclBundle::open({}) failed: {e}",
+            opened_path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+//  Scale-band derivation
+// ---------------------------------------------------------------------------
+
+/// Build a `Vec<ScaleBand>` from `--scale-lower / --scale-upper / --bands`,
+/// using `factor = (upper / lower)^(1/bands)` so band edges are
+/// geometrically spaced.
+fn derive_scale_bands(
+    n_bands: usize,
+    scale_lower_arcsec: f64,
+    scale_upper_arcsec: f64,
+    quads_per_cell: usize,
+    max_reuse: usize,
+) -> Vec<ScaleBand> {
+    let factor = (scale_upper_arcsec / scale_lower_arcsec).powf(1.0 / n_bands as f64);
+    (0..n_bands)
+        .map(|i| {
+            let lower = scale_lower_arcsec * factor.powi(i as i32);
+            let upper = scale_lower_arcsec * factor.powi(i as i32 + 1);
+            ScaleBand {
+                label: format!("band_{i:02}"),
+                band_idx: i as u32,
+                scale_lower_arcsec: lower,
+                scale_upper_arcsec: upper,
+                quads_per_cell,
+                max_reuse,
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+//  BycellExcerptSource: walk shard_NNNN.csv.gz files in a bycell excerpt
+//  directory, expose them as a CellStarSource.
+// ---------------------------------------------------------------------------
+
+/// `CellStarSource` impl for a starfield-gaia bycell excerpt — a
+/// directory of `shard_NNNN.csv.gz` files whose shard index equals the
+/// HEALPix nested-scheme cell id at the excerpt's `cell_depth`.
+///
+/// PR6 v1 only supports the identity passthrough: bundle's `cell_depth`
+/// must equal the excerpt's depth. Cross-depth resharding is a
+/// follow-up.
+#[derive(Debug)]
+pub struct BycellExcerptSource {
+    /// `cell_id (= shard index) -> path on disk`, populated by scanning
+    /// the excerpt directory at construction time.
+    cell_files: HashMap<u32, PathBuf>,
+    /// One past the largest populated cell. The orchestrator iterates
+    /// `0..cell_count()`; this keeps the iteration bounded by what's on
+    /// disk rather than by the depth's full-sky count, which would
+    /// fsync 12,288 empty manifest entries at depth 5 even for sparse
+    /// test fixtures.
+    cell_count: u32,
+    /// Magnitude cap applied to the loaded CSV rows.
+    mag_limit: f64,
+}
+
+impl BycellExcerptSource {
+    /// Scan `excerpt_dir` for `shard_NNNN.csv.gz` files and validate
+    /// that no shard index exceeds the cell count for `cell_depth`
+    /// (`12 * 4^depth`).
+    pub fn open(excerpt_dir: &Path, cell_depth: u8, mag_limit: f64) -> Result<Self, String> {
+        if !excerpt_dir.is_dir() {
+            return Err(format!(
+                "--excerpt-dir {} is not a directory",
+                excerpt_dir.display(),
+            ));
+        }
+        let max_cells = 12u64 << (2 * cell_depth as u64);
+        let mut cell_files = HashMap::new();
+        for entry in std::fs::read_dir(excerpt_dir)
+            .map_err(|e| format!("failed to read {}: {e}", excerpt_dir.display()))?
+        {
+            let entry = entry.map_err(|e| format!("read_dir entry failed: {e}"))?;
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n,
+                None => continue,
+            };
+            let stripped = match name
+                .strip_prefix("shard_")
+                .and_then(|s| s.strip_suffix(".csv.gz"))
+                .or_else(|| {
+                    name.strip_prefix("shard_")
+                        .and_then(|s| s.strip_suffix(".csv"))
+                }) {
+                Some(s) => s,
+                None => continue,
+            };
+            let idx: u32 = match stripped.parse() {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            if (idx as u64) >= max_cells {
+                return Err(format!(
+                    "shard index {idx} from {} exceeds cell count {max_cells} for depth {cell_depth}; \
+                     the excerpt was likely produced at a different depth — cross-depth resharding \
+                     is not supported in PR6 v1, rebuild the excerpt at depth {cell_depth} or pass \
+                     --cell-depth to match the excerpt's depth",
+                    path.display(),
+                ));
+            }
+            cell_files.insert(idx, path);
+        }
+        if cell_files.is_empty() {
+            return Err(format!(
+                "no shard_*.csv(.gz) files found in {}",
+                excerpt_dir.display(),
+            ));
+        }
+        let cell_count = cell_files.keys().copied().max().map(|m| m + 1).unwrap_or(0);
+        Ok(Self {
+            cell_files,
+            cell_count,
+            mag_limit,
+        })
+    }
+
+    /// Number of populated cells (cells with a corresponding shard
+    /// file). Distinct from [`Self::cell_count`], which is one past the
+    /// largest populated cell.
+    pub fn populated_count(&self) -> usize {
+        self.cell_files.len()
+    }
+}
+
+impl CellStarSource for BycellExcerptSource {
+    fn cell_count(&self) -> u32 {
+        self.cell_count
+    }
+
+    fn stars_in_cell(&self, cell_id: u32) -> std::io::Result<Vec<CellStar>> {
+        let path = match self.cell_files.get(&cell_id) {
+            Some(p) => p,
+            None => return Ok(Vec::new()),
+        };
+        let catalog = Dr3Catalog::from_csv_file(path, self.mag_limit)
+            .map_err(|e| std::io::Error::other(format!("{}: load failed: {e}", path.display())))?;
+        let entries = catalog.0.brighter_than_ref(f64::INFINITY);
+        let mut out = Vec::with_capacity(entries.len());
+        for entry in entries {
+            if !entry.core.phot_g_mean_mag.is_finite() {
+                continue;
+            }
+            out.push(entry_to_cell_star(entry));
+        }
+        Ok(out)
+    }
+}
+
+/// Convert one `Dr3Entry` row to the [`CellStar`] tuple consumed by the
+/// cell-driven builder. `sidecar` and `gaia` are populated from the
+/// same source columns; the multi-band builder reads `gaia`, the
+/// legacy single-band path would read `sidecar` (unused here but we
+/// populate both for forward compat with mixed pipelines).
+pub fn entry_to_cell_star(entry: &Dr3Entry) -> CellStar {
+    let core = &entry.core;
+    let ra_rad = core.ra.to_radians();
+    let dec_rad = core.dec.to_radians();
+    let mag = core.phot_g_mean_mag;
+
+    let radial_velocity = entry
+        .radial_velocity
+        .as_ref()
+        .and_then(|rv| rv.radial_velocity)
+        .unwrap_or(f64::NAN);
+
+    let pmra = core.pmra.unwrap_or(f64::NAN);
+    let pmdec = core.pmdec.unwrap_or(f64::NAN);
+    let parallax = core.parallax.unwrap_or(f64::NAN);
+    let pmra_err = core.pmra_error.unwrap_or(f32::NAN);
+    let pmdec_err = core.pmdec_error.unwrap_or(f32::NAN);
+    let parallax_err = core.parallax_error.unwrap_or(f32::NAN);
+    let ra_dec_corr = core.ra_dec_corr.unwrap_or(f32::NAN);
+    let ruwe = entry.ipd.ruwe.unwrap_or(f32::NAN);
+
+    let mut flags: u32 = 0;
+    if !pmra.is_nan() && !pmdec.is_nan() {
+        flags |= GaiaRecord::FLAG_HAS_PM;
+    }
+    if !parallax.is_nan() {
+        flags |= GaiaRecord::FLAG_HAS_PARALLAX;
+    }
+    if !radial_velocity.is_nan() {
+        flags |= GaiaRecord::FLAG_HAS_RADIAL_VELOCITY;
+    }
+    if !ra_dec_corr.is_nan() {
+        flags |= GaiaRecord::FLAG_HAS_RA_DEC_CORR;
+    }
+    if !ruwe.is_nan() {
+        flags |= GaiaRecord::FLAG_HAS_RUWE;
+    }
+
+    let sidecar = SidecarRecord {
+        source_id: core.source_id,
+        ref_epoch: core.ref_epoch,
+        ra: core.ra,
+        dec: core.dec,
+        pmra,
+        pmdec,
+        parallax,
+        radial_velocity,
+        sigma_ra: core.ra_error,
+        sigma_dec: core.dec_error,
+        sigma_pmra: pmra_err,
+        sigma_pmdec: pmdec_err,
+        sigma_parallax: parallax_err,
+        flags: 0,
+    };
+
+    let gaia = GaiaRecord {
+        source_id: core.source_id,
+        ref_epoch: core.ref_epoch,
+        ra: core.ra,
+        dec: core.dec,
+        pmra,
+        pmdec,
+        parallax,
+        radial_velocity,
+        phot_g_mean_mag: mag,
+        sigma_ra: core.ra_error,
+        sigma_dec: core.dec_error,
+        sigma_pmra: pmra_err,
+        sigma_pmdec: pmdec_err,
+        sigma_parallax: parallax_err,
+        ra_dec_corr,
+        ruwe,
+        flags,
+    };
+
+    CellStar {
+        catalog_id: core.source_id,
+        ra_rad,
+        dec_rad,
+        mag,
+        sidecar,
+        gaia,
+    }
+}
+
+/// Append `.<suffix>` to `prefix`. Used for the same reason
+/// `build-from-shards` does: `Path::set_extension` would clobber any
+/// existing trailing extension on the prefix.
+fn with_suffix(prefix: &Path, suffix: &str) -> PathBuf {
+    let mut s = prefix.as_os_str().to_owned();
+    s.push(".");
+    s.push(suffix);
+    PathBuf::from(s)
+}
+
+// ---------------------------------------------------------------------------
+//  Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drop a zero-byte file with the expected name into `dir`. The
+    /// excerpt-source open path only inspects filenames; CSV parsing is
+    /// deferred to the per-cell `stars_in_cell` call, which the
+    /// discovery-only tests don't exercise.
+    fn touch_synthetic_shard(dir: &Path, shard_idx: u32) {
+        let path = dir.join(format!("shard_{shard_idx:04}.csv.gz"));
+        std::fs::write(&path, b"").unwrap();
+    }
+
+    #[test]
+    fn derive_scale_bands_geometric() {
+        let bands = derive_scale_bands(3, 10.0, 80.0, 100, 8);
+        assert_eq!(bands.len(), 3);
+        assert!((bands[0].scale_lower_arcsec - 10.0).abs() < 1e-9);
+        assert!((bands[2].scale_upper_arcsec - 80.0).abs() < 1e-9);
+        // Geometric: each upper == 2x lower.
+        for b in &bands {
+            let ratio = b.scale_upper_arcsec / b.scale_lower_arcsec;
+            assert!((ratio - 2.0).abs() < 1e-9, "non-geometric band: {b:?}");
+        }
+        // band_idx is dense and labels are zero-padded.
+        for (i, b) in bands.iter().enumerate() {
+            assert_eq!(b.band_idx as usize, i);
+            assert_eq!(b.label, format!("band_{i:02}"));
+        }
+    }
+
+    #[test]
+    fn excerpt_source_open_rejects_oversized_shard_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        // depth 0 → 12 cells → max id 11. We write shard_0099 to force
+        // the rejection path.
+        touch_synthetic_shard(tmp.path(), 99);
+        let err = BycellExcerptSource::open(tmp.path(), 0, 16.0).unwrap_err();
+        assert!(
+            err.contains("exceeds cell count"),
+            "expected cross-depth rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn excerpt_source_open_empty_dir_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = BycellExcerptSource::open(tmp.path(), 5, 16.0).unwrap_err();
+        assert!(
+            err.contains("no shard_"),
+            "expected empty-dir error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn excerpt_source_indexes_shards_at_correct_depth() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Depth 5 → max id 12,287. Four small shards in the low ids.
+        for &cid in &[0u32, 1, 7, 42] {
+            touch_synthetic_shard(tmp.path(), cid);
+        }
+        let src = BycellExcerptSource::open(tmp.path(), 5, 16.0).unwrap();
+        assert_eq!(src.populated_count(), 4);
+        // cell_count == one past the largest populated cell.
+        assert_eq!(src.cell_count(), 43);
+    }
+
+    /// End-to-end smoke: build a tiny bundle programmatically using a
+    /// hand-rolled `CellStarSource` (which avoids the brittle CSV
+    /// round-trip through `Dr3Catalog::from_csv_file`), then assert the
+    /// produced bundle opens via `ZdclBundle::open` and has the
+    /// expected band count.
+    #[test]
+    fn run_e2e_synthetic_two_band_bundle() {
+        use chrono::{DateTime, Utc};
+        use zodiacal::bundle::ZdclBundle;
+        use zodiacal::bundle::gaia_shard::GaiaRecord;
+        use zodiacal::bundle::manifest::{BuildMetadata, BuildSource};
+        use zodiacal::bundle::tidy::{BandMetadata, GaiaMetadata, TidyMetadata, tidy_to_folder};
+        use zodiacal::index::cell_builder::{CellStar, CellStarSource};
+        use zodiacal::index::multiband_cell_builder::{
+            BundleWorkDirPaths, MultiBandCellBuildConfig, build_bundle_work_dir,
+        };
+        use zodiacal::refinement::SidecarRecord;
+
+        const TEST_DEPTH: u8 = 5;
+
+        struct ClusteredSource {
+            cells: Vec<u32>,
+            stars_per_cell: usize,
+        }
+        impl CellStarSource for ClusteredSource {
+            fn cell_count(&self) -> u32 {
+                self.cells.iter().copied().max().unwrap_or(0) + 1
+            }
+            fn stars_in_cell(&self, cell_id: u32) -> std::io::Result<Vec<CellStar>> {
+                if !self.cells.contains(&cell_id) {
+                    return Ok(Vec::new());
+                }
+                // Place each cell's stars at distinct fixed offsets in
+                // an arbitrary patch of sky. The bundle reader doesn't
+                // re-validate that stars actually fall in their declared
+                // cells — the source's cell-assignment is taken as
+                // ground truth. This keeps the test independent of
+                // cdshealpix's exact center coordinates.
+                let base_ra = 0.5 + cell_id as f64 * 0.01;
+                let base_dec = 0.1;
+                let mut out = Vec::with_capacity(self.stars_per_cell);
+                for i in 0..self.stars_per_cell {
+                    let dra = (i as f64 - 4.0) * 1e-5;
+                    let ddec = (i as f64 - 4.0) * 7e-6;
+                    let ra = base_ra + dra;
+                    let dec = base_dec + ddec;
+                    let cell_id_12: u64 = (cell_id as u64) << (2 * (12 - TEST_DEPTH as u64));
+                    let source_id: u64 = (cell_id_12 << 35) | (i as u64 + 1);
+                    let mag = 12.0 + i as f64 * 0.01;
+                    out.push(CellStar {
+                        catalog_id: source_id,
+                        ra_rad: ra,
+                        dec_rad: dec,
+                        mag,
+                        sidecar: SidecarRecord {
+                            source_id,
+                            ref_epoch: 2016.0,
+                            ra: ra.to_degrees(),
+                            dec: dec.to_degrees(),
+                            pmra: 0.0,
+                            pmdec: 0.0,
+                            parallax: 0.0,
+                            radial_velocity: f64::NAN,
+                            sigma_ra: 0.1,
+                            sigma_dec: 0.1,
+                            sigma_pmra: 0.0,
+                            sigma_pmdec: 0.0,
+                            sigma_parallax: 0.0,
+                            flags: 0,
+                        },
+                        gaia: GaiaRecord {
+                            source_id,
+                            ref_epoch: 2016.0,
+                            ra: ra.to_degrees(),
+                            dec: dec.to_degrees(),
+                            pmra: 0.0,
+                            pmdec: 0.0,
+                            parallax: 0.0,
+                            radial_velocity: f64::NAN,
+                            phot_g_mean_mag: mag,
+                            sigma_ra: 0.1,
+                            sigma_dec: 0.1,
+                            sigma_pmra: 0.0,
+                            sigma_pmdec: 0.0,
+                            sigma_parallax: 0.0,
+                            ra_dec_corr: f32::NAN,
+                            ruwe: f32::NAN,
+                            flags: 0,
+                        },
+                    });
+                }
+                Ok(out)
+            }
+        }
+
+        let work_tmp = tempfile::tempdir().unwrap();
+        let out_tmp = tempfile::tempdir().unwrap();
+        let cells = vec![0u32, 1, 7];
+        let source = ClusteredSource {
+            cells: cells.clone(),
+            stars_per_cell: 8,
+        };
+        let bands = derive_scale_bands(2, 1.0, 50.0, 50, 8);
+        let cfg = MultiBandCellBuildConfig {
+            bands: bands.clone(),
+            max_stars_per_cell: 1_000,
+            mag_limit: 20.0,
+            cell_depth: TEST_DEPTH,
+        };
+        let paths = BundleWorkDirPaths {
+            work_dir: work_tmp.path().to_path_buf(),
+        };
+        build_bundle_work_dir(&source, &cfg, &paths).unwrap();
+
+        let bundle_path = out_tmp.path().join("smoke.zdcl.bundle");
+        let metadata = TidyMetadata {
+            cell_depth: TEST_DEPTH,
+            experiment: "build-from-excerpt-series smoke".into(),
+            build_metadata: BuildMetadata {
+                tool: "zodiacal-tools test".into(),
+                build_started_utc: "2026-05-05T00:00:00Z".parse::<DateTime<Utc>>().unwrap(),
+                build_finished_utc: "2026-05-05T01:00:00Z".parse::<DateTime<Utc>>().unwrap(),
+                source: BuildSource {
+                    kind: "test-fixture".into(),
+                    release: "test".into(),
+                    path: "/tmp".into(),
+                },
+            },
+            gaia: GaiaMetadata {
+                max_stars_per_cell: 1_000,
+                mag_limit: 20.0,
+                schema_version: 1,
+            },
+            bands: bands
+                .iter()
+                .map(|b| BandMetadata {
+                    label: b.label.clone(),
+                    scale_lower_arcsec: b.scale_lower_arcsec,
+                    scale_upper_arcsec: b.scale_upper_arcsec,
+                    quads_per_cell: b.quads_per_cell as u32,
+                    max_reuse: b.max_reuse as u32,
+                })
+                .collect(),
+        };
+        tidy_to_folder(work_tmp.path(), &bundle_path, &metadata).unwrap();
+
+        // Bundle opens, reports two bands.
+        let bundle = ZdclBundle::open(&bundle_path).unwrap();
+        assert_eq!(bundle.bands().len(), 2);
+        assert!(bundle_path.join("manifest.json").is_file());
+
+        // Loader returns one Index per band.
+        let bands_loaded = zodiacal::index::store::load_bundle_bands(&bundle_path).unwrap();
+        assert_eq!(bands_loaded.len(), 2);
+    }
+}

--- a/zodiacal-tools/src/main.rs
+++ b/zodiacal-tools/src/main.rs
@@ -9,12 +9,16 @@
 use std::path::PathBuf;
 use std::process;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 use zodiacal::index::source::DEFAULT_CELL_DEPTH;
 
+mod build_from_excerpt_series;
 mod build_from_shards;
 
+use build_from_excerpt_series::{
+    BuildFromExcerptSeriesConfig, OutputFormat, run as run_build_from_excerpt_series,
+};
 use build_from_shards::{BuildFromShardsConfig, run as run_build_from_shards};
 
 #[derive(Parser)]
@@ -25,6 +29,27 @@ use build_from_shards::{BuildFromShardsConfig, run as run_build_from_shards};
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+}
+
+/// Output-form selector for `build-from-excerpt-series`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum OutputFormatArg {
+    /// Folder bundle (`<prefix>.zdcl.bundle/`).
+    Dir,
+    /// Zip-archive bundle (`<prefix>.zdcl.bundle.zip`).
+    Zip,
+    /// Both forms.
+    Both,
+}
+
+impl From<OutputFormatArg> for OutputFormat {
+    fn from(v: OutputFormatArg) -> Self {
+        match v {
+            OutputFormatArg::Dir => OutputFormat::Dir,
+            OutputFormatArg::Zip => OutputFormat::Zip,
+            OutputFormatArg::Both => OutputFormat::Both,
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -79,6 +104,92 @@ enum Commands {
         #[arg(long)]
         threads: Option<usize>,
     },
+
+    /// Build a multi-band `.zdcl.bundle` from a starfield-gaia
+    /// "bycell" excerpt directory (a tree of `shard_NNNN.csv.gz`
+    /// files, one per HEALPix cell at the excerpt's depth).
+    ///
+    /// Drives PR3's parallel cell-driven build phase plus PR4's
+    /// single-threaded tidy phase to produce a folder or zip bundle
+    /// (or both). The work directory survives across runs to support
+    /// resume from crashes; pass `--prune-work-dir` to opt into
+    /// destructive cleanup once the bundle is committed.
+    ///
+    /// PR6 v1 only supports the **fast path** where the bundle's
+    /// `--cell-depth` equals the excerpt's depth. Cross-depth
+    /// resharding is rejected with a clear error.
+    BuildFromExcerptSeries {
+        /// Directory containing `shard_NNNN.csv.gz` files. Omit to use
+        /// the starfield-gaia cache directory.
+        #[arg(long)]
+        excerpt_dir: Option<PathBuf>,
+
+        /// Build scratch directory. Required; survives across runs to
+        /// support resume.
+        #[arg(long)]
+        work_dir: PathBuf,
+
+        /// Output prefix; final artifact is `<prefix>.zdcl.bundle/`
+        /// or `<prefix>.zdcl.bundle.zip` (or both).
+        #[arg(long)]
+        output_prefix: PathBuf,
+
+        /// Output form to emit.
+        #[arg(long, value_enum, default_value_t = OutputFormatArg::Dir)]
+        output_format: OutputFormatArg,
+
+        /// G-band magnitude cutoff applied to source rows. Capped at
+        /// 17.0; deeper requires the streaming sidecar work.
+        #[arg(long, default_value = "16.0")]
+        mag_limit: f64,
+
+        /// Per-cell brightness-truncation cap (applied after
+        /// per-cell load, before quad emission).
+        #[arg(long, default_value_t = 10_000)]
+        max_stars_per_cell: usize,
+
+        /// HEALPix nested-scheme depth for cell sharding. Must equal
+        /// the excerpt's depth (PR6 v1 limitation).
+        #[arg(long, default_value_t = DEFAULT_CELL_DEPTH)]
+        cell_depth: u8,
+
+        /// Number of scale bands. Band `i`'s scale range is
+        /// `[scale_lower * f^i, scale_lower * f^(i+1)]`, where
+        /// `f = (scale_upper / scale_lower)^(1 / bands)`.
+        #[arg(long, default_value_t = 12)]
+        bands: usize,
+
+        /// Lower edge of band 0, in arcseconds.
+        #[arg(long, default_value = "10.0")]
+        scale_lower: f64,
+
+        /// Upper edge of band `bands - 1`, in arcseconds.
+        #[arg(long, default_value = "600.0")]
+        scale_upper: f64,
+
+        /// Per-band quad-count cap.
+        #[arg(long, default_value_t = 100)]
+        quads_per_cell: usize,
+
+        /// Per-cell, per-band cap on how many times a single star
+        /// may be referenced across emitted quads.
+        #[arg(long, default_value_t = 8)]
+        max_reuse: u32,
+
+        /// Free-text experiment label embedded in the manifest.
+        #[arg(long, default_value = "")]
+        experiment: String,
+
+        /// Rayon worker thread count.
+        #[arg(long)]
+        threads: Option<usize>,
+
+        /// Remove the work directory after a successful tidy.
+        /// Default: keep, so a follow-up tidy can produce the
+        /// alternate output form without rebuilding.
+        #[arg(long, default_value_t = false)]
+        prune_work_dir: bool,
+    },
 }
 
 fn main() {
@@ -106,6 +217,45 @@ fn main() {
             };
             if let Err(e) = run_build_from_shards(&cfg) {
                 eprintln!("build-from-shards failed: {e}");
+                process::exit(1);
+            }
+        }
+        Commands::BuildFromExcerptSeries {
+            excerpt_dir,
+            work_dir,
+            output_prefix,
+            output_format,
+            mag_limit,
+            max_stars_per_cell,
+            cell_depth,
+            bands,
+            scale_lower,
+            scale_upper,
+            quads_per_cell,
+            max_reuse,
+            experiment,
+            threads,
+            prune_work_dir,
+        } => {
+            let cfg = BuildFromExcerptSeriesConfig {
+                excerpt_dir: excerpt_dir.clone(),
+                work_dir: work_dir.clone(),
+                output_prefix: output_prefix.clone(),
+                output_format: (*output_format).into(),
+                mag_limit: *mag_limit,
+                max_stars_per_cell: *max_stars_per_cell,
+                cell_depth: *cell_depth,
+                bands: *bands,
+                scale_lower_arcsec: *scale_lower,
+                scale_upper_arcsec: *scale_upper,
+                quads_per_cell: *quads_per_cell,
+                max_reuse: *max_reuse,
+                experiment: experiment.clone(),
+                threads: *threads,
+                prune_work_dir: *prune_work_dir,
+            };
+            if let Err(e) = run_build_from_excerpt_series(&cfg) {
+                eprintln!("build-from-excerpt-series failed: {e}");
                 process::exit(1);
             }
         }


### PR DESCRIPTION
## Summary

PR6 of the `.zdcl.bundle` roadmap — ties PR3's parallel multi-band cell-driven build phase and PR4's tidy phase together behind a single user-facing CLI subcommand, and adds a core-side full-sky bundle loader so PR7's production benchmark can plug bundles into the existing `solve(&[&Index])` signature without additional plumbing.

The CLI is `zodiacal-tools build-from-excerpt-series`. It walks a starfield-gaia ``shard_NNNN.csv.gz`` bycell excerpt directory (one shard per HEALPix cell at the excerpt's depth), runs the parallel build phase into a work directory, and finalizes via `tidy_to_folder` and/or `tidy_to_zip` per the user's `--output-format` choice. PR6 v1 only supports the **fast path** (bundle's ``--cell-depth`` matches the source excerpt's depth); cross-depth resharding errors out with a clear message and is deferred to a follow-up.

## New files / types / functions

**New file:**
- `zodiacal-tools/src/build_from_excerpt_series.rs`

**New types:**
- `BuildFromExcerptSeriesConfig` — parsed-CLI fields the entry point consumes
- `OutputFormat` — `Dir | Zip | Both` selector
- `BycellExcerptSource` — `CellStarSource` impl over a `shard_NNNN.csv.gz` directory

**New functions:**
- `build_from_excerpt_series::run(&cfg) -> Result<(), String>` — drives the full pipeline
- `build_from_excerpt_series::derive_scale_bands(...)` — geometric band-edge derivation from `(scale_lower, scale_upper, n_bands)`
- `build_from_excerpt_series::entry_to_cell_star(&Dr3Entry) -> CellStar` — Gaia-DR3 row to bundle-format star with full 104 B `GaiaRecord` populated
- `zodiacal::index::store::load_bundle_bands(path) -> io::Result<Vec<Index>>` — full-sky multi-band loader, exported via `zodiacal::index::load_bundle_bands`
- New CLI subcommand `Commands::BuildFromExcerptSeries { ... }` in `zodiacal-tools/src/main.rs`

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 299 lib tests + 9 zodiacal-tools tests pass
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] CLI ``--help`` renders all flags
- [x] `BycellExcerptSource::open` rejects shard ids that exceed the cell count for the requested depth
- [x] `BycellExcerptSource::open` errors on an empty directory
- [x] `BycellExcerptSource::open` indexes shards correctly, exposes `cell_count() == max_populated + 1`
- [x] `derive_scale_bands` produces geometrically spaced edges with dense `band_idx` and `band_NN` labels
- [x] End-to-end smoke: programmatic `build_bundle_work_dir` → `tidy_to_folder` → `ZdclBundle::open` → `load_bundle_bands` returns the expected band count
- [x] Core-side smoke for `load_bundle_bands` lives in ``src/index/store.rs#mod tests``

## Deferred to PR7

- Production benchmark on the real G ≤ 20 bycell excerpt
- README solve-rate refresh against the bundle format
- `scripts/analyze_index.py` bundle support
- Cross-depth resharding (``bundle_depth ≠ source_depth``) for `BycellExcerptSource`
- Full CSV-shard-driven CLI integration test (the smoke test deliberately bypasses the CSV parser to avoid coupling to ``starfield-gaia``'s row schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)