### PR TITLE
bundle: bound FsAccessor and ZdclBundle caches with LRU eviction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +955,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,7 +1122,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1124,6 +1136,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1656,6 +1673,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -3746,6 +3772,7 @@ dependencies = [
  "glob",
  "image",
  "indicatif 0.18.4",
+ "lru",
  "memmap2",
  "nalgebra",
  "ndarray 0.17.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 starfield = "0.11"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
+lru = "0.18.0"
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/src/bundle/accessor.rs
+++ b/src/bundle/accessor.rs
@@ -16,15 +16,22 @@
 //!
 //! See `docs/bundle-format.md` for the broader bundle format design.
 
-use std::collections::HashMap;
 use std::fs::File;
 use std::io;
+use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
+use lru::LruCache;
 use memmap2::Mmap;
 use zip::ZipArchive;
+
+/// Default eviction cap for [`FsAccessor`]'s mmap LRU. Tuned so a
+/// 1000-case bench-bundle sweep at ~6,000 cells/case (5° hint on a
+/// depth-9 bundle) stays within typical host RAM. Override via
+/// [`FsAccessor::open_with_capacity`].
+pub const FS_ACCESSOR_DEFAULT_CACHE_CAP: usize = 100_000;
 
 /// Storage-agnostic entry access for a bundle.
 ///
@@ -47,47 +54,50 @@ pub trait SubfileAccessor: Send + Sync {
 
     /// Return a read-only view of the entry's bytes.
     ///
-    /// For [`FsAccessor`] this is an mmap-backed slice cached for the
-    /// lifetime of the accessor; for [`ZipAccessor`] this is a freshly
+    /// For [`FsAccessor`] this hands back an `Arc<Mmap>` (cheap clone of
+    /// a cached entry; the Arc keeps the mapping alive even if the LRU
+    /// cache evicts the slot). For [`ZipAccessor`] this is a freshly
     /// decompressed owned buffer.
-    fn read_entry(&self, rel: &str) -> io::Result<EntryBytes<'_>>;
+    fn read_entry(&self, rel: &str) -> io::Result<EntryBytes>;
 }
 
 /// A read-only view of an entry's bytes.
 ///
-/// `Mmap` borrows a slice from a memory map owned by the accessor;
-/// `Owned` carries a freshly decompressed buffer. Both deref to `[u8]`,
-/// so consumer code can treat them identically.
-pub enum EntryBytes<'a> {
-    /// Borrowed slice into an mmap owned by the accessor.
-    Mmap(&'a [u8]),
+/// `Mmap` carries an [`Arc`]-shared memory map; `Owned` carries a freshly
+/// decompressed buffer. Both deref to `[u8]`, so consumer code can treat
+/// them identically. The `Arc<Mmap>` keeps the mapping alive for as long
+/// as any caller holds an `EntryBytes`, even if the originating
+/// accessor's LRU cache has since evicted the slot.
+pub enum EntryBytes {
+    /// Shared memory map backing the entry's bytes.
+    Mmap(Arc<Mmap>),
     /// Owned buffer (e.g. decompressed from a zip entry).
     Owned(Vec<u8>),
 }
 
-impl<'a> Deref for EntryBytes<'a> {
+impl Deref for EntryBytes {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
         match self {
-            EntryBytes::Mmap(slice) => slice,
+            EntryBytes::Mmap(arc) => &arc[..],
             EntryBytes::Owned(buf) => buf.as_slice(),
         }
     }
 }
 
-impl<'a> AsRef<[u8]> for EntryBytes<'a> {
+impl AsRef<[u8]> for EntryBytes {
     fn as_ref(&self) -> &[u8] {
         self
     }
 }
 
-impl<'a> std::fmt::Debug for EntryBytes<'a> {
+impl std::fmt::Debug for EntryBytes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            EntryBytes::Mmap(slice) => f
+            EntryBytes::Mmap(arc) => f
                 .debug_struct("EntryBytes::Mmap")
-                .field("len", &slice.len())
+                .field("len", &arc.len())
                 .finish(),
             EntryBytes::Owned(buf) => f
                 .debug_struct("EntryBytes::Owned")
@@ -99,14 +109,13 @@ impl<'a> std::fmt::Debug for EntryBytes<'a> {
 
 /// Filesystem-backed accessor.
 ///
-/// Each entry is mmapped on first access; subsequent reads return a slice
-/// into the cached mmap. The cache lives in a `Mutex<HashMap<...>>`
-/// guarded by interior mutability, so the accessor itself is `Send + Sync`
-/// and the trait method takes `&self`.
-///
-/// The mmaps are stored as `Box<Mmap>` to keep their addresses stable
-/// across hash-map rehashes, which lets us hand out `&[u8]` slices
-/// borrowing from those mmaps for the lifetime of the accessor.
+/// Each entry is mmapped on first access. The mapping is wrapped in
+/// `Arc<Mmap>` and stored in a bounded LRU cache; on a hit the accessor
+/// hands back an `Arc<Mmap>` clone. Eviction is safe because callers
+/// holding an [`EntryBytes::Mmap`] keep the underlying mapping alive
+/// through their `Arc`, even after the LRU drops the slot. The cap is
+/// configurable via [`Self::open_with_capacity`]; the default is
+/// [`FS_ACCESSOR_DEFAULT_CACHE_CAP`].
 ///
 /// # Path-traversal hardening
 ///
@@ -122,18 +131,27 @@ pub struct FsAccessor {
     /// Canonicalized base directory. All resolved entries must live
     /// underneath this path post-canonicalization.
     root: PathBuf,
-    cache: Mutex<HashMap<String, Box<Mmap>>>,
+    cache: Mutex<LruCache<String, Arc<Mmap>>>,
 }
 
 impl FsAccessor {
-    /// Open a directory root as an accessor.
+    /// Open a directory root as an accessor with the default
+    /// per-process mmap LRU capacity ([`FS_ACCESSOR_DEFAULT_CACHE_CAP`]).
+    pub fn open(root: impl AsRef<Path>) -> io::Result<Self> {
+        Self::open_with_capacity(root, FS_ACCESSOR_DEFAULT_CACHE_CAP)
+    }
+
+    /// Open a directory root with an explicit cache cap. Smaller caps
+    /// trade hit rate for VM/RAM bound; larger caps suit long-running
+    /// services that stream many distinct entries.
     ///
     /// The path must point at an existing directory; otherwise an
     /// `io::Error` of kind [`io::ErrorKind::NotFound`] (or similar) is
     /// returned. The directory is canonicalized once at construction
     /// time and that canonical path is used as the traversal-check
     /// prefix for every subsequent entry lookup.
-    pub fn open(root: impl AsRef<Path>) -> io::Result<Self> {
+    pub fn open_with_capacity(root: impl AsRef<Path>, cap: usize) -> io::Result<Self> {
+        let cap = NonZeroUsize::new(cap.max(1)).expect("max(1) ensures non-zero");
         let root = root.as_ref().to_path_buf();
         let meta = std::fs::metadata(&root)?;
         if !meta.is_dir() {
@@ -148,7 +166,7 @@ impl FsAccessor {
         let root = std::fs::canonicalize(&root)?;
         Ok(Self {
             root,
-            cache: Mutex::new(HashMap::new()),
+            cache: Mutex::new(LruCache::new(cap)),
         })
     }
 
@@ -237,7 +255,7 @@ impl SubfileAccessor for FsAccessor {
         Ok(out)
     }
 
-    fn read_entry(&self, rel: &str) -> io::Result<EntryBytes<'_>> {
+    fn read_entry(&self, rel: &str) -> io::Result<EntryBytes> {
         // Validate the name up-front so a malicious raw key can't slip
         // past the cache layer. The cache key is the *raw*
         // bundle-relative name, but we only ever insert via the
@@ -245,18 +263,11 @@ impl SubfileAccessor for FsAccessor {
         // safe path.
         Self::validate_name(rel)?;
 
-        // Fast path: cache hit.
+        // Fast path: LRU hit. `get` promotes the entry to most-recent.
         {
-            let cache = self.cache.lock().expect("FsAccessor cache poisoned");
+            let mut cache = self.cache.lock().expect("FsAccessor cache poisoned");
             if let Some(mmap) = cache.get(rel) {
-                let slice: &[u8] = &mmap[..];
-                // SAFETY: the `Box<Mmap>` is stored in the cache and
-                // never removed for the lifetime of `self`. Its mapped
-                // memory has a stable address (independent of the
-                // HashMap's bucket layout, since we go through `Box`).
-                // Therefore the slice is valid for `&'_ self`.
-                let extended: &[u8] = unsafe { std::mem::transmute::<&[u8], &[u8]>(slice) };
-                return Ok(EntryBytes::Mmap(extended));
+                return Ok(EntryBytes::Mmap(Arc::clone(mmap)));
             }
         }
 
@@ -264,17 +275,22 @@ impl SubfileAccessor for FsAccessor {
         let abs = self.resolve(rel)?;
         let file = File::open(&abs)?;
         // SAFETY: we treat the mapping as immutable for the lifetime of
-        // the accessor, which matches the `Mmap` (read-only) contract.
+        // the Arc, which matches the `Mmap` (read-only) contract.
         let mmap = unsafe { Mmap::map(&file)? };
-        let boxed = Box::new(mmap);
+        let arc = Arc::new(mmap);
 
         let mut cache = self.cache.lock().expect("FsAccessor cache poisoned");
-        // Another thread may have raced us; if so, drop our mapping and
-        // use theirs so callers see a consistent ptr per entry.
-        let entry = cache.entry(rel.to_string()).or_insert(boxed);
-        let slice: &[u8] = &entry[..];
-        let extended: &[u8] = unsafe { std::mem::transmute::<&[u8], &[u8]>(slice) };
-        Ok(EntryBytes::Mmap(extended))
+        // Another thread may have raced us; if so, prefer the entry
+        // that's already cached so concurrent callers converge on the
+        // same Arc when possible. The LRU's `put` returns the previous
+        // value if the key was already present.
+        let to_return = if let Some(existing) = cache.get(rel) {
+            Arc::clone(existing)
+        } else {
+            cache.put(rel.to_string(), Arc::clone(&arc));
+            arc
+        };
+        Ok(EntryBytes::Mmap(to_return))
     }
 }
 
@@ -354,7 +370,7 @@ impl SubfileAccessor for ZipAccessor {
         Ok(out)
     }
 
-    fn read_entry(&self, rel: &str) -> io::Result<EntryBytes<'_>> {
+    fn read_entry(&self, rel: &str) -> io::Result<EntryBytes> {
         use std::io::Read;
         let mut archive = self.archive.lock().expect("ZipAccessor mutex poisoned");
         let mut entry = archive.by_name(rel).map_err(zip_to_io_err)?;

--- a/src/bundle/reader.rs
+++ b/src/bundle/reader.rs
@@ -29,12 +29,20 @@
 //! to a later PR. The duplication only costs a few hundred kB per band
 //! per region load and never changes solver semantics.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 use std::io;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use cdshealpix::nested;
+use lru::LruCache;
+
+/// Default eviction cap for [`ZdclBundle`]'s per-cell shard LRU. Tuned
+/// so a 1000-case bench-bundle sweep at ~6,000 cells/case (5° hint on
+/// a depth-9 bundle) stays within typical host RAM. Override via
+/// [`ZdclBundle::open_with_capacity`].
+pub const ZDCL_BUNDLE_DEFAULT_CACHE_CAP: usize = 100_000;
 
 use crate::index::IndexStar;
 use crate::index::source::IndexFragment;
@@ -127,7 +135,7 @@ pub struct ZdclBundle {
     accessor: Box<dyn SubfileAccessor>,
     manifest: BundleManifest,
     populated_cells: BTreeSet<u32>,
-    cell_cache: Mutex<HashMap<u32, Arc<CellEntries>>>,
+    cell_cache: Mutex<LruCache<u32, Arc<CellEntries>>>,
 }
 
 impl std::fmt::Debug for ZdclBundle {
@@ -152,6 +160,14 @@ impl ZdclBundle {
     /// cell ids by listing entries under `quads/`. The populated-cell set
     /// is cached for the bundle's lifetime.
     pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
+        Self::open_with_capacity(path, ZDCL_BUNDLE_DEFAULT_CACHE_CAP)
+    }
+
+    /// Open a bundle with an explicit per-cell shard LRU cap. Use a
+    /// larger cap for long-running query servers; smaller caps trade
+    /// hit rate for tighter memory use.
+    pub fn open_with_capacity(path: impl AsRef<Path>, cap: usize) -> io::Result<Self> {
+        let cap = NonZeroUsize::new(cap.max(1)).expect("max(1) ensures non-zero");
         let path = path.as_ref();
         let meta = std::fs::metadata(path)?;
         let accessor: Box<dyn SubfileAccessor> = if meta.is_dir() {
@@ -189,7 +205,7 @@ impl ZdclBundle {
             accessor,
             manifest,
             populated_cells,
-            cell_cache: Mutex::new(HashMap::new()),
+            cell_cache: Mutex::new(LruCache::new(cap)),
         })
     }
 
@@ -539,8 +555,9 @@ impl ZdclBundle {
 
     /// Load the per-cell `.zqd` + `.zga` byte buffers (cached).
     fn cell_bytes(&self, cell_id: u32) -> io::Result<Arc<CellEntries>> {
+        // Fast path: LRU hit. `get` promotes the entry to most-recent.
         {
-            let cache = self.cell_cache.lock().expect("cell cache poisoned");
+            let mut cache = self.cell_cache.lock().expect("cell cache poisoned");
             if let Some(entry) = cache.get(&cell_id) {
                 return Ok(Arc::clone(entry));
             }
@@ -561,9 +578,13 @@ impl ZdclBundle {
         });
 
         let mut cache = self.cell_cache.lock().expect("cell cache poisoned");
-        // Lost a race? Use whatever's already there.
-        let entry = cache.entry(cell_id).or_insert_with(|| Arc::clone(&entries));
-        Ok(Arc::clone(entry))
+        // Lost a race? Use whatever's already there so concurrent
+        // callers converge on the same Arc when possible.
+        if let Some(existing) = cache.get(&cell_id) {
+            return Ok(Arc::clone(existing));
+        }
+        cache.put(cell_id, Arc::clone(&entries));
+        Ok(entries)
     }
 
     /// Derive the bundle-depth cell id from a Gaia DR3 `source_id`.


### PR DESCRIPTION
## Summary

Closes #119 and #121.

Both bundle-side caches were unbounded `Mutex<HashMap<...>>`s — entries stayed in memory for the lifetime of the accessor / bundle. Long-running queriers OOMed:

- `bench-bundle` at 5° hint on the depth-9 bundle: malloc denial at case 92.
- `bench-bundle` at 2° hint on the same bundle: malloc denial at case 549.

This PR replaces both with `LruCache<K, V>` from the `lru` crate (v0.18.0), default cap 100,000 entries, override via `open_with_capacity`.

## API change worth flagging

`EntryBytes` lost its lifetime parameter:

```diff
-pub enum EntryBytes<'a> {
-    Mmap(&'a [u8]),
+pub enum EntryBytes {
+    Mmap(Arc<Mmap>),
     Owned(Vec<u8>),
 }
```

The previous `Mmap(&'a [u8])` aliased into `Box<Mmap>` and required the cache never to evict (the unsafe transmute in `FsAccessor::read_entry` extended slice lifetime to `&'_ self`). With LRU eviction that contract breaks. Switching to `Arc<Mmap>` lets callers hold an `EntryBytes` after the LRU drops the slot — the mmap stays alive via the Arc clone — and removes the unsafe block entirely.

`Deref<Target = [u8]>` and `AsRef<[u8]>` are unchanged, so most consumer code compiles without changes.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] `cargo fmt`
- [x] `cargo test --lib` (299 passed)
- [x] `cargo test --test bundle_solve_e2e` (1 passed, exercises the full bundle reader path)
- [ ] Re-run the radius sweep at 0.5° / 1° / 2° / 4° to confirm large-radius benches now complete (filed as a follow-up; will land in `docs/d9-bundle-validation.md` once the sweep finishes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)