### PR TITLE
multiband: group bundle work by source partition for cache locality

### DIFF
--- a/src/index/cell_builder.rs
+++ b/src/index/cell_builder.rs
@@ -91,6 +91,19 @@ pub trait CellStarSource: Sync {
     /// `cell_id`, after applying any source-side magnitude/quality
     /// filters. Order is irrelevant — the builder sorts.
     fn stars_in_cell(&self, cell_id: u32) -> io::Result<Vec<CellStar>>;
+
+    /// Group key for cache locality. Cells that return the same key
+    /// share an underlying source partition, so the orchestrator can
+    /// batch them together to keep the partition cache hot.
+    ///
+    /// The default returns `cell_id`, which disables grouping (every
+    /// cell is its own group). Sources that derive bundle cells from a
+    /// coarser source grid (e.g. depth-5 CSV shards feeding a depth-8
+    /// bundle) should override to return the source-cell parent so
+    /// bundle siblings cluster.
+    fn source_partition_key(&self, cell_id: u32) -> u32 {
+        cell_id
+    }
 }
 
 /// Configuration for [`build_index_cell_driven`].

--- a/src/index/multiband_cell_builder.rs
+++ b/src/index/multiband_cell_builder.rs
@@ -565,13 +565,12 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
         // of a source partition). Each rayon worker handles a whole
         // group in sequence so the partition cache only needs to absorb
         // cross-worker overlap, not random per-cell access.
-        let result: io::Result<()> =
-            partition_groups.par_iter().try_for_each(|group| {
-                for &cell_id in group {
-                    process_cell(cell_id)?;
-                }
-                Ok(())
-            });
+        let result: io::Result<()> = partition_groups.par_iter().try_for_each(|group| {
+            for &cell_id in group {
+                process_cell(cell_id)?;
+            }
+            Ok(())
+        });
         // Closing the channel signals the actor to drain remaining
         // messages, do a final flush, and exit. Always wait for the
         // actor before returning a result — both the rayon and actor

--- a/src/index/multiband_cell_builder.rs
+++ b/src/index/multiband_cell_builder.rs
@@ -345,6 +345,33 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
         }
     }
 
+    // Group bundle cells by their source partition so a rayon worker
+    // processes all siblings of one source partition before moving on.
+    // This keeps the partition cache small: with random access, every
+    // worker can hold a different partition concurrently (peak memory
+    // ≈ N_workers × partition_size); with grouped access, each worker
+    // touches one partition at a time and the cache only needs a few
+    // slots to absorb cross-worker overlap.
+    to_process.sort_by_key(|&c| source.source_partition_key(c));
+    let mut partition_groups: Vec<Vec<u32>> = Vec::new();
+    {
+        let mut current_key: Option<u32> = None;
+        let mut current: Vec<u32> = Vec::new();
+        for cell_id in to_process {
+            let key = source.source_partition_key(cell_id);
+            if Some(key) != current_key {
+                if !current.is_empty() {
+                    partition_groups.push(std::mem::take(&mut current));
+                }
+                current_key = Some(key);
+            }
+            current.push(cell_id);
+        }
+        if !current.is_empty() {
+            partition_groups.push(current);
+        }
+    }
+
     // Sort the bands once up front; pass them to the per-cell loop in
     // a stable band-idx order so the band table on disk matches the
     // configured layout.
@@ -429,7 +456,9 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
             Ok(())
         };
 
-        let result: io::Result<()> = to_process.par_iter().try_for_each(|&cell_id| {
+        // Per-cell body, hoisted into a closure so the par-over-groups
+        // loop below can call it in sequence within each group.
+        let process_cell = |cell_id: u32| -> io::Result<()> {
             let mut stars = source.stars_in_cell(cell_id)?;
 
             // Brightness-truncate: sort by mag ascending, take the first N.
@@ -447,7 +476,7 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
                 // re-pull it.
                 commit_cell_progress(cell_id, CellStats::default())?;
                 n_cells_empty.fetch_add(1, Ordering::Relaxed);
-                return Ok::<(), io::Error>(());
+                return Ok(());
             }
 
             // Build all bands' quads over this cell's stars (sorted-by-mag
@@ -530,7 +559,19 @@ pub fn build_bundle_work_dir<S: CellStarSource + ?Sized>(
             )?;
             n_cells_processed.fetch_add(1, Ordering::Relaxed);
             Ok(())
-        });
+        };
+
+        // Iterate over partition groups (one group = all bundle siblings
+        // of a source partition). Each rayon worker handles a whole
+        // group in sequence so the partition cache only needs to absorb
+        // cross-worker overlap, not random per-cell access.
+        let result: io::Result<()> =
+            partition_groups.par_iter().try_for_each(|group| {
+                for &cell_id in group {
+                    process_cell(cell_id)?;
+                }
+                Ok(())
+            });
         // Closing the channel signals the actor to drain remaining
         // messages, do a final flush, and exit. Always wait for the
         // actor before returning a result — both the rayon and actor

