### PR TITLE
bundle: cross-cell patch quads (.zqd v2)

### DIFF
--- a/docs/bundle-format.md
+++ b/docs/bundle-format.md
@@ -121,7 +121,7 @@ When all cells are committed, a single-threaded finalize step:
 ```json
 {
   "format": "zdcl-bundle",
-  "format_version": 1,
+  "format_version": 2,
   "cell_depth": 5,
   "n_cells": 12288,
   "experiment": "G≤20 DR3 bycell, 12 bands √2 at 10-600 arcsec, 100 quads/cell/band, max_stars_per_cell=10000, max_reuse=8 — built 2026-05-05 from build-from-excerpt-series",
@@ -173,15 +173,18 @@ The free-text `experiment` field is for human ops notes — a one-liner summariz
 
 ### `quads/cell_NNNNN.zqd` — quads + codes for one cell, all bands
 
-One file per HEALPix cell holds **every band's quads** for that cell, with a band table at the head pointing at each band's quad/code blocks. Indices are **into this cell's `cell_NNNNN.zga` file** — local indices, not global. (Cross-cell quads are not supported by the current cell-driven builder; once they are, a straddle quad lives in the file of whichever cell contains its centroid.)
+One file per HEALPix cell holds **every band's quads** for that cell, with a band table at the head pointing at each band's quad/code blocks. Each quad's 4 star_ids are **packed `(neighbor_idx, local_idx)` u32s** that resolve to a position in either *this* cell's `.zga` (when `neighbor_idx == 0`) or one of the cells listed in the per-shard neighbor table (when `1 <= neighbor_idx <= n_neighbors`). A quad is emitted in the file of the cell containing its **centroid** (the unit-vector mean of its four members), so each physical asterism appears in exactly one `.zqd`.
 
 ```
 magic         8 B  "ZDCLQUAD"
-version       4 B  u32 LE = 1
+version       4 B  u32 LE = 2
 reserved      4 B
 cell_id       8 B  u64 LE                 — defensive duplication; filename is the source of truth
 n_bands       4 B  u32 LE                 — must equal manifest.bands.len()
-reserved      4 B  → align band table to 8
+n_neighbors   4 B  u32 LE                 — count of neighbor-cell entries below; max 15
+
+neighbor_table  n_neighbors × 8 B
+                cell_id      8 B  u64 LE  — referenced HEALPix cell id (entry K → neighbor_idx K+1)
 
 band_table    n_bands × 24 B
               for each band:
@@ -190,12 +193,14 @@ band_table    n_bands × 24 B
                 quads_offset 8 B  u64 LE  — byte offset of this band's quads block, relative to shard start
                 codes_offset 8 B  u64 LE  — byte offset of this band's codes block, relative to shard start
 
-padding to 8-byte boundary
-
 per band, in band_idx order, no padding between blocks:
-  quads_block  n_quads × 16 B  (4 × u32 local star indices)
+  quads_block  n_quads × 16 B  (4 × u32 LE packed star refs:
+                                  bits[31..28] = neighbor_idx,
+                                  bits[27..0]  = local_idx in source cell's .zga)
   codes_block  n_quads × 32 B  (4 × f64)
 ```
+
+Pre-PR8 (v1) shards have `n_neighbors == 0` and every star_id has `neighbor_idx == 0` — the bottom 28 bits are the legacy local index. v2 readers reject v1 magic on parse; rebuild affected bundles to roll forward. The 4-bit `neighbor_idx` cap of 15 is well above the 8-edge-neighbor maximum of HEALPix nested cells.
 
 The reader pattern is:
 

--- a/src/bundle/manifest.rs
+++ b/src/bundle/manifest.rs
@@ -54,7 +54,13 @@ pub const FORMAT_MAGIC: &str = "zdcl-bundle";
 
 /// Current on-disk schema version. `load` rejects manifests with a different
 /// version (forward-compat is opt-in via a future match arm).
-pub const FORMAT_VERSION: u32 = 1;
+///
+/// Bumped to 2 in PR8 (cross-cell patch quads): the manifest itself
+/// keeps the same JSON shape, but `.zqd` shards inside a v2 bundle may
+/// carry a neighbor table and pack `(neighbor_idx, local_idx)` into each
+/// quad's star_ids. See `docs/bundle-format.md` and
+/// `crate::bundle::quad_shard` for the on-disk details.
+pub const FORMAT_VERSION: u32 = 2;
 
 /// Required `gaia.record_size` for a v1 bundle. Mismatches are rejected by
 /// `load` to prevent accidentally reading a 96 B-record bundle as 104 B (or

--- a/src/bundle/quad_shard.rs
+++ b/src/bundle/quad_shard.rs
@@ -18,16 +18,38 @@
 //! never consults its underlying stream's position when computing offsets;
 //! readers always interpret offsets relative to the slice they're given.
 //!
+//! ## Cross-cell patch quads (v2)
+//!
+//! v2 shards may carry quads whose member stars live in this cell *or* in
+//! one of its HEALPix edge-neighbors. The header carries a `n_neighbors`
+//! count and, immediately after it, a `n_neighbors × 8 B` table of the
+//! referenced neighbor cell ids. Each `u32` star_id in the quads block
+//! packs `(neighbor_idx << 28) | local_idx`:
+//!
+//! - `bits[31..28]` neighbor_idx: `0` = this cell; `1..=N` = entry
+//!   `neighbor_idx - 1` in the neighbor table. Max 15 neighbors fit in
+//!   four bits, which is plenty for HEALPix nested cells (≤ 8
+//!   edge-neighbors).
+//! - `bits[27..0]` local_idx: position in the indicated cell's `.zga`
+//!   record vector. Max 268 M.
+//!
+//! Pre-PR8 (v1) shards have an empty neighbor table; every star_id has
+//! `neighbor_idx == 0` and the bits-27..0 region is the legacy local
+//! index.
+//!
 //! Byte layout (all little-endian):
 //!
 //! ```text
 //! HEADER (32 B)
 //!   magic         8 B   b"ZDCLQUAD"
-//!   version       4 B   u32 LE = 1
+//!   version       4 B   u32 LE = 2
 //!   reserved      4 B   zero
 //!   cell_id       8 B   u64 LE
 //!   n_bands       4 B   u32 LE
-//!   reserved      4 B   pad to 8
+//!   n_neighbors   4 B   u32 LE   (was reserved padding in v1)
+//!
+//! NEIGHBOR TABLE   n_neighbors × 8 B
+//!   cell_id      8 B  u64 LE   referenced cell id
 //!
 //! BAND TABLE   n_bands × 24 B
 //!   band_idx     4 B  u32 LE
@@ -36,7 +58,7 @@
 //!   codes_offset 8 B  u64 LE   byte offset relative to shard start
 //!
 //! Per band, in band_idx order, no padding between blocks:
-//!   quads_block   n_quads × 16 B   (4 × u32 LE local star indices)
+//!   quads_block   n_quads × 16 B   (4 × u32 LE packed star refs)
 //!   codes_block   n_quads × 32 B   (4 × f64 LE)
 //! ```
 
@@ -53,20 +75,68 @@ compile_error!(
 pub const QUAD_SHARD_MAGIC: &[u8; 8] = b"ZDCLQUAD";
 
 /// On-disk format version this module reads and writes.
-pub const QUAD_SHARD_VERSION: u32 = 1;
+pub const QUAD_SHARD_VERSION: u32 = 2;
 
 /// Size of the fixed file header (magic + version + reserved + cell_id +
-/// n_bands + reserved).
+/// n_bands + n_neighbors).
 pub const HEADER_SIZE: usize = 32;
 
 /// Size of one band-table entry on disk.
 pub const BAND_ENTRY_SIZE: usize = 24;
+
+/// Size of one neighbor-table entry on disk (just a u64 cell id).
+pub const NEIGHBOR_ENTRY_SIZE: usize = 8;
 
 /// Encoded size of a single quad record on disk: `DIMQUADS × u32`.
 pub const QUAD_RECORD_SIZE: usize = DIMQUADS * 4;
 
 /// Encoded size of a single code record on disk: `DIMCODES × f64`.
 pub const CODE_RECORD_SIZE: usize = DIMCODES * 8;
+
+/// Maximum number of neighbor cells a v2 shard can reference. Limited by
+/// the 4-bit `neighbor_idx` field in each packed star_id (`0` is the self
+/// cell, leaving `1..=15` for neighbor-table entries).
+pub const MAX_NEIGHBORS: usize = 15;
+
+/// Maximum local-index value representable inside a packed star_id (28
+/// bits → 268,435,455).
+pub const MAX_LOCAL_IDX: u32 = (1u32 << 28) - 1;
+
+/// Pack a `(neighbor_idx, local_idx)` pair into the 32-bit on-disk
+/// representation: `(neighbor_idx << 28) | local_idx`.
+///
+/// `neighbor_idx == 0` means "this cell" (the .zqd's own cell). Values
+/// in `1..=MAX_NEIGHBORS` are interpreted by the reader as positions in
+/// the neighbor table (`neighbor_idx - 1`).
+///
+/// Returns `InvalidInput` if either field overflows its bit range.
+pub fn pack_star_id(neighbor_idx: u32, local_idx: u32) -> io::Result<u32> {
+    if neighbor_idx > MAX_NEIGHBORS as u32 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "neighbor_idx {neighbor_idx} exceeds 4-bit cap {MAX_NEIGHBORS}; \
+                 cannot pack into v2 quad star_id"
+            ),
+        ));
+    }
+    if local_idx > MAX_LOCAL_IDX {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "local_idx {local_idx} exceeds 28-bit cap {MAX_LOCAL_IDX}; \
+                 cannot pack into v2 quad star_id"
+            ),
+        ));
+    }
+    Ok((neighbor_idx << 28) | local_idx)
+}
+
+/// Reverse of [`pack_star_id`]: returns `(neighbor_idx, local_idx)`.
+#[inline]
+pub fn unpack_star_id(packed: u32) -> (u32, u32) {
+    (packed >> 28, packed & MAX_LOCAL_IDX)
+}
 
 // Compile-time sanity: the spec pins the on-disk layout at 16 B per quad and
 // 32 B per code, which assumes DIMQUADS = 4 and DIMCODES = 4. If those ever
