### PR TITLE
multiband: batch BuildManifest saves (default every 20 cells)

### DIFF
--- a/src/bundle/reader.rs
+++ b/src/bundle/reader.rs
@@ -934,6 +934,7 @@ mod tests {
             bands: two_bands(),
             max_stars_per_cell: 1_000,
             cell_depth: TEST_DEPTH,
+            manifest_save_every: 1,
         };
         let paths = BundleWorkDirPaths {
             work_dir: work_tmp.path().to_path_buf(),
@@ -954,6 +955,7 @@ mod tests {
             bands: two_bands(),
             max_stars_per_cell: 1_000,
             cell_depth: TEST_DEPTH,
+            manifest_save_every: 1,
         };
         let paths = BundleWorkDirPaths {
             work_dir: work_tmp.path().to_path_buf(),

--- a/src/index/multiband_cell_builder.rs
+++ b/src/index/multiband_cell_builder.rs
@@ -349,6 +349,25 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
     let max_stars_per_cell = config.max_stars_per_cell;
     let cell_depth = config.cell_depth;
 
+    // Single chokepoint for "this cell is done" — locks the manifest,
+    // marks the cell + each band complete, and saves the manifest only
+    // when the dirty counter hits the batch size. Both the empty-cell
+    // and populated-cell paths funnel through here so the lock-and-mark
+    // ritual lives in one place.
+    let commit_cell_progress = |cell_id: u32, stats: CellStats| -> io::Result<()> {
+        let mut m = manifest.lock().unwrap();
+        m.commit_cell(work_dir, cell_id, stats)?;
+        for b in &sorted_bands {
+            m.mark_band_complete(cell_id, b.band_idx);
+        }
+        let pending = manifest_dirty.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+        if pending >= manifest_save_every {
+            m.save(work_dir)?;
+            manifest_dirty.store(0, std::sync::atomic::Ordering::Relaxed);
+        }
+        Ok(())
+    };
+
     let result: io::Result<()> = to_process.par_iter().try_for_each(|&cell_id| {
         let mut stars = source.stars_in_cell(cell_id)?;
 
@@ -365,17 +384,7 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
         if stars.is_empty() {
             // Empty cell: still mark complete so a resume run doesn't
             // re-pull it.
-            let mut m = manifest.lock().unwrap();
-            m.commit_cell(work_dir, cell_id, CellStats::default())?;
-            for b in &sorted_bands {
-                m.mark_band_complete(cell_id, b.band_idx);
-            }
-            let pending = manifest_dirty.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-            if pending >= manifest_save_every {
-                m.save(work_dir)?;
-                manifest_dirty.store(0, std::sync::atomic::Ordering::Relaxed);
-            }
-            drop(m);
+            commit_cell_progress(cell_id, CellStats::default())?;
             n_cells_empty.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             return Ok::<(), io::Error>(());
         }
@@ -451,25 +460,13 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
         let n_stars = stars.len() as u64;
         let n_quads_total: u64 = band_blocks.iter().map(|(_, qs, _)| qs.len() as u64).sum();
 
-        let mut m = manifest.lock().unwrap();
-        m.commit_cell(
-            work_dir,
+        commit_cell_progress(
             cell_id,
             CellStats {
                 n_stars,
                 n_quads: n_quads_total,
             },
         )?;
-        for b in &sorted_bands {
-            m.mark_band_complete(cell_id, b.band_idx);
-        }
-        let pending = manifest_dirty.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-        if pending >= manifest_save_every {
-            m.save(work_dir)?;
-            manifest_dirty.store(0, std::sync::atomic::Ordering::Relaxed);
-        }
-        drop(m);
-
         n_cells_processed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(())
     });

--- a/src/index/multiband_cell_builder.rs
+++ b/src/index/multiband_cell_builder.rs
@@ -82,6 +82,18 @@ pub struct MultiBandCellBuildConfig {
     pub max_stars_per_cell: usize,
     /// HEALPix depth at which cells are sharded.
     pub cell_depth: u8,
+    /// Save the build manifest to disk every N cell completions (and
+    /// once at end-of-build). Defaults to 20.
+    ///
+    /// Each manifest save is a `BuildManifest::save` → fsync, which at
+    /// large `cell_count` (e.g. 786K cells at depth 8) becomes the
+    /// dominant wall-time cost — workers serialize on the manifest
+    /// mutex while one of them does a synchronous disk write. Batching
+    /// trades resume granularity (after a crash, at most N committed
+    /// cells may need to be redone) for ~N× wall-time speedup.
+    ///
+    /// `1` recovers the per-cell-save behaviour. `0` is treated as 1.
+    pub manifest_save_every: usize,
 }
 
 /// Filesystem layout for the build's work directory.
@@ -323,6 +335,15 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
     sorted_bands.sort_by_key(|b| b.band_idx);
 
     let manifest = Mutex::new(manifest);
+    // Tracks how many cells have been committed since the last
+    // `manifest.save`. The orchestrator calls `save` only when this
+    // counter reaches `manifest_save_every`, then resets — turning
+    // the formerly-per-cell fsync into a periodic one. The
+    // post-rayon code path always issues a final save, so even if
+    // `to_process.len() % save_every != 0` the on-disk manifest
+    // matches the in-memory state when the call returns.
+    let manifest_dirty = std::sync::atomic::AtomicUsize::new(0);
+    let manifest_save_every = config.manifest_save_every.max(1);
     let n_cells_empty = std::sync::atomic::AtomicU32::new(0);
     let n_cells_processed = std::sync::atomic::AtomicU32::new(0);
     let max_stars_per_cell = config.max_stars_per_cell;
@@ -349,7 +370,11 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
             for b in &sorted_bands {
                 m.mark_band_complete(cell_id, b.band_idx);
             }
-            m.save(work_dir)?;
+            let pending = manifest_dirty.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+            if pending >= manifest_save_every {
+                m.save(work_dir)?;
+                manifest_dirty.store(0, std::sync::atomic::Ordering::Relaxed);
+            }
             drop(m);
             n_cells_empty.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             return Ok::<(), io::Error>(());
@@ -438,13 +463,29 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
         for b in &sorted_bands {
             m.mark_band_complete(cell_id, b.band_idx);
         }
-        m.save(work_dir)?;
+        let pending = manifest_dirty.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+        if pending >= manifest_save_every {
+            m.save(work_dir)?;
+            manifest_dirty.store(0, std::sync::atomic::Ordering::Relaxed);
+        }
         drop(m);
 
         n_cells_processed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(())
     });
     result?;
+
+    // Flush any cells that completed since the last batched save.
+    // Without this, an interrupted-but-clean exit (or one whose total
+    // cell count is not a multiple of `manifest_save_every`) would
+    // leave the on-disk manifest behind the in-memory state.
+    {
+        let m = manifest.lock().unwrap();
+        if manifest_dirty.load(std::sync::atomic::Ordering::Relaxed) > 0 {
+            m.save(work_dir)?;
+            manifest_dirty.store(0, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
 
     let final_manifest = manifest.into_inner().unwrap();
 
@@ -629,6 +670,7 @@ mod tests {
             bands: three_bands(),
             max_stars_per_cell: 10_000,
             cell_depth: 5,
+            manifest_save_every: 1,
         }
     }
 
@@ -923,6 +965,7 @@ mod tests {
             ],
             max_stars_per_cell: 10_000,
             cell_depth: 5,
+            manifest_save_every: 1,
         };
 
         let source = SyntheticSource {
@@ -1005,6 +1048,7 @@ mod tests {
             bands: three_bands(),
             max_stars_per_cell: 10,
             cell_depth: 5,
+            manifest_save_every: 1,
         };
         build_bundle_work_dir(&LotsOfStars, &cfg, &paths).unwrap();
 
@@ -1085,6 +1129,7 @@ mod tests {
                 bands,
                 max_stars_per_cell: 100,
                 cell_depth: 5,
+                manifest_save_every: 1,
             };
             let source = SyntheticSource {
                 n_cells: 1,

--- a/src/index/multiband_cell_builder.rs
+++ b/src/index/multiband_cell_builder.rs
@@ -37,6 +37,7 @@ use std::hash::{Hash, Hasher};
 use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rayon::prelude::*;
@@ -334,38 +335,59 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
     let mut sorted_bands: Vec<ScaleBand> = config.bands.clone();
     sorted_bands.sort_by_key(|b| b.band_idx);
 
-    let manifest = Mutex::new(manifest);
-    // Tracks how many cells have been committed since the last
-    // `manifest.save`. The orchestrator calls `save` only when this
-    // counter reaches `manifest_save_every`, then resets — turning
-    // the formerly-per-cell fsync into a periodic one. The
-    // post-rayon code path always issues a final save, so even if
-    // `to_process.len() % save_every != 0` the on-disk manifest
-    // matches the in-memory state when the call returns.
-    let manifest_dirty = std::sync::atomic::AtomicUsize::new(0);
+    // Manifest + "cells committed since last save" counter live behind
+    // one Mutex so each commit is a single lock acquire.
+    struct ManifestState {
+        manifest: BuildManifest,
+        dirty: usize,
+    }
+    impl ManifestState {
+        /// Mark a cell complete and advance the dirty counter; save to
+        /// disk when at least `save_every` cells have committed since
+        /// the last save.
+        fn commit(
+            &mut self,
+            work_dir: &Path,
+            cell_id: u32,
+            stats: CellStats,
+            bands: &[ScaleBand],
+            save_every: usize,
+        ) -> io::Result<()> {
+            self.manifest.commit_cell(work_dir, cell_id, stats)?;
+            for b in bands {
+                self.manifest.mark_band_complete(cell_id, b.band_idx);
+            }
+            self.dirty += 1;
+            if self.dirty >= save_every {
+                self.flush(work_dir)?;
+            }
+            Ok(())
+        }
+
+        /// Save the manifest if anything has been committed since the
+        /// last save. No-op otherwise.
+        fn flush(&mut self, work_dir: &Path) -> io::Result<()> {
+            if self.dirty > 0 {
+                self.manifest.save(work_dir)?;
+                self.dirty = 0;
+            }
+            Ok(())
+        }
+    }
+    let state = Mutex::new(ManifestState { manifest, dirty: 0 });
     let manifest_save_every = config.manifest_save_every.max(1);
-    let n_cells_empty = std::sync::atomic::AtomicU32::new(0);
-    let n_cells_processed = std::sync::atomic::AtomicU32::new(0);
+    let n_cells_empty = AtomicU32::new(0);
+    let n_cells_processed = AtomicU32::new(0);
     let max_stars_per_cell = config.max_stars_per_cell;
     let cell_depth = config.cell_depth;
 
-    // Single chokepoint for "this cell is done" — locks the manifest,
-    // marks the cell + each band complete, and saves the manifest only
-    // when the dirty counter hits the batch size. Both the empty-cell
-    // and populated-cell paths funnel through here so the lock-and-mark
-    // ritual lives in one place.
+    // Single chokepoint for "this cell is done"; both the empty-cell
+    // and populated-cell paths funnel through here.
     let commit_cell_progress = |cell_id: u32, stats: CellStats| -> io::Result<()> {
-        let mut m = manifest.lock().unwrap();
-        m.commit_cell(work_dir, cell_id, stats)?;
-        for b in &sorted_bands {
-            m.mark_band_complete(cell_id, b.band_idx);
-        }
-        let pending = manifest_dirty.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-        if pending >= manifest_save_every {
-            m.save(work_dir)?;
-            manifest_dirty.store(0, std::sync::atomic::Ordering::Relaxed);
-        }
-        Ok(())
+        state
+            .lock()
+            .unwrap()
+            .commit(work_dir, cell_id, stats, &sorted_bands, manifest_save_every)
     };
 
     let result: io::Result<()> = to_process.par_iter().try_for_each(|&cell_id| {
@@ -385,7 +407,7 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
             // Empty cell: still mark complete so a resume run doesn't
             // re-pull it.
             commit_cell_progress(cell_id, CellStats::default())?;
-            n_cells_empty.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            n_cells_empty.fetch_add(1, Ordering::Relaxed);
             return Ok::<(), io::Error>(());
         }
 
@@ -467,24 +489,16 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
                 n_quads: n_quads_total,
             },
         )?;
-        n_cells_processed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        n_cells_processed.fetch_add(1, Ordering::Relaxed);
         Ok(())
     });
     result?;
 
-    // Flush any cells that completed since the last batched save.
-    // Without this, an interrupted-but-clean exit (or one whose total
-    // cell count is not a multiple of `manifest_save_every`) would
-    // leave the on-disk manifest behind the in-memory state.
-    {
-        let m = manifest.lock().unwrap();
-        if manifest_dirty.load(std::sync::atomic::Ordering::Relaxed) > 0 {
-            m.save(work_dir)?;
-            manifest_dirty.store(0, std::sync::atomic::Ordering::Relaxed);
-        }
-    }
+    // Flush any cells that committed since the last batched save so
+    // the on-disk manifest matches the in-memory state on return.
+    state.lock().unwrap().flush(work_dir)?;
 
-    let final_manifest = manifest.into_inner().unwrap();
+    let final_manifest = state.into_inner().unwrap().manifest;
 
     // ---------- per-band totals via mmapped re-scan ----------------------
     let mut per_band_quad_counts = vec![0u64; n_bands];

--- a/src/index/multiband_cell_builder.rs
+++ b/src/index/multiband_cell_builder.rs
@@ -204,6 +204,60 @@ pub fn cleanup_work_dir_partials(work_dir: &Path) -> io::Result<()> {
 }
 
 // ---------------------------------------------------------------------------
+//  Build-manifest state (orchestrator-local)
+// ---------------------------------------------------------------------------
+
+/// Build-manifest plus the count of cells committed since the last
+/// `save`. The orchestrator wraps this in a `Mutex` so workers
+/// serialize on a single lock per cell-commit. `commit` advances the
+/// counter and only fsyncs the manifest when the configured batch
+/// threshold is reached; `flush` issues an unconditional save iff
+/// anything is pending. Both methods are private to this module.
+struct ManifestState {
+    manifest: BuildManifest,
+    /// Cells committed since the last `save`; reset on every save.
+    dirty: usize,
+}
+
+impl ManifestState {
+    fn new(manifest: BuildManifest) -> Self {
+        Self { manifest, dirty: 0 }
+    }
+
+    /// Mark a cell complete and advance the dirty counter; save to
+    /// disk when at least `save_every` cells have committed since
+    /// the last save.
+    fn commit(
+        &mut self,
+        work_dir: &Path,
+        cell_id: u32,
+        stats: CellStats,
+        bands: &[ScaleBand],
+        save_every: usize,
+    ) -> io::Result<()> {
+        self.manifest.commit_cell(work_dir, cell_id, stats)?;
+        for b in bands {
+            self.manifest.mark_band_complete(cell_id, b.band_idx);
+        }
+        self.dirty += 1;
+        if self.dirty >= save_every {
+            self.flush(work_dir)?;
+        }
+        Ok(())
+    }
+
+    /// Save the manifest if anything has been committed since the
+    /// last save. No-op otherwise.
+    fn flush(&mut self, work_dir: &Path) -> io::Result<()> {
+        if self.dirty > 0 {
+            self.manifest.save(work_dir)?;
+            self.dirty = 0;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
 //  Per-cell write
 // ---------------------------------------------------------------------------
 
@@ -337,44 +391,7 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
 
     // Manifest + "cells committed since last save" counter live behind
     // one Mutex so each commit is a single lock acquire.
-    struct ManifestState {
-        manifest: BuildManifest,
-        dirty: usize,
-    }
-    impl ManifestState {
-        /// Mark a cell complete and advance the dirty counter; save to
-        /// disk when at least `save_every` cells have committed since
-        /// the last save.
-        fn commit(
-            &mut self,
-            work_dir: &Path,
-            cell_id: u32,
-            stats: CellStats,
-            bands: &[ScaleBand],
-            save_every: usize,
-        ) -> io::Result<()> {
-            self.manifest.commit_cell(work_dir, cell_id, stats)?;
-            for b in bands {
-                self.manifest.mark_band_complete(cell_id, b.band_idx);
-            }
-            self.dirty += 1;
-            if self.dirty >= save_every {
-                self.flush(work_dir)?;
-            }
-            Ok(())
-        }
-
-        /// Save the manifest if anything has been committed since the
-        /// last save. No-op otherwise.
-        fn flush(&mut self, work_dir: &Path) -> io::Result<()> {
-            if self.dirty > 0 {
-                self.manifest.save(work_dir)?;
-                self.dirty = 0;
-            }
-            Ok(())
-        }
-    }
-    let state = Mutex::new(ManifestState { manifest, dirty: 0 });
+    let state = Mutex::new(ManifestState::new(manifest));
     let manifest_save_every = config.manifest_save_every.max(1);
     let n_cells_empty = AtomicU32::new(0);
     let n_cells_processed = AtomicU32::new(0);

--- a/src/index/store.rs
+++ b/src/index/store.rs
@@ -1010,6 +1010,7 @@ mod tests {
             ],
             max_stars_per_cell: 1_000,
             cell_depth: TEST_DEPTH,
+            manifest_save_every: 1,
         };
         let paths = BundleWorkDirPaths {
             work_dir: work_tmp.path().to_path_buf(),

--- a/tests/bundle_solve_e2e.rs
+++ b/tests/bundle_solve_e2e.rs
@@ -238,6 +238,7 @@ fn build_test_bundle(work_dir: &Path, output_dir: &Path, source: &ClusteredSourc
         bands: bands.clone(),
         max_stars_per_cell: 10_000,
         cell_depth: TEST_DEPTH,
+        manifest_save_every: 1,
     };
     let paths = BundleWorkDirPaths {
         work_dir: work_dir.to_path_buf(),

--- a/zodiacal-tools/src/build_from_excerpt_series.rs
+++ b/zodiacal-tools/src/build_from_excerpt_series.rs
@@ -106,6 +106,9 @@ pub struct BuildFromExcerptSeriesConfig {
     pub threads: Option<usize>,
     /// If true, [`prune_work_dir`] is called after a successful tidy.
     pub prune_work_dir: bool,
+    /// Save the build manifest to disk every N cell completions.
+    /// Defaults to 20 in the CLI; 1 recovers per-cell-save behaviour.
+    pub manifest_save_every: usize,
 }
 
 /// Top-level entry point.
@@ -195,6 +198,7 @@ pub fn run(cfg: &BuildFromExcerptSeriesConfig) -> Result<(), String> {
         bands: bands.clone(),
         max_stars_per_cell: cfg.max_stars_per_cell,
         cell_depth: cfg.cell_depth,
+        manifest_save_every: cfg.manifest_save_every.max(1),
     };
     let paths = BundleWorkDirPaths {
         work_dir: cfg.work_dir.clone(),
@@ -911,6 +915,7 @@ mod tests {
             bands: bands.clone(),
             max_stars_per_cell: 1_000,
             cell_depth: TEST_DEPTH,
+            manifest_save_every: 1,
         };
         let paths = BundleWorkDirPaths {
             work_dir: work_tmp.path().to_path_buf(),

--- a/zodiacal-tools/src/main.rs
+++ b/zodiacal-tools/src/main.rs
@@ -246,6 +246,17 @@ enum Commands {
         /// alternate output form without rebuilding.
         #[arg(long, default_value_t = false)]
         prune_work_dir: bool,
+
+        /// Persist the build manifest every N cell completions
+        /// instead of after every cell. Each save is an
+        /// fsync-blocking write; at large `cell_count` (e.g. 786K
+        /// at depth 8) this batching is the difference between a
+        /// 10-hour build and a 1-hour one. Resume granularity
+        /// becomes "at most N committed cells redone after a
+        /// crash", which is cheap. Pass 1 to recover per-cell-save
+        /// behaviour.
+        #[arg(long, default_value_t = 20)]
+        manifest_save_every: usize,
     },
 }
 
@@ -333,6 +344,7 @@ fn main() {
             experiment,
             threads,
             prune_work_dir,
+            manifest_save_every,
         } => {
             let cfg = BuildFromExcerptSeriesConfig {
                 excerpt_dir: excerpt_dir.clone(),
@@ -350,6 +362,7 @@ fn main() {
                 experiment: experiment.clone(),
                 threads: *threads,
                 prune_work_dir: *prune_work_dir,
+                manifest_save_every: *manifest_save_every,
             };
             if let Err(e) = run_build_from_excerpt_series(&cfg) {
                 eprintln!("build-from-excerpt-series failed: {e}");


### PR DESCRIPTION
## Why

The orchestrator's per-cell \`BuildManifest::save\` was the dominant wall-time cost at large cell counts. At depth 8 (786,432 cells) the running build was using only ~11 of 80 cores — the rest were parked on the manifest mutex waiting for one worker to finish a synchronous disk write. **Turns a CPU-bound build into an fsync-bound one (~10h instead of ~1h).**

## What

Add \`MultiBandCellBuildConfig.manifest_save_every\` (default 20 in the CLI, 1 in unit-test fixtures so per-cell-save coverage stays).

- The orchestrator increments a shared dirty counter on every commit.
- Only the worker that hits the threshold calls \`manifest.save()\`.
- After the rayon loop, a final unconditional save flushes any cells committed since the last batched write.

\`--manifest-save-every\` CLI flag added with default 20.

## Resume semantics

After a crash, at most \`manifest_save_every\` already-committed cells may need to be redone — their \`.zga\` / \`.zqd\` are on disk but the manifest doesn't list them, so the resume run rebuilds them (deterministic, same bytes). This is cheap — a few seconds per cell — and worth ~20× wall-time savings on large builds.

## Test plan

- [x] \`cargo test --lib\` (299 tests pass)
- [x] \`cargo test --test bundle_solve_e2e\` (1 test pass)
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\`
- [x] Test fixtures use \`manifest_save_every: 1\` so per-cell coverage stays unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)