### PR TITLE
multiband: drop unused mag_limit from MultiBandCellBuildConfig

### DIFF
--- a/src/bundle/reader.rs
+++ b/src/bundle/reader.rs
@@ -933,7 +933,6 @@ mod tests {
         let cfg = MultiBandCellBuildConfig {
             bands: two_bands(),
             max_stars_per_cell: 1_000,
-            mag_limit: 20.0,
             cell_depth: TEST_DEPTH,
         };
         let paths = BundleWorkDirPaths {
@@ -954,7 +953,6 @@ mod tests {
         let cfg = MultiBandCellBuildConfig {
             bands: two_bands(),
             max_stars_per_cell: 1_000,
-            mag_limit: 20.0,
             cell_depth: TEST_DEPTH,
         };
         let paths = BundleWorkDirPaths {

--- a/src/index/multiband_cell_builder.rs
+++ b/src/index/multiband_cell_builder.rs
@@ -80,9 +80,6 @@ pub struct MultiBandCellBuildConfig {
     /// Brightness-truncation cap per cell. Sources may already filter
     /// upstream, but the orchestrator enforces this defensively.
     pub max_stars_per_cell: usize,
-    /// Magnitude limit recorded as informational metadata. Not
-    /// enforced by the orchestrator — the source filters upstream.
-    pub mag_limit: f64,
     /// HEALPix depth at which cells are sharded.
     pub cell_depth: u8,
 }
@@ -631,7 +628,6 @@ mod tests {
         MultiBandCellBuildConfig {
             bands: three_bands(),
             max_stars_per_cell: 10_000,
-            mag_limit: 20.0,
             cell_depth: 5,
         }
     }
@@ -926,7 +922,6 @@ mod tests {
                 },
             ],
             max_stars_per_cell: 10_000,
-            mag_limit: 20.0,
             cell_depth: 5,
         };
 
@@ -1009,7 +1004,6 @@ mod tests {
         let cfg = MultiBandCellBuildConfig {
             bands: three_bands(),
             max_stars_per_cell: 10,
-            mag_limit: 20.0,
             cell_depth: 5,
         };
         build_bundle_work_dir(&LotsOfStars, &cfg, &paths).unwrap();
@@ -1090,7 +1084,6 @@ mod tests {
             let cfg = MultiBandCellBuildConfig {
                 bands,
                 max_stars_per_cell: 100,
-                mag_limit: 20.0,
                 cell_depth: 5,
             };
             let source = SyntheticSource {

--- a/src/index/store.rs
+++ b/src/index/store.rs
@@ -1009,7 +1009,6 @@ mod tests {
                 },
             ],
             max_stars_per_cell: 1_000,
-            mag_limit: 20.0,
             cell_depth: TEST_DEPTH,
         };
         let paths = BundleWorkDirPaths {

--- a/tests/bundle_solve_e2e.rs
+++ b/tests/bundle_solve_e2e.rs
@@ -237,7 +237,6 @@ fn build_test_bundle(work_dir: &Path, output_dir: &Path, source: &ClusteredSourc
     let cfg = MultiBandCellBuildConfig {
         bands: bands.clone(),
         max_stars_per_cell: 10_000,
-        mag_limit: 16.0,
         cell_depth: TEST_DEPTH,
     };
     let paths = BundleWorkDirPaths {

--- a/zodiacal-tools/src/build_from_excerpt_series.rs
+++ b/zodiacal-tools/src/build_from_excerpt_series.rs
@@ -191,7 +191,6 @@ pub fn run(cfg: &BuildFromExcerptSeriesConfig) -> Result<(), String> {
     let multi_cfg = MultiBandCellBuildConfig {
         bands: bands.clone(),
         max_stars_per_cell: cfg.max_stars_per_cell,
-        mag_limit: cfg.mag_limit,
         cell_depth: cfg.cell_depth,
     };
     let paths = BundleWorkDirPaths {
@@ -746,7 +745,6 @@ mod tests {
         let cfg = MultiBandCellBuildConfig {
             bands: bands.clone(),
             max_stars_per_cell: 1_000,
-            mag_limit: 20.0,
             cell_depth: TEST_DEPTH,
         };
         let paths = BundleWorkDirPaths {


### PR DESCRIPTION
## Why

The orchestrator never read \`MultiBandCellBuildConfig.mag_limit\`; the docstring already noted *\"Not enforced by the orchestrator — the source filters upstream.\"* With \`max_stars_per_cell\` as the dominant per-cell density cap, the brightest N stars in each cell are the same regardless of the mag cut — mag-limit is effectively a CSV-parse-speed knob (skip rows we'd discard anyway) and a sparse-cell coverage knob (gain a few faint stars in cells with <N stars at the cut). Neither concern lives at the orchestrator layer.

## What

Drop the unused field. Keep mag-limit at the API boundaries where it's actually used:

- \`BycellExcerptSource\` still takes mag_limit and threads it to \`Dr3Catalog::from_csv_file\` for parse-time row filtering (the build-speed knob).
- \`TidyMetadata.gaia.mag_limit\` / \`BundleManifest.gaia.mag_limit\` still record the catalog depth for downstream consumers.

Updated 8 call sites that were plumbing the field through. No behavior change.

## Test plan

- [x] \`cargo test --lib\` (299 tests pass)
- [x] \`cargo test --test bundle_solve_e2e\` (1 test pass)
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\`
- [x] \`cargo fmt\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)