@@ -75,6 +145,11 @@ const _: () = assert!(QUAD_RECORD_SIZE == 16);
 const _: () = assert!(CODE_RECORD_SIZE == 32);
 
 /// One band's quads + codes to be emitted into a `.zqd` file.
+///
+/// In v2 each `Quad.star_ids` entry is interpreted as a packed `(neighbor_idx,
+/// local_idx)` value (see [`pack_star_id`]). Single-cell quads pass
+/// `neighbor_idx = 0` and the local index unchanged, which is bit-identical
+/// to the v1 encoding.
 pub struct BandEmit<'a> {
     pub band_idx: u32,
     pub quads: &'a [Quad],
@@ -92,13 +167,15 @@ pub struct BandEntry {
 
 /// Borrowing reader over a mmapped (or otherwise loaded) `.zqd` byte slice.
 ///
-/// The header + band-table is parsed eagerly on construction (it's tiny —
-/// typically under 320 B for a dozen bands). Per-band quad / code blocks are
-/// decoded on demand via [`BandView`].
+/// The header + neighbor + band-table is parsed eagerly on construction
+/// (it's tiny — typically well under a kilobyte even for a dozen bands +
+/// eight neighbors). Per-band quad / code blocks are decoded on demand
+/// via [`BandView`].
 #[derive(Debug)]
 pub struct QuadShard<'a> {
     raw: &'a [u8],
     cell_id: u64,
+    neighbor_cells: Vec<u64>,
     band_table: Vec<BandEntry>,
 }
 
@@ -113,14 +190,24 @@ pub struct BandView<'a> {
 
 // --- writer ----------------------------------------------------------------
 
-/// Write a `.zqd` shard for one cell containing every band's quads/codes.
+/// Write a `.zqd` v2 shard for one cell containing every band's
+/// quads/codes plus an optional neighbor table referenced by patch
+/// quads.
+///
+/// `neighbor_cells` lists the cell ids that quads in `bands` may
+/// reference via the `neighbor_idx` portion of each packed `Quad.star_ids`
+/// element. Pass an empty slice for cells whose quads are all
+/// self-contained — the resulting shard then has an empty neighbor
+/// table and is byte-identical in spirit to a v1 shard apart from the
+/// version field.
 ///
 /// The writer accepts the bands in any order; entries are sorted ascending
 /// by `band_idx` before being written, so the on-disk band table is always
 /// monotonic. `band_idx` values must be unique across the input slice.
 ///
 /// Returns `InvalidInput` if any `Quad.star_ids` element does not fit in a
-/// `u32`, or if duplicate `band_idx` values are present, or if a band's
+/// `u32`, or if `neighbor_cells.len()` exceeds [`MAX_NEIGHBORS`], or if
+/// duplicate `band_idx` values are present, or if a band's
 /// `quads.len() != codes.len()`.
 ///
 /// **Offsets are slice-relative.** All `quads_offset` / `codes_offset`
@@ -139,8 +226,18 @@ pub struct BandView<'a> {
 pub fn write_quad_shard<W: Write>(
     w: &mut W,
     cell_id: u64,
+    neighbor_cells: &[u64],
     bands: &[BandEmit<'_>],
 ) -> io::Result<()> {
+    if neighbor_cells.len() > MAX_NEIGHBORS {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "neighbor_cells.len() = {} exceeds MAX_NEIGHBORS = {MAX_NEIGHBORS}",
+                neighbor_cells.len()
+            ),
+        ));
+    }
     // Build a sorted view of the input without mutating the caller's slice.
     // We sort indirectly via a Vec of references so we don't have to clone
     // BandEmit (which would also force its lifetime to be 'static).
@@ -188,6 +285,8 @@ pub fn write_quad_shard<W: Write>(
     }
 
     let n_bands = order.len() as u32;
+    let n_neighbors = neighbor_cells.len();
+    let neighbor_table_size = n_neighbors * NEIGHBOR_ENTRY_SIZE;
     let band_table_size = order.len() * BAND_ENTRY_SIZE;
 
     // Compute total shard size, then allocate one buffer. Offsets baked
@@ -199,7 +298,7 @@ pub fn write_quad_shard<W: Write>(
         let n_quads = b.quads.len();
         data_size += n_quads * QUAD_RECORD_SIZE + n_quads * CODE_RECORD_SIZE;
     }
-    let total_size = HEADER_SIZE + band_table_size + data_size;
+    let total_size = HEADER_SIZE + neighbor_table_size + band_table_size + data_size;
     let mut buf: Vec<u8> = Vec::with_capacity(total_size);
 
     // --- header --- (32 B)
@@ -208,8 +307,14 @@ pub fn write_quad_shard<W: Write>(
     buf.extend_from_slice(&0u32.to_le_bytes()); // reserved
     buf.extend_from_slice(&cell_id.to_le_bytes());
     buf.extend_from_slice(&n_bands.to_le_bytes());
-    buf.extend_from_slice(&0u32.to_le_bytes()); // reserved (header pad to 8)
+    buf.extend_from_slice(&(n_neighbors as u32).to_le_bytes());
     debug_assert_eq!(buf.len(), HEADER_SIZE);
+
+    // --- neighbor table --- (n_neighbors × 8 B)
+    for nc in neighbor_cells {
+        buf.extend_from_slice(&nc.to_le_bytes());
+    }
+    debug_assert_eq!(buf.len(), HEADER_SIZE + neighbor_table_size);
 
     // --- placeholder band table --- we'll fill the real entries in below
     // once we know each band's slice-relative quads/codes offsets.
@@ -316,9 +421,41 @@ impl<'a> QuadShard<'a> {
         // bytes[12..16] reserved
         let cell_id = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
         let n_bands = u32::from_le_bytes(bytes[24..28].try_into().unwrap()) as usize;
-        // bytes[28..32] reserved (pad)
+        let n_neighbors = u32::from_le_bytes(bytes[28..32].try_into().unwrap()) as usize;
 
-        let band_table_start = HEADER_SIZE;
+        if n_neighbors > MAX_NEIGHBORS {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "quad shard n_neighbors = {n_neighbors} exceeds MAX_NEIGHBORS = {MAX_NEIGHBORS}"
+                ),
+            ));
+        }
+
+        let neighbor_table_start = HEADER_SIZE;
+        let neighbor_table_end = neighbor_table_start
+            .checked_add(n_neighbors * NEIGHBOR_ENTRY_SIZE)
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "neighbor-table size overflow")
+            })?;
+        if neighbor_table_end > bytes.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "quad shard truncated: neighbor-table ends at {neighbor_table_end}, \
+                     file is {} bytes",
+                    bytes.len()
+                ),
+            ));
+        }
+        let mut neighbor_cells: Vec<u64> = Vec::with_capacity(n_neighbors);
+        for k in 0..n_neighbors {
+            let off = neighbor_table_start + k * NEIGHBOR_ENTRY_SIZE;
+            let nc = u64::from_le_bytes(bytes[off..off + 8].try_into().unwrap());
+            neighbor_cells.push(nc);
+        }
+
+        let band_table_start = neighbor_table_end;
         let band_table_end = band_table_start
             .checked_add(n_bands.checked_mul(BAND_ENTRY_SIZE).ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidData, "band-table size overflow")
@@ -480,6 +617,7 @@ impl<'a> QuadShard<'a> {
         Ok(QuadShard {
             raw: bytes,
             cell_id,
+            neighbor_cells,
             band_table,
         })
     }
@@ -494,6 +632,21 @@ impl<'a> QuadShard<'a> {
 
     pub fn bands(&self) -> &[BandEntry] {
         &self.band_table
+    }
+
+    /// Cell ids referenced by patch quads in this shard. The vector is
+    /// empty for shards whose quads are all self-contained (every
+    /// `Quad.star_ids` element packs `neighbor_idx == 0`).
+    ///
+    /// A packed star_id with `neighbor_idx == k > 0` resolves to
+    /// `neighbor_cells()[k - 1]`.
+    pub fn neighbor_cells(&self) -> &[u64] {
+        &self.neighbor_cells
+    }
+
+    /// Number of neighbor cells referenced (`neighbor_cells().len()`).
+    pub fn n_neighbors(&self) -> usize {
+        self.neighbor_cells.len()
     }
 
     /// Look up the entry for `band_idx` via binary search (O(log n_bands)).
@@ -567,10 +720,18 @@ mod tests {
     }
 
     fn write_to_vec(cell_id: u64, bands: &[BandEmit<'_>]) -> Vec<u8> {
+        write_to_vec_with_neighbors(cell_id, &[], bands)
+    }
+
+    fn write_to_vec_with_neighbors(
+        cell_id: u64,
+        neighbors: &[u64],
+        bands: &[BandEmit<'_>],
+    ) -> Vec<u8> {
         let mut buf = Vec::new();
         {
             let mut cur = Cursor::new(&mut buf);
-            write_quad_shard(&mut cur, cell_id, bands).expect("write_quad_shard");
+            write_quad_shard(&mut cur, cell_id, neighbors, bands).expect("write_quad_shard");
         }
         buf
     }
@@ -854,6 +1015,7 @@ mod tests {
         let err = write_quad_shard(
             &mut cur,
             7,
+            &[],
             &[
                 BandEmit {
                     band_idx: 2,
@@ -891,6 +1053,7 @@ mod tests {
         let err = write_quad_shard(
             &mut cur,
             0,
+            &[],
             &[BandEmit {
                 band_idx: 0,
                 quads: &q,
@@ -910,6 +1073,7 @@ mod tests {
         let err = write_quad_shard(
             &mut cur,
             0,
+            &[],
             &[BandEmit {
                 band_idx: 0,
                 quads: &q,
@@ -938,11 +1102,11 @@ mod tests {
         // Expected header (32 B):
         let expected_head: [u8; 32] = [
             // magic "ZDCLQUAD"
-            b'Z', b'D', b'C', b'L', b'Q', b'U', b'A', b'D', // version = 1 (u32 LE)
-            0x01, 0x00, 0x00, 0x00, // reserved
+            b'Z', b'D', b'C', b'L', b'Q', b'U', b'A', b'D', // version = 2 (u32 LE)
+            0x02, 0x00, 0x00, 0x00, // reserved
             0x00, 0x00, 0x00, 0x00, // cell_id (u64 LE)
             0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01, // n_bands = 1
-            0x01, 0x00, 0x00, 0x00, // reserved (pad)
+            0x01, 0x00, 0x00, 0x00, // n_neighbors = 0
             0x00, 0x00, 0x00, 0x00,
         ];
         assert_eq!(&bytes[..HEADER_SIZE], &expected_head[..]);
@@ -1129,6 +1293,116 @@ mod tests {
         assert!(err.to_string().contains("ascending"), "got: {err}");
     }
 
+    #[test]
+    fn pack_unpack_star_id_roundtrip() {
+        // Self-cell encoding: neighbor_idx = 0, local_idx unchanged.
+        let s = pack_star_id(0, 1234).unwrap();
+        assert_eq!(unpack_star_id(s), (0, 1234));
+
+        // Patch encoding: neighbor_idx = 5, large local_idx.
+        let p = pack_star_id(5, 0x0fff_abcd).unwrap();
+        assert_eq!(unpack_star_id(p), (5, 0x0fff_abcd));
+
+        // Boundary values.
+        assert_eq!(unpack_star_id(pack_star_id(0, 0).unwrap()), (0, 0));
+        assert_eq!(
+            unpack_star_id(pack_star_id(MAX_NEIGHBORS as u32, MAX_LOCAL_IDX).unwrap()),
+            (MAX_NEIGHBORS as u32, MAX_LOCAL_IDX)
+        );
+
+        // Out-of-range fields are rejected.
+        assert!(pack_star_id(MAX_NEIGHBORS as u32 + 1, 0).is_err());
+        assert!(pack_star_id(0, MAX_LOCAL_IDX + 1).is_err());
+    }
+
+    #[test]
+    fn neighbor_table_roundtrip() {
+        let neighbors: Vec<u64> = vec![10, 11, 12, 13, 14, 15, 16, 17];
+        // Every other quad references a neighbor cell.
+        let q: Vec<Quad> = vec![
+            Quad {
+                star_ids: [
+                    pack_star_id(0, 0).unwrap() as usize,
+                    pack_star_id(1, 5).unwrap() as usize,
+                    pack_star_id(0, 7).unwrap() as usize,
+                    pack_star_id(3, 9).unwrap() as usize,
+                ],
+            },
+            Quad {
+                star_ids: [
+                    pack_star_id(0, 1).unwrap() as usize,
+                    pack_star_id(0, 2).unwrap() as usize,
+                    pack_star_id(0, 3).unwrap() as usize,
+                    pack_star_id(0, 4).unwrap() as usize,
+                ],
+            },
+        ];
+        let c: Vec<Code> = vec![make_code(0.0), make_code(1.0)];
+        let bytes = write_to_vec_with_neighbors(
+            999,
+            &neighbors,
+            &[BandEmit {
+                band_idx: 0,
+                quads: &q,
+                codes: &c,
+            }],
+        );
+        let shard = QuadShard::parse(&bytes).expect("parse");
+        assert_eq!(shard.neighbor_cells(), neighbors.as_slice());
+        assert_eq!(shard.n_neighbors(), 8);
+
+        let view = shard.band(0).unwrap();
+        let got: Vec<Quad> = view.quads_iter().collect();
+        assert_eq!(got.len(), 2);
+        for (g, w) in got.iter().zip(q.iter()) {
+            assert_eq!(g.star_ids, w.star_ids);
+        }
+        let (n0, l0) = unpack_star_id(got[0].star_ids[1] as u32);
+        assert_eq!((n0, l0), (1, 5));
+    }
+
+    #[test]
+    fn empty_neighbor_table_roundtrip() {
+        let q: Vec<Quad> = vec![make_quad(1, 2, 3, 4)];
+        let c: Vec<Code> = vec![make_code(0.0)];
+        let bytes = write_to_vec_with_neighbors(
+            7,
+            &[],
+            &[BandEmit {
+                band_idx: 0,
+                quads: &q,
+                codes: &c,
+            }],
+        );
+        let shard = QuadShard::parse(&bytes).expect("parse");
+        assert!(shard.neighbor_cells().is_empty());
+        assert_eq!(shard.n_neighbors(), 0);
+        let got: Vec<Quad> = shard.band(0).unwrap().quads_iter().collect();
+        assert_eq!(got[0].star_ids, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn too_many_neighbors_rejected() {
+        let q: Vec<Quad> = vec![make_quad(1, 2, 3, 4)];
+        let c: Vec<Code> = vec![make_code(0.0)];
+        // 16 neighbors > MAX_NEIGHBORS (15).
+        let many: Vec<u64> = (0u64..16).collect();
+        let mut buf = Vec::new();
+        let mut cur = Cursor::new(&mut buf);
+        let err = write_quad_shard(
+            &mut cur,
+            0,
+            &many,
+            &[BandEmit {
+                band_idx: 0,
+                quads: &q,
+                codes: &c,
+            }],
+        )
+        .expect_err("oversized neighbor table must reject");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
     /// Regression for issue #84: shard offsets must be slice-relative, so
     /// a shard written mid-stream still round-trips when its embedded byte
     /// slice is handed to `QuadShard::parse`. Before the fix, the writer
@@ -1167,6 +1441,7 @@ mod tests {
             write_quad_shard(
                 &mut cur,
                 123,
+                &[],
                 &[
                     BandEmit {
                         band_idx: 0,

--- a/src/bundle/reader.rs
+++ b/src/bundle/reader.rs
@@ -45,7 +45,7 @@ use super::accessor::{FsAccessor, SubfileAccessor, ZipAccessor};
 use super::gaia_shard::{GaiaRecord, GaiaShard};
 use super::layout::cell_filename_width;
 use super::manifest::{BandInfo, BundleManifest, FORMAT_MAGIC, FORMAT_VERSION, GAIA_RECORD_SIZE};
-use super::quad_shard::QuadShard;
+use super::quad_shard::{QuadShard, unpack_star_id};
 
 /// Subdirectory holding `.zqd` quad shards inside a bundle.
 const QUADS_SUBDIR: &str = "quads";
@@ -101,7 +101,7 @@ pub struct VerifyError {
 pub enum VerifyErrorKind {
     /// Magic bytes did not match `b"ZDCLQUAD"` or `b"ZDCLGAIA"`.
     BadMagic,
-    /// On-disk format version was not the expected `1`.
+    /// On-disk format version was not the expected current value.
     BadVersion,
     /// Embedded `cell_id` field disagreed with the filename's cell id.
     BadCellId,
@@ -219,21 +219,65 @@ impl ZdclBundle {
     }
 
     /// Slice every band over `region`.
+    ///
+    /// Cross-cell patch quads (v2 shards) may reference stars in
+    /// HEALPix-edge-neighbor cells. The reader walks each region cell's
+    /// `.zqd` neighbor table, expands the loaded cell set to include every
+    /// referenced neighbor, and resolves each quad's packed `(neighbor_idx,
+    /// local_idx)` into a global index into the concatenated gaia vector.
     pub fn load_region(&self, region: &SkyRegion) -> io::Result<MultiBandFragment> {
-        let cells = self.cells_in_region(region);
+        let region_cells = self.cells_in_region(region);
 
-        // Per-cell parsed shards plus the running base index of each
-        // cell's gaia records inside the concatenated `gaia_records`.
-        struct CellLoaded {
+        // Per-region-cell quad-shard bytes (parsed once for the neighbor
+        // table). We hold both the entries and the parse output so the
+        // band loop below can reuse them.
+        struct RegionCell {
+            cell_id: u32,
             entries: Arc<CellEntries>,
-            base: usize,
-            n_records: usize,
+            neighbor_cells: Vec<u64>,
         }
-        let mut loaded: Vec<CellLoaded> = Vec::with_capacity(cells.len());
-        let mut gaia_records: Vec<GaiaRecord> = Vec::new();
+        let mut region_loaded: Vec<RegionCell> = Vec::with_capacity(region_cells.len());
 
-        for cell_id in &cells {
+        // Build the expanded cell set: the union of region cells and
+        // every neighbor any of their `.zqd` shards references. The
+        // expanded set is what we actually load `.zga` for.
+        let mut expanded_set: BTreeSet<u32> = BTreeSet::new();
+        for cell_id in &region_cells {
             let entries = self.cell_bytes(*cell_id)?;
+            let qs = QuadShard::parse(&entries.quads).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("cell {cell_id} quad shard: {e}"),
+                )
+            })?;
+            let neighbors = qs.neighbor_cells().to_vec();
+            // Add this cell + all referenced neighbors that fit in u32
+            // (every cell at a sane HEALPix depth does). Skip neighbors
+            // that aren't populated in this bundle — patch quads
+            // referencing absent neighbors are dropped on resolve below.
+            expanded_set.insert(*cell_id);
+            for &nc in &neighbors {
+                if nc <= u32::MAX as u64 {
+                    let nc32 = nc as u32;
+                    if self.populated_cells.contains(&nc32) {
+                        expanded_set.insert(nc32);
+                    }
+                }
+            }
+            region_loaded.push(RegionCell {
+                cell_id: *cell_id,
+                entries,
+                neighbor_cells: neighbors,
+            });
+        }
+
+        // Load every expanded cell's gaia records in cell-id order so
+        // `expanded_base[cell_id]` is the start of that cell's records
+        // in the concatenated gaia vector.
+        let mut gaia_records: Vec<GaiaRecord> = Vec::new();
+        let mut expanded_base: HashMap<u32, (usize, usize)> = HashMap::new(); // cell_id → (base, n_records)
+        for &cell_id in &expanded_set {
+            let entries = self.cell_bytes(cell_id)?;
             let gaia = GaiaShard::parse(&entries.gaia).map_err(|e| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -243,14 +287,9 @@ impl ZdclBundle {
             let base = gaia_records.len();
             let n = gaia.len();
             gaia_records.extend_from_slice(gaia.records());
-            loaded.push(CellLoaded {
-                entries,
-                base,
-                n_records: n,
-            });
+            expanded_base.insert(cell_id, (base, n));
         }
 
-        // Pre-build a per-band scale range pulled from the manifest.
         let n_bands = self.manifest.bands.len();
         let scale_ranges: Vec<(f64, f64)> = self
             .manifest
@@ -264,26 +303,24 @@ impl ZdclBundle {
             })
             .collect();
 
-        // Build the canonical IndexStar vector once from the unioned
-        // gaia records. Each band's fragment shares this list (cloned).
         let stars: Vec<IndexStar> = gaia_records.iter().map(gaia_record_to_index_star).collect();
 
-        // Concatenate per-band quads + codes across cells, remapping
-        // local cell-relative star indices to global indices into
-        // `gaia_records` via each cell's `base`.
+        // Concatenate per-band quads + codes across region cells,
+        // resolving each packed (neighbor_idx, local_idx) to a global
+        // index into `gaia_records`. Quads referencing a cell that
+        // isn't in the expanded set (e.g., a neighbor that wasn't
+        // populated by the build, or that the bundle is missing) are
+        // dropped — their codes are dropped alongside them.
         let mut per_band_quads: Vec<Vec<Quad>> = (0..n_bands).map(|_| Vec::new()).collect();
         let mut per_band_codes: Vec<Vec<Code>> = (0..n_bands).map(|_| Vec::new()).collect();
 
-        for cell in &loaded {
-            let qs = QuadShard::parse(&cell.entries.quads).map_err(|e| {
+        for region in &region_loaded {
+            let qs = QuadShard::parse(&region.entries.quads).map_err(|e| {
                 io::Error::new(io::ErrorKind::InvalidData, format!("cell quad shard: {e}"))
             })?;
             for entry in qs.bands() {
                 let band_idx = entry.band_idx as usize;
                 if band_idx >= n_bands {
-                    // Manifest says n_bands; on-disk band_idx out of
-                    // range is malformed but we surface a clear error
-                    // rather than panic.
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!(
@@ -300,26 +337,59 @@ impl ZdclBundle {
                 let c_dst = &mut per_band_codes[band_idx];
                 q_dst.reserve(entry.n_quads as usize);
                 c_dst.reserve(entry.n_quads as usize);
-                let base = cell.base;
-                let n_records = cell.n_records;
-                for q in view.quads_iter() {
-                    let mut remapped = q;
-                    for slot in remapped.star_ids.iter_mut() {
-                        if *slot >= n_records {
-                            return Err(io::Error::new(
-                                io::ErrorKind::InvalidData,
-                                format!(
-                                    "cell {} band {} quad references star idx {slot} but cell has only {n_records} records",
-                                    qs.cell_id(),
-                                    entry.band_idx
-                                ),
-                            ));
+
+                for (q, code) in view.quads_iter().zip(view.codes_iter()) {
+                    let mut resolved = [0usize; crate::quads::DIMQUADS];
+                    let mut ok = true;
+                    for (i, &packed) in q.star_ids.iter().enumerate() {
+                        let (nbr_idx, local_idx) = unpack_star_id(packed as u32);
+                        let source_cell: u32 = if nbr_idx == 0 {
+                            region.cell_id
+                        } else {
+                            let slot = (nbr_idx as usize) - 1;
+                            match region.neighbor_cells.get(slot) {
+                                Some(&nc) if nc <= u32::MAX as u64 => nc as u32,
+                                _ => {
+                                    return Err(io::Error::new(
+                                        io::ErrorKind::InvalidData,
+                                        format!(
+                                            "cell {} band {} quad references neighbor_idx {nbr_idx} but neighbor table has {} entries",
+                                            qs.cell_id(),
+                                            entry.band_idx,
+                                            region.neighbor_cells.len(),
+                                        ),
+                                    ));
+                                }
+                            }
+                        };
+                        match expanded_base.get(&source_cell) {
+                            Some(&(base, n_records)) => {
+                                if (local_idx as usize) >= n_records {
+                                    return Err(io::Error::new(
+                                        io::ErrorKind::InvalidData,
+                                        format!(
+                                            "cell {} band {} quad references star idx {local_idx} in cell {source_cell} but that cell has only {n_records} records",
+                                            qs.cell_id(),
+                                            entry.band_idx,
+                                        ),
+                                    ));
+                                }
+                                resolved[i] = base + (local_idx as usize);
+                            }
+                            None => {
+                                // Neighbor cell isn't loaded (not in
+                                // expanded set because not populated in
+                                // this bundle). Drop the quad.
+                                ok = false;
+                                break;
+                            }
                         }
-                        *slot += base;
                     }
-                    q_dst.push(remapped);
+                    if ok {
+                        q_dst.push(Quad { star_ids: resolved });
+                        c_dst.push(code);
+                    }
                 }
-                c_dst.extend(view.codes_iter());
             }
         }
 

--- a/src/bundle/tidy.rs
+++ b/src/bundle/tidy.rs
@@ -666,7 +666,7 @@ mod tests {
         let path = cell_shard_path(work_dir, QUADS_SUBDIR, QUAD_EXT, TEST_DEPTH, cell_id);
         let f = File::create(&path).unwrap();
         let mut buf = BufWriter::new(f);
-        write_quad_shard(&mut buf, cell_id as u64, bands).unwrap();
+        write_quad_shard(&mut buf, cell_id as u64, &[], bands).unwrap();
         buf.flush().unwrap();
     }
 

--- a/src/index/multiband_cell_builder.rs
+++ b/src/index/multiband_cell_builder.rs
@@ -566,7 +566,7 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
                         Vec::with_capacity(band_cfg.quads_per_cell);
                     let mut keep_codes: Vec<Code> =
                         Vec::with_capacity(band_cfg.quads_per_cell);
-                    for (q, c) in raw_quads.into_iter().zip(raw_codes.into_iter()) {
+                    for (q, c) in raw_quads.into_iter().zip(raw_codes) {
                         if keep_quads.len() >= band_cfg.quads_per_cell {
                             break;
                         }

--- a/src/index/multiband_cell_builder.rs
+++ b/src/index/multiband_cell_builder.rs
@@ -1,15 +1,33 @@
-//! Multi-band, cell-driven bundle work-dir builder (PR3 of the
-//! `.zdcl.bundle` roadmap).
+//! Multi-band, cell-driven bundle work-dir builder.
 //!
 //! Phase 1 of the bundle build pipeline: workers iterate cells in
 //! parallel, build every scale band's quads over each cell's star
 //! buffer, and emit per-cell `.zqd` (multi-band) and `.zga` shards
-//! into a work directory. The tidy phase (PR4), reader (PR5), and
-//! CLI (PR6) live in follow-up PRs; this module ships only the
-//! work-dir-producing primitive.
+//! into a work directory. The tidy phase finalizes the work_dir into
+//! a folder/zip bundle.
 //!
 //! See `docs/bundle-format.md` § "Phase 1 — parallel shard build" for
 //! the design.
+//!
+//! ## Two-phase build (PR8)
+//!
+//! - **Phase A** (gaia-only): walk cells in parallel, brightness-truncate,
+//!   sort by `source_id`, and write `.zga` shards atomically. Each
+//!   cell's gaia shard is the durable input for Phase B; once all cells
+//!   are committed, every cross-cell quad emitter has the data it needs
+//!   to build patch quads.
+//! - **Phase B** (patch quads): walk cells in parallel again. For each
+//!   cell C, parse its and its eight HEALPix edge-neighbors' `.zga`
+//!   files into one combined patch buffer, build every band's quads over
+//!   the patch, and write the resulting `.zqd` shard with a neighbor
+//!   table referencing whichever neighbor cells the quads actually used.
+//!
+//! Phase B's per-cell builds are independent (they only read sibling
+//! `.zga` files, never write to them), so the second pass parallelises
+//! cleanly. Cells whose quads turn out to be entirely self-contained
+//! emit a `.zqd` with an empty neighbor table — bit-identical (apart
+//! from the `version = 2` field and the `n_neighbors = 0` slot) to the
+//! pre-PR8 layout.
 //!
 //! ## Shape
 //!
@@ -23,13 +41,13 @@
 //!
 //! ## Resume granularity
 //!
-//! A cell is "done" iff `completed_cells.contains(cell_id)` AND every
-//! band is marked complete for it. The orchestrator marks all bands
-//! complete in one critical section after the `.zqd` rename succeeds,
-//! so `(cell, band)` granularity is effectively per-cell at this
-//! revision — the per-band manifest field is recorded for forward
-//! compatibility with PR4+ if a future builder ever races a single
-//! cell's bands across workers.
+//! A cell is "done" iff its `.zga` exists AND `is_complete(cell_id)`
+//! AND every band is `is_band_complete(cell_id, band_idx)`. Phase A
+//! commits a cell as `is_complete` (and as empty in `completed_per_band`
+//! for empty cells) once its `.zga` is durable on disk. Phase B
+//! flips each band complete after the `.zqd` rename succeeds. Resume
+//! semantics: a cell whose `.zga` was committed but whose `.zqd` was
+//! not skips Phase A (already done) and runs only Phase B.
 
 use std::collections::hash_map::DefaultHasher;
 use std::fs::File;
@@ -41,12 +59,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use rayon::prelude::*;
 
-use crate::bundle::gaia_shard::{GaiaRecord, write_gaia_shard};
+use crate::bundle::gaia_shard::{GaiaRecord, GaiaShard, write_gaia_shard};
 use crate::bundle::layout::cell_shard_path;
-use crate::bundle::quad_shard::{BandEmit, QuadShard, write_quad_shard};
+use crate::bundle::quad_shard::{
+    BandEmit, MAX_NEIGHBORS, QuadShard, pack_star_id, write_quad_shard,
+};
+use crate::quads::{Code, DIMQUADS, Quad};
 
 use super::build_manifest::{BuildManifest, CellStats};
-use super::cell_builder::CellStarSource;
+use super::cell_builder::{CellStar, CellStarSource};
 use super::quads::build_quads_for_cell_multiband;
 
 /// One scale band in a multi-band bundle build.
@@ -217,48 +238,22 @@ fn nonce_hex(cell_id: u32, seed: u64) -> String {
     format!("{:08x}", v as u32)
 }
 
-/// Per-cell write entry-point: emit the `.zqd` and `.zga` shards
-/// atomically into `work_dir/{quads,gaia}/`.
+/// Phase A per-cell write: emit just the `.zga` shard atomically.
 ///
-/// Skips writing entirely if both `bands_emit` is all-empty AND
-/// `gaia_records` is empty. Otherwise writes both files: `.part.HHHHHHHH`
-/// → fsync → atomic rename onto the canonical name.
-///
-/// Returns one quad count per band in `bands_emit`, in input order.
-pub fn write_cell_shards(
+/// Returns the on-disk gaia records (sorted by source_id, mutated in
+/// place by the writer). The caller may discard them — Phase B re-reads
+/// every cell's `.zga` from disk so it always sees the durable bytes.
+fn write_gaia_shard_only(
     work_dir: &Path,
     cell_depth: u8,
     cell_id: u32,
-    bands_emit: &[BandEmit<'_>],
     mut gaia_records: Vec<GaiaRecord>,
     nonce_seed: u64,
-) -> io::Result<Vec<u64>> {
-    let counts: Vec<u64> = bands_emit.iter().map(|b| b.quads.len() as u64).collect();
-    let all_quads_empty = bands_emit.iter().all(|b| b.quads.is_empty());
-    if all_quads_empty && gaia_records.is_empty() {
-        return Ok(counts);
+) -> io::Result<()> {
+    if gaia_records.is_empty() {
+        return Ok(());
     }
-
     let nonce = nonce_hex(cell_id, nonce_seed);
-
-    // ---------- quad shard -------------------------------------------------
-    let zqd_final = cell_shard_path(work_dir, QUADS_SUBDIR, QUAD_EXT, cell_depth, cell_id);
-    let zqd_partial: PathBuf = {
-        let mut s = zqd_final.as_os_str().to_owned();
-        s.push(".part.");
-        s.push(&nonce);
-        PathBuf::from(s)
-    };
-    {
-        let f = File::create(&zqd_partial)?;
-        let mut w = BufWriter::new(f);
-        write_quad_shard(&mut w, cell_id as u64, bands_emit)?;
-        w.flush()?;
-        w.get_ref().sync_all()?;
-    }
-    std::fs::rename(&zqd_partial, &zqd_final)?;
-
-    // ---------- gaia shard -------------------------------------------------
     let zga_final = cell_shard_path(work_dir, GAIA_SUBDIR, GAIA_EXT, cell_depth, cell_id);
     let zga_partial: PathBuf = {
         let mut s = zga_final.as_os_str().to_owned();
@@ -274,17 +269,58 @@ pub fn write_cell_shards(
         w.get_ref().sync_all()?;
     }
     std::fs::rename(&zga_partial, &zga_final)?;
+    Ok(())
+}
 
-    Ok(counts)
+/// Phase B per-cell write: emit the `.zqd` shard atomically, including
+/// any neighbor-table entries referenced by patch quads.
+fn write_quad_shard_only(
+    work_dir: &Path,
+    cell_depth: u8,
+    cell_id: u32,
+    neighbor_cells: &[u64],
+    bands_emit: &[BandEmit<'_>],
+    nonce_seed: u64,
+) -> io::Result<()> {
+    let all_quads_empty = bands_emit.iter().all(|b| b.quads.is_empty());
+    // Even cells with no quads in any band still need a .zqd on disk so
+    // that the reader's populated-cell enumeration (which lists `.zqd`
+    // files) finds them. Skip only when there are no bands at all.
+    if bands_emit.is_empty() && all_quads_empty {
+        return Ok(());
+    }
+
+    let nonce = nonce_hex(cell_id, nonce_seed);
+    let zqd_final = cell_shard_path(work_dir, QUADS_SUBDIR, QUAD_EXT, cell_depth, cell_id);
+    let zqd_partial: PathBuf = {
+        let mut s = zqd_final.as_os_str().to_owned();
+        s.push(".part.");
+        s.push(&nonce);
+        PathBuf::from(s)
+    };
+    {
+        let f = File::create(&zqd_partial)?;
+        let mut w = BufWriter::new(f);
+        write_quad_shard(&mut w, cell_id as u64, neighbor_cells, bands_emit)?;
+        w.flush()?;
+        w.get_ref().sync_all()?;
+    }
+    std::fs::rename(&zqd_partial, &zqd_final)?;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
 //  Orchestrator
 // ---------------------------------------------------------------------------
 
-/// Phase-1 orchestrator: build every cell's per-cell shards in
-/// parallel, atomic-renaming each into place and updating the build
-/// manifest after every successful commit.
+/// Two-phase orchestrator: write every cell's `.zga` (Phase A), then
+/// build cross-cell patch quads against each cell + its HEALPix
+/// neighbors and write `.zqd` (Phase B).
+///
+/// Both phases iterate cells in parallel and update the build manifest
+/// after every successful per-cell commit. Resume semantics are
+/// per-phase: a cell whose `.zga` was committed but whose `.zqd` was
+/// not skips Phase A and runs only Phase B on the next invocation.
 pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
     source: &S,
     config: &MultiBandCellBuildConfig,
@@ -304,37 +340,57 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
     manifest.ensure_per_band(n_bands);
     manifest.save(work_dir)?;
 
-    // Collect cells to process. Skip cells that are completed in
-    // `completed_cells` *and* in every per-band set.
-    let cell_count = source.cell_count();
-    let mut to_process: Vec<u32> = Vec::with_capacity(cell_count as usize);
-    let mut n_cells_resumed = 0u32;
-    for cell_id in 0..cell_count {
-        let cell_complete = manifest.is_complete(cell_id);
-        let bands_complete = (0..n_bands as u32).all(|b| manifest.is_band_complete(cell_id, b));
-        if cell_complete && bands_complete {
-            n_cells_resumed += 1;
-        } else {
-            to_process.push(cell_id);
-        }
-    }
-
-    // Sort the bands once up front; pass them to the per-cell loop in
-    // a stable band-idx order so the band table on disk matches the
+    // Sort the bands once up front; pass them to both phases in a
+    // stable band-idx order so the band table on disk matches the
     // configured layout.
     let mut sorted_bands: Vec<ScaleBand> = config.bands.clone();
     sorted_bands.sort_by_key(|b| b.band_idx);
 
-    let manifest = Mutex::new(manifest);
-    let n_cells_empty = std::sync::atomic::AtomicU32::new(0);
-    let n_cells_processed = std::sync::atomic::AtomicU32::new(0);
-    let max_stars_per_cell = config.max_stars_per_cell;
+    let cell_count = source.cell_count();
     let cell_depth = config.cell_depth;
 
-    let result: io::Result<()> = to_process.par_iter().try_for_each(|&cell_id| {
+    // Capture which cells were already fully done (both phases
+    // committed) before this invocation so the summary's
+    // `n_cells_resumed` only counts those.
+    let initially_resumed: std::collections::HashSet<u32> = (0..cell_count)
+        .filter(|&cell_id| {
+            manifest.is_complete(cell_id)
+                && (0..n_bands as u32).all(|b| manifest.is_band_complete(cell_id, b))
+        })
+        .collect();
+
+    // -------- Phase A: walk cells, write .zga shards. ----------------
+    //
+    // A cell is in scope for Phase A iff its `.zga` is not yet on disk.
+    // Resume picks up cleanly: previously committed `.zga`s skip the
+    // (potentially expensive) per-cell pull, but their cell ids stay in
+    // `manifest.completed_cells` so Phase B can iterate them.
+    let mut phase_a_cells: Vec<u32> = Vec::new();
+    for cell_id in 0..cell_count {
+        let zga = cell_shard_path(work_dir, GAIA_SUBDIR, GAIA_EXT, cell_depth, cell_id);
+        // Cell already had Phase A done iff:
+        //   - it's marked complete in the manifest, AND
+        //   - either its zga exists (had stars) OR commit_cell stats are zero (empty cell).
+        // The simplest way to encode that is: skip iff manifest.is_complete(cell_id)
+        // AND (zga exists OR the cell is recorded with zero n_stars).
+        if manifest.is_complete(cell_id) {
+            // Empty cells stay empty on resume; cells with stars must
+            // have an existing zga (or we'd have crashed before the
+            // commit_cell line).
+            if zga.exists() || cell_recorded_empty(&manifest, cell_id) {
+                continue;
+            }
+        }
+        phase_a_cells.push(cell_id);
+    }
+
+    let manifest = Mutex::new(manifest);
+    let n_cells_empty = std::sync::atomic::AtomicU32::new(0);
+    let max_stars_per_cell = config.max_stars_per_cell;
+
+    let phase_a: io::Result<()> = phase_a_cells.par_iter().try_for_each(|&cell_id| {
         let mut stars = source.stars_in_cell(cell_id)?;
 
-        // Brightness-truncate: sort by mag ascending, take the first N.
         if stars.len() > max_stars_per_cell {
             stars.sort_by(|a, b| {
                 a.mag
@@ -345,10 +401,10 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
         }
 
         if stars.is_empty() {
-            // Empty cell: still mark complete so a resume run doesn't
-            // re-pull it.
             let mut m = manifest.lock().unwrap();
             m.commit_cell(work_dir, cell_id, CellStats::default())?;
+            // Empty cells are also "done" for every band — there are
+            // no patch quads to build.
             for b in &sorted_bands {
                 m.mark_band_complete(cell_id, b.band_idx);
             }
@@ -358,19 +414,10 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
             return Ok::<(), io::Error>(());
         }
 
-        // Build all bands' quads over this cell's stars (sorted-by-mag
-        // already; build_quads_for_cell re-sorts internally, that's
-        // fine — same result).
-        let mut band_blocks = build_quads_for_cell_multiband(&stars, &sorted_bands);
-
-        // Build the gaia record vector for this cell, preserving
-        // `stars` order so quad star_ids are still valid.
-        let mut gaia_records: Vec<GaiaRecord> = stars
+        let gaia_records: Vec<GaiaRecord> = stars
             .iter()
             .map(|s| {
                 let mut g = s.gaia;
-                // Set the supplement bit if the source_id's high bit
-                // is set; mirrors starfield-gaia's encoding.
                 if (s.gaia.source_id >> 63) & 1 == 1 {
                     g.flags |= GaiaRecord::FLAG_SOURCE_KIND_SUPPLEMENT;
                 }
@@ -378,37 +425,217 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
             })
             .collect();
 
-        // The on-disk `.zga` is sorted by source_id (write_gaia_shard
-        // sorts internally). Quad star_ids reference cell-local
-        // indices, so we must remap them through the same permutation
-        // used to sort the gaia records — otherwise the reader walks
-        // a quad's star_ids into the SORTED vec but the original
-        // computation referenced UNSORTED positions, producing
-        // garbage WCS hypotheses on lookup.
-        //
-        // Build the source_id-sort permutation, apply it to
-        // `gaia_records`, then rewrite every quad's star_ids through
-        // the inverse permutation `old_idx -> new_idx`.
-        let n_records = gaia_records.len();
-        let mut order: Vec<usize> = (0..n_records).collect();
-        order.sort_by_key(|&i| gaia_records[i].source_id);
-        let mut old_to_new = vec![0usize; n_records];
-        for (new_idx, &old_idx) in order.iter().enumerate() {
-            old_to_new[old_idx] = new_idx;
+        let n_stars = stars.len() as u64;
+        write_gaia_shard_only(work_dir, cell_depth, cell_id, gaia_records, cell_id as u64)?;
+
+        let mut m = manifest.lock().unwrap();
+        m.commit_cell(
+            work_dir,
+            cell_id,
+            CellStats {
+                n_stars,
+                n_quads: 0, // Filled in by Phase B.
+            },
+        )?;
+        m.save(work_dir)?;
+        drop(m);
+
+        Ok(())
+    });
+    phase_a?;
+
+    // Best-effort fsync the gaia subdirectory so every committed `.zga`
+    // is durably named before Phase B starts reading them.
+    if let Ok(dir) = File::open(work_dir.join(GAIA_SUBDIR)) {
+        let _ = dir.sync_all();
+    }
+
+    // -------- Phase B: walk cells, build patch quads, write .zqd. -----
+    //
+    // A cell is in scope for Phase B iff:
+    //   - it has a `.zga` on disk (i.e. Phase A produced records), AND
+    //   - at least one of its bands is not yet marked complete.
+    let mut phase_b_cells: Vec<u32> = Vec::new();
+    {
+        let m = manifest.lock().unwrap();
+        for cell_id in 0..cell_count {
+            let zga = cell_shard_path(work_dir, GAIA_SUBDIR, GAIA_EXT, cell_depth, cell_id);
+            if !zga.exists() {
+                continue;
+            }
+            let all_bands_done = (0..n_bands as u32).all(|b| m.is_band_complete(cell_id, b));
+            if !all_bands_done {
+                phase_b_cells.push(cell_id);
+            }
         }
-        let sorted_gaia: Vec<GaiaRecord> = order.iter().map(|&i| gaia_records[i]).collect();
-        gaia_records = sorted_gaia;
-        for (_band_idx, quads, _codes) in band_blocks.iter_mut() {
-            for q in quads.iter_mut() {
-                for slot in q.star_ids.iter_mut() {
-                    *slot = old_to_new[*slot];
-                }
+    }
+    let phase_b: io::Result<()> = phase_b_cells.par_iter().try_for_each(|&cell_id| {
+        // Compute neighbor cell ids at this depth via cdshealpix. The
+        // returned list is up to 8 ids; some of them may not have been
+        // populated by Phase A (empty cells), so the patch loader filters
+        // those out.
+        let mut neighbors: Vec<u64> = Vec::with_capacity(8);
+        cdshealpix::nested::append_bulk_neighbours(
+            cell_depth,
+            cell_id as u64,
+            &mut neighbors,
+        );
+        // Self goes first so its records dominate the patch when ties
+        // matter; neighbors follow in deterministic ascending order.
+        // (cdshealpix returns them in a direction-enum order we don't
+        // care about; sort for reproducibility regardless of caller.)
+        neighbors.sort_unstable();
+        let mut patch_cells: Vec<u64> = Vec::with_capacity(neighbors.len() + 1);
+        patch_cells.push(cell_id as u64);
+        for &nc in &neighbors {
+            if nc == cell_id as u64 {
+                continue; // defensive — shouldn't happen, but skip self repeats
+            }
+            patch_cells.push(nc);
+        }
+
+        // Read every patch cell's `.zga` once; assemble:
+        //   combined_stars    Vec<CellStar>     for build_quads_for_cell_multiband
+        //   per_star_origin   Vec<(cell_id, local_idx)>  parallel, one per star
+        let mut combined_stars: Vec<CellStar> = Vec::new();
+        let mut per_star_origin: Vec<(u64, u32)> = Vec::new();
+        for &pc in &patch_cells {
+            // Only depth-fitted u32 cells exist on disk in this build.
+            if pc > u32::MAX as u64 {
+                continue;
+            }
+            let zga_path =
+                cell_shard_path(work_dir, GAIA_SUBDIR, GAIA_EXT, cell_depth, pc as u32);
+            if !zga_path.exists() {
+                continue;
+            }
+            let bytes = std::fs::read(&zga_path)?;
+            let shard = GaiaShard::parse(&bytes).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "phase B: cell {cell_id} failed to parse neighbor {pc} .zga: {e}"
+                    ),
+                )
+            })?;
+            for (local_idx, rec) in shard.records().iter().enumerate() {
+                combined_stars.push(gaia_record_to_cell_star(rec));
+                per_star_origin.push((pc, local_idx as u32));
             }
         }
 
-        // Materialize band emit slices for the writer (must be after
-        // the remap above).
-        let bands_emit: Vec<BandEmit<'_>> = band_blocks
+        if combined_stars.is_empty() {
+            // Defensive: zga existed but was empty. Mark all bands
+            // complete so we don't loop forever on resume.
+            let mut m = manifest.lock().unwrap();
+            for b in &sorted_bands {
+                m.mark_band_complete(cell_id, b.band_idx);
+            }
+            m.save(work_dir)?;
+            return Ok::<(), io::Error>(());
+        }
+
+        // Build all bands' quads over the combined patch buffer. Quad
+        // star_ids are positions in `combined_stars`, which we then map
+        // back to `(source_cell_id, local_idx)` via per_star_origin.
+        //
+        // Patch quads can span cell boundaries; the same physical
+        // asterism would be discovered redundantly in every cell whose
+        // patch encloses all 4 stars. To emit each quad exactly once
+        // (and to keep per-cell `quads_per_cell` budgets honest), filter
+        // each quad to the file of its centroid cell — the HEALPix cell
+        // containing the unit-vector mean of the 4 member stars. The
+        // builder runs with an inflated budget so the post-filter still
+        // hits each cell's nominal quad count for the band.
+        let inflated_bands: Vec<ScaleBand> = sorted_bands
+            .iter()
+            .map(|b| ScaleBand {
+                quads_per_cell: b.quads_per_cell.saturating_mul(9),
+                ..b.clone()
+            })
+            .collect();
+        let raw_band_blocks =
+            build_quads_for_cell_multiband(&combined_stars, &inflated_bands);
+
+        let band_blocks: Vec<(u32, Vec<Quad>, Vec<Code>)> =
+            raw_band_blocks
+                .into_iter()
+                .zip(sorted_bands.iter())
+                .map(|((band_idx, raw_quads, raw_codes), band_cfg)| {
+                    let mut keep_quads: Vec<Quad> =
+                        Vec::with_capacity(band_cfg.quads_per_cell);
+                    let mut keep_codes: Vec<Code> =
+                        Vec::with_capacity(band_cfg.quads_per_cell);
+                    for (q, c) in raw_quads.into_iter().zip(raw_codes.into_iter()) {
+                        if keep_quads.len() >= band_cfg.quads_per_cell {
+                            break;
+                        }
+                        let centroid = quad_centroid(&q, &combined_stars);
+                        let centroid_cell = cdshealpix::nested::hash(
+                            cell_depth,
+                            centroid.0,
+                            centroid.1,
+                        );
+                        if centroid_cell == cell_id as u64 {
+                            keep_quads.push(q);
+                            keep_codes.push(c);
+                        }
+                    }
+                    (band_idx, keep_quads, keep_codes)
+                })
+                .collect();
+
+        // Encode each quad's star_ids into the v2 packed format and
+        // build the per-cell neighbor table from the unique non-self
+        // source cell ids actually referenced.
+        let self_cell = cell_id as u64;
+        let mut neighbor_table: Vec<u64> = Vec::new();
+        // Maps a referenced neighbor cell id → 1-based slot in neighbor_table.
+        let mut neighbor_slot: std::collections::HashMap<u64, u32> =
+            std::collections::HashMap::new();
+
+        let mut packed_blocks: Vec<(u32, Vec<Quad>, Vec<Code>)> =
+            Vec::with_capacity(band_blocks.len());
+        for (band_idx, quads, codes) in band_blocks {
+            let mut packed_quads: Vec<Quad> = Vec::with_capacity(quads.len());
+            for q in quads {
+                let mut new_ids = [0usize; DIMQUADS];
+                for (i, &combined_idx) in q.star_ids.iter().enumerate() {
+                    let (origin_cell, origin_local) = per_star_origin[combined_idx];
+                    let nbr_idx = if origin_cell == self_cell {
+                        0u32
+                    } else {
+                        match neighbor_slot.get(&origin_cell) {
+                            Some(&slot) => slot,
+                            None => {
+                                let next_slot = neighbor_table.len() as u32 + 1;
+                                if next_slot
+                                    > MAX_NEIGHBORS as u32
+                                {
+                                    return Err(io::Error::new(
+                                        io::ErrorKind::InvalidInput,
+                                        format!(
+                                            "phase B: cell {cell_id} would reference {} neighbor cells, exceeding the {}-cell on-disk cap",
+                                            next_slot,
+                                            MAX_NEIGHBORS,
+                                        ),
+                                    ));
+                                }
+                                neighbor_table.push(origin_cell);
+                                neighbor_slot.insert(origin_cell, next_slot);
+                                next_slot
+                            }
+                        }
+                    };
+                    let packed = pack_star_id(nbr_idx, origin_local)?;
+                    new_ids[i] = packed as usize;
+                }
+                packed_quads.push(Quad { star_ids: new_ids });
+            }
+            packed_blocks.push((band_idx, packed_quads, codes));
+        }
+
+        let bands_emit: Vec<BandEmit<'_>> = packed_blocks
             .iter()
             .map(|(idx, qs, cs)| BandEmit {
                 band_idx: *idx,
@@ -417,24 +644,32 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
             })
             .collect();
 
-        let _ = write_cell_shards(
+        write_quad_shard_only(
             work_dir,
             cell_depth,
             cell_id,
+            &neighbor_table,
             &bands_emit,
-            gaia_records,
             cell_id as u64,
         )?;
 
-        let n_stars = stars.len() as u64;
-        let n_quads_total: u64 = band_blocks.iter().map(|(_, qs, _)| qs.len() as u64).sum();
+        let n_quads_total: u64 = packed_blocks.iter().map(|(_, qs, _)| qs.len() as u64).sum();
 
+        // Update the manifest: the cell is already in completed_cells
+        // (Phase A added it); commit_cell with the same n_stars and the
+        // new n_quads is idempotent in cell_stats but updates n_quads.
         let mut m = manifest.lock().unwrap();
+        let existing_n_stars = m
+            .cell_stats
+            .iter()
+            .find(|(c, _)| *c == cell_id)
+            .map(|(_, s)| s.n_stars)
+            .unwrap_or(0);
         m.commit_cell(
             work_dir,
             cell_id,
             CellStats {
-                n_stars,
+                n_stars: existing_n_stars,
                 n_quads: n_quads_total,
             },
         )?;
@@ -444,12 +679,29 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
         m.save(work_dir)?;
         drop(m);
 
-        n_cells_processed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(())
     });
-    result?;
+    phase_b?;
 
     let final_manifest = manifest.into_inner().unwrap();
+
+    // n_cells_processed = unique cells that needed any work this run
+    // (Phase A, Phase B, or both). Cells already done before the run
+    // are tracked via `n_cells_resumed`. Empty cells are tracked
+    // separately.
+    let mut touched: std::collections::HashSet<u32> = std::collections::HashSet::new();
+    for &c in &phase_a_cells {
+        touched.insert(c);
+    }
+    for &c in &phase_b_cells {
+        touched.insert(c);
+    }
+    // Empty cells are part of phase_a_cells but tracked separately on
+    // the summary. Subtract them from n_cells_processed so the field
+    // reflects "cells that produced shards on disk" not "cells visited".
+    let n_empty = n_cells_empty.into_inner();
+    let n_cells_processed = (touched.len() as u32).saturating_sub(n_empty);
+    let n_cells_resumed = initially_resumed.len() as u32;
 
     // ---------- per-band totals via mmapped re-scan ----------------------
     let mut per_band_quad_counts = vec![0u64; n_bands];
@@ -474,13 +726,85 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
     }
 
     Ok(BuildBundleSummary {
-        n_cells_processed: n_cells_processed.into_inner(),
+        n_cells_processed,
         n_cells_resumed,
-        n_cells_empty: n_cells_empty.into_inner(),
+        n_cells_empty: n_empty,
         n_stars: final_manifest.n_stars,
         per_band_quad_counts,
         per_band_populated_cells,
     })
+}
+
+/// Compute a quad's spherical centroid — the unit-vector mean of its
+/// four member stars, projected back to (RA, Dec) in radians. Used to
+/// decide which HEALPix cell's `.zqd` a patch quad belongs to: by
+/// convention each quad is emitted once, in the file of the cell
+/// containing its centroid.
+fn quad_centroid(q: &Quad, stars: &[CellStar]) -> (f64, f64) {
+    use crate::geom::sphere::radec_to_xyz;
+    let mut sum = [0.0f64; 3];
+    for &i in &q.star_ids {
+        let s = &stars[i];
+        let v = radec_to_xyz(s.ra_rad, s.dec_rad);
+        for k in 0..3 {
+            sum[k] += v[k];
+        }
+    }
+    // Normalize back to a unit vector.
+    let n = (sum[0] * sum[0] + sum[1] * sum[1] + sum[2] * sum[2]).sqrt();
+    if n == 0.0 {
+        return (0.0, 0.0);
+    }
+    let x = sum[0] / n;
+    let y = sum[1] / n;
+    let z = sum[2] / n;
+    let dec = z.clamp(-1.0, 1.0).asin();
+    let ra = y.atan2(x).rem_euclid(2.0 * std::f64::consts::PI);
+    (ra, dec)
+}
+
+/// True iff the manifest records `cell_id` with zero stars (i.e. an
+/// empty-cell commit). Used by Phase A's resume check to distinguish
+/// "this cell was empty and we already noted that" from "this cell
+/// crashed mid-write and needs a retry".
+fn cell_recorded_empty(manifest: &BuildManifest, cell_id: u32) -> bool {
+    manifest
+        .cell_stats
+        .iter()
+        .any(|(c, s)| *c == cell_id && s.n_stars == 0)
+}
+
+/// Build a `CellStar` minimally from a `GaiaRecord` — just the four
+/// fields `build_quads_for_cell_multiband` actually consumes (RA/Dec in
+/// radians, magnitude, catalog_id). The unused sidecar/gaia fields are
+/// populated from the same record for completeness, but the inner quad
+/// builder never reads them.
+fn gaia_record_to_cell_star(g: &GaiaRecord) -> CellStar {
+    CellStar {
+        catalog_id: g.source_id,
+        ra_rad: g.ra.to_radians(),
+        dec_rad: g.dec.to_radians(),
+        mag: g.phot_g_mean_mag,
+        // The patch builder never inspects these; populate them from
+        // the same record so the struct is well-formed.
+        sidecar: crate::refinement::SidecarRecord {
+            source_id: g.source_id,
+            ref_epoch: g.ref_epoch,
+            ra: g.ra,
+            dec: g.dec,
+            pmra: g.pmra,
+            pmdec: g.pmdec,
+            parallax: g.parallax,
+            radial_velocity: g.radial_velocity,
+            sigma_ra: g.sigma_ra,
+            sigma_dec: g.sigma_dec,
+            sigma_pmra: g.sigma_pmra,
+            sigma_pmdec: g.sigma_pmdec,
+            sigma_parallax: g.sigma_parallax,
+            flags: g.flags,
+        },
+        gaia: *g,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -796,9 +1120,15 @@ mod tests {
             pull_count: AtomicU32::new(0),
         };
         let summary = build_bundle_work_dir(&source2, &cfg, &paths).unwrap();
-        assert_eq!(summary.n_cells_resumed, 2);
-        assert_eq!(summary.n_cells_processed, 2);
-        // Cells 0+1 must NOT be re-pulled.
+        // After a crash mid-Phase-A, cells 0+1 had Phase A done but
+        // not Phase B; on resume they need Phase B work, so they're
+        // counted in `n_cells_processed`. No cell was fully done before
+        // the resume started (a fully-done cell needs both phases), so
+        // `n_cells_resumed` is zero. All four cells go through Phase B.
+        assert_eq!(summary.n_cells_resumed, 0);
+        assert_eq!(summary.n_cells_processed, 4);
+        // Cells 0+1 must NOT be re-pulled (their .zga is durable from
+        // the previous run, so Phase A skips them).
         assert_eq!(source2.pull_count.load(Ordering::Relaxed), 2);
 
         // Compare to a fresh clean build.


### PR DESCRIPTION
## Summary

Bumps the `.zdcl` bundle format from v1 to v2 to support quads whose
member stars span HEALPix cell boundaries. The cell-driven builder
previously restricted each quad's 4 stars to a single cell, dropping
the asterisms (~38% of test cases) whose centroid straddles a cell
edge — those fields could never solve, no matter how good the verifier.

The architectural fix: each cell now builds quads against a 9-cell
patch (itself plus 8 HEALPix edge-neighbors), filters quads to those
whose centroid lands in the cell (so each physical asterism is emitted
exactly once), and writes a `.zqd` shard whose star_ids pack
`(neighbor_idx, local_idx)` with the neighbor table at the head of the
file. Pre-PR8 v1 shards do not parse under v2 — rebuild affected
bundles to roll forward.

## Format change

- **`.zqd` header** gains a `u32 n_neighbors` field (replaces the old
  reserved pad) followed by `n_neighbors × u64` neighbor-cell ids.
- **Each quad's 4 `u32` star_ids** now pack
  `(neighbor_idx << 28) | local_idx`. `neighbor_idx == 0` means "this
  cell"; values `1..=15` index into the neighbor table. 4 bits is
  plenty for HEALPix nested cells (≤ 8 edge-neighbors).
- **`BundleManifest.format_version`** → 2.

See `docs/bundle-format.md` for the updated layout.

## Build pipeline

`build_bundle_work_dir` now runs in two phases:
- **Phase A** writes each cell's `.zga` (gaia records). Once durable,
  it serves as the input to Phase B for that cell *and* every
  neighbor whose patch-build references it.
- **Phase B** builds patch quads per cell against the 9-cell patch,
  filters by centroid, and writes the `.zqd`. Resume semantics: a
  cell whose `.zga` was committed but whose `.zqd` was not skips
  Phase A and runs only Phase B.

## Reader

`ZdclBundle::load_region` walks each region cell's `.zqd` neighbor
table to compute an expanded cell set (region cells ∪ referenced
neighbors), loads every expanded cell's `.zga`, and resolves each
packed star_id into a global gaia index. Quads referencing
un-populated neighbor cells (rare; only happens at sky-edge holes)
are dropped on load.

## Test plan

- [x] `cargo test --workspace --quiet` — 313 tests pass (303 lib + 1
      e2e + 9 reader/tidy/store integration)
- [x] `cargo test --test bundle_solve_e2e -- --nocapture` — 8/8
      synthetic pointings solve, all errors < 17 arcsec (well below
      30″ threshold)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] New unit tests for `pack_star_id` / `unpack_star_id`,
      neighbor-table round-trip, empty-neighbor-table round-trip,
      and oversized-neighbor-table rejection in `quad_shard.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)