--- a/zodiacal-tools/src/build_from_excerpt_series.rs
+++ b/zodiacal-tools/src/build_from_excerpt_series.rs
@@ -403,7 +403,11 @@ impl std::fmt::Debug for BycellExcerptSource {
     }
 }
 
-const PARTITION_CACHE_CAPACITY: usize = 32;
+// Small because the orchestrator sorts work by partition key, so
+// adjacent units of work share the same partition. The cache only needs
+// to absorb the brief overlap when a worker advances to the next
+// partition while another is still finishing the previous one.
+const PARTITION_CACHE_CAPACITY: usize = 4;
 
 struct PartitionCache {
     /// Map: source_cell_id → Arc<HashMap<bundle_cell_id, stars>>.
@@ -602,21 +606,33 @@ impl BycellExcerptSource {
     }
 }
 
+impl BycellExcerptSource {
+    /// Map a bundle cell to its parent source-shard cell. Used both
+    /// internally and for `source_partition_key` so the orchestrator
+    /// can batch siblings together.
+    fn parent_source_cell(&self, cell_id: u32) -> u32 {
+        if self.bundle_depth == self.source_depth {
+            cell_id
+        } else {
+            let delta = self.bundle_depth - self.source_depth;
+            cell_id >> (2 * delta as u32)
+        }
+    }
+}
+
 impl CellStarSource for BycellExcerptSource {
     fn cell_count(&self) -> u32 {
         self.cell_count
     }
 
     fn stars_in_cell(&self, cell_id: u32) -> std::io::Result<Vec<CellStar>> {
-        // Find the parent source cell for this bundle cell.
-        let source_cell = if self.bundle_depth == self.source_depth {
-            cell_id
-        } else {
-            let delta = self.bundle_depth - self.source_depth;
-            cell_id >> (2 * delta as u32)
-        };
+        let source_cell = self.parent_source_cell(cell_id);
         let partition = self.load_and_partition(source_cell)?;
         Ok(partition.get(&cell_id).cloned().unwrap_or_default())
+    }
+
+    fn source_partition_key(&self, cell_id: u32) -> u32 {
+        self.parent_source_cell(cell_id)
     }
 }
 


### PR DESCRIPTION
## Problem

Two consecutive depth-8 mag-20 builds OOMed at the **same** ~57 GB anon-rss ceiling, despite landing at very different progress points (88k cells in run 1, 642k in run 2). Confirmed via kernel OOM logs.

The mag-20 dataset is 304 GB compressed; the largest galactic-plane source-depth-5 shards parse to ~5 GB each, and a partition (`Arc<HashMap<bundle_cell, Vec<CellStar>>>`) for one of those source cells holds ~10M stars × 224 bytes = ~2 GB. With 80 rayon workers doing random per-cell access into a 32-slot LRU cache, peak resident memory was bounded only by how many plane partitions happened to be cached + in-flight at once.

## Fix

Cluster the work so each rayon worker handles all 64 bundle siblings of one source partition before moving on. The cache then only has to absorb cross-worker overlap rather than per-worker random access.

- Add `CellStarSource::source_partition_key(cell_id) -> u32` with default = identity. `BycellExcerptSource` overrides to return `cell_id >> (2 * (bundle_depth - source_depth))`.
- Multiband orchestrator sorts `to_process` by partition key, groups consecutive same-key cells into `Vec<Vec<u32>>`, and `par_iter`s over groups. Each worker drains a whole group serially.
- Drop `PARTITION_CACHE_CAPACITY` 32 → 4. With grouped access only a few partitions are simultaneously hot.

## Probably-not-sufficient-on-its-own

This may not fully resolve the OOM at depth-8 mag-20 — even one plane partition is multi-GB and we have 80 workers. Likely follow-ups:
- Strip `sidecar: SidecarRecord` (88 bytes / 224 = 39%) from `CellStar` on the bundle path; the bundle never reads it (it writes the same astrometric data via the larger `gaia: GaiaRecord`).
- Pre-truncate per-bundle-cell star vectors during partition build, instead of after read.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] `cargo test --lib` (299 passed)
- [x] `cargo test --test bundle_solve_e2e`
- [ ] Restart depth-8 G≤20 build and observe peak RSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)