### PR TITLE
multiband: restore per-shard fsync (revert #108)

### DIFF
--- a/src/index/multiband_cell_builder.rs
+++ b/src/index/multiband_cell_builder.rs
@@ -286,18 +286,11 @@ fn nonce_hex(cell_id: u32, seed: u64) -> String {
 ///
 /// Skips writing entirely if both `bands_emit` is all-empty AND
 /// `gaia_records` is empty. Otherwise each file is written to
-/// `.part.HHHHHHHH` and atomically renamed onto its canonical name.
-///
-/// **No `fsync` between write and rename.** Workers don't block on
-/// the disk; the page cache absorbs writes and the kernel flushes
-/// lazily. A power loss between rename and the kernel's writeback
-/// would leave behind a renamed-but-empty (or partial) shard. The
-/// build manifest's batched save (default every 20 cells) is the
-/// only durability anchor — on resume, any cell whose manifest entry
-/// isn't on disk gets rebuilt from scratch and overwrites whatever
-/// was left on disk. Net cost of this trade: a few wasted seconds
-/// per torn cell after a hard crash, in exchange for vastly higher
-/// IOPS on the happy path.
+/// `.part.HHHHHHHH`, fsynced, and atomically renamed onto the
+/// canonical name. The fsync also acts as backpressure for the
+/// kernel's writeback — without it, the page cache fills under
+/// large builds (depth 8+) and every subsequent write blocks
+/// erratically.
 ///
 /// Returns one quad count per band in `bands_emit`, in input order.
 pub fn write_cell_shards(
@@ -330,8 +323,7 @@ pub fn write_cell_shards(
 }
 
 /// Write `final_path` via a `final_path.part.<nonce>` sibling +
-/// in-process buffer flush + atomic rename. Does NOT fsync — see the
-/// note on [`write_cell_shards`] for the durability rationale.
+/// in-process buffer flush + `fsync` + atomic rename.
 fn atomic_write_shard<F>(final_path: &Path, nonce: &str, write: F) -> io::Result<()>
 where
     F: FnOnce(&mut BufWriter<File>) -> io::Result<()>,
@@ -347,6 +339,7 @@ where
         let mut w = BufWriter::new(f);
         write(&mut w)?;
         w.flush()?;
+        w.get_ref().sync_all()?;
     }
     std::fs::rename(&partial, final_path)
 }


### PR DESCRIPTION
## Empirical: #108 made the depth-8 build *slower*

At depth 8 (786K cells), removing the per-shard \`fsync\` decelerated the build vs. keeping it. Observed across 24 min of running:

| time | shards | rate |
|---|---:|---:|
| 3 min | 13,690 | ~75/sec |
| 7 min | 22,549 | ~53/sec (marginal) |
| **24 min** | **48,420** | **~25/sec marginal** |

Projection: ~9 hours total vs. ~1.5 hours with the fsync (per the #107 batched-saves baseline). Hypothesis: \`fsync\` was acting as inadvertent backpressure that let the kernel coalesce dirty pages into batched sequential writes. Without it, the kernel's writeback engages erratically once dirty-page limits hit, blocking individual writers in unpredictable patterns. Disk throughput dropped from 240 MB/s (with fsync) to 141 MB/s (without).

## What

Restore the \`sync_all\` on the per-shard write path. Keep the \`atomic_write_shard\` helper from #108 — that refactor is fine and worth keeping for readability.

Net diff: +7 -14 lines (the helper now has the fsync inside it).

## Test plan

- [x] \`cargo test --lib\` (299 tests pass)
- [x] \`cargo test --test bundle_solve_e2e\`
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\`
- [ ] Real-data: rebuild depth-8 with this binary, confirm wall-clock returns to ~1.5 h baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)