### PR TITLE
Solver trace JSON + manim-palette renderer for inspecting solves

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,37 @@ cargo run -p zodiacal-tools --release -- bench-bundle \
     --test-cases-dir ../zodiacal-test-cases/set1-legacy
 ```
 
+### Inspecting individual solves
+
+`bench-bundle --trace-out DIR` emits a `<case>.trace.json` sidecar per
+successful solve, containing the full WCS, the matched quad's four
+(field, catalog) pairs, and every verification matched-pair the solver
+recorded. Useful when you want to see *which* detection became A/B/C/D
+and which top-50 stars verified vs missed.
+
+```bash
+cargo run -p zodiacal-tools --release -- bench-bundle \
+    --bundle-path <bundle.zdcl> \
+    --test-cases-dir ../zodiacal-test-cases/set2-dr3-mag19 \
+    --trace-out /tmp/traces
+```
+
+`scripts/render_solver_trace.py` overlays a trace on its FITS plate using
+the manim default palette (A=red, B=green, C=cyan, D=orange), with
+clipped backbone/reference lines and a dashed AB-diameter validity
+circle. Top-50 verification hits draw as open lime circles, misses as
+crimson ×s, and rank > 50 detections as faint cyan ×s underneath.
+Requires `numpy`, `matplotlib`, and `astropy`.
+
+```bash
+python scripts/render_solver_trace.py \
+    --case 0042 \
+    --fits  /path/to/frame_0042.fits \
+    --src-json  ../zodiacal-test-cases/set2-dr3-mag19/0042.json \
+    --trace /tmp/traces/0042.trace.json \
+    --out   /tmp/0042.png
+```
+
 ## Building Indexes
 
 Zodiacal requires prebuilt index files (`.zdcl`) containing star positions and quad hash codes. These are built from a [starfield](https://github.com/OrbitalCommons/starfield) binary catalog.

--- a/scripts/render_solver_trace.py
+++ b/scripts/render_solver_trace.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Render a FITS plate with the matched quad overlaid using the manim
+default-palette convention.
+
+Inputs:
+  --case        case id (used to look up FITS / JSON / trace)
+  --fits        full path to the FITS frame
+  --src-json    extracted-sources JSON (zodiacal extract output)
+  --trace       bench-bundle --trace-out sidecar
+  --out         output PNG path
+  --hdu         HDU index (default = first 2-D image HDU)
+
+Colour convention (manim default palette):
+  A (anchor)            #FC6255   AB-backbone line          #FFFF00 (yellow)
+  B (backbone tip)      #83C167   AC, AD reference lines    #58C4DD α≈0.55
+  C (interior 1)        #58C4DD   AB-diameter circle        GREY_C dashed
+  D (interior 2)        #FF862F   detected (non top-50)     cyan ×
+
+Quad identification:
+  A, B = the pair with the longest pixel-distance in {p0..p3}.
+  C, D = the remaining two, ordered so C has the smaller x (matches
+         astrometry.net's `cx ≤ dx` disambiguation).
+
+Lines never overlap a vertex's marker disk: segments are clipped at
+each endpoint's circle boundary.
+"""
+import argparse
+import itertools
+import json
+from pathlib import Path
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.patches import Circle
+from astropy.io import fits
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--case", required=True)
+ap.add_argument("--fits", required=True, type=Path)
+ap.add_argument("--src-json", required=True, type=Path)
+ap.add_argument("--trace", required=True, type=Path)
+ap.add_argument("--out", required=True, type=Path)
+ap.add_argument("--hdu", type=int, default=None,
+                help="HDU index. Default: first 2-D image HDU.")
+ap.add_argument("--top-n", type=int, default=50)
+args = ap.parse_args()
+
+# --- palette ---
+COL_A = "#FC6255"   # anchor
+COL_B = "#83C167"   # backbone tip
+COL_C = "#58C4DD"   # interior 1
+COL_D = "#FF862F"   # interior 2
+COL_AB = "#FFFF00"  # AB backbone segment
+COL_AC = "#58C4DD"  # AC/AD reference (semi-saturated)
+COL_VAL_CIRCLE = "0.55"  # grey_c dashed
+COL_HIT = "lime"
+COL_MISS = "crimson"
+COL_NONTOP = "cyan"
+
+trace = json.loads(args.trace.read_text())
+src_json = json.loads(args.src_json.read_text())
+
+hdul = fits.open(args.fits)
+if args.hdu is not None:
+    sci = hdul[args.hdu]
+else:
+    sci = next((h for h in hdul if h.data is not None and h.data.ndim >= 2))
+img = np.squeeze(sci.data).astype(np.float32)
+ny, nx = img.shape
+
+
+def y_flip(y):
+    return (ny - 1) - y
+
+
+sources_sorted = sorted(src_json["sources"], key=lambda s: -s["flux"])
+all_xy = np.array([(s["x"], y_flip(s["y"])) for s in sources_sorted])
+top_xy = all_xy[:args.top_n]
+rest_xy = all_xy[args.top_n:]
+
+quad = trace["quad"]
+quad_field_idx = quad["field_indices"]
+# Quad stars in trace order (matches solver's reordered_orig / index_indices).
+quad_xy = np.array([(c["px"], y_flip(c["py"])) for c in quad["catalog"]])
+
+# --- identify A, B (longest pair), then C, D --------------------------------
+ij_pairs = list(itertools.combinations(range(4), 2))
+dists = [np.hypot(quad_xy[i, 0] - quad_xy[j, 0],
+                  quad_xy[i, 1] - quad_xy[j, 1]) for i, j in ij_pairs]
+ai, bi = ij_pairs[int(np.argmax(dists))]
+others = [k for k in range(4) if k not in (ai, bi)]
+# astrometry.net uses cx ≤ dx (smaller x is C). Use the image-pixel x
+# as the disambiguation since we haven't normalised to code space.
+others_sorted = sorted(others, key=lambda k: quad_xy[k, 0])
+ci, di = others_sorted
+
+A = quad_xy[ai]; B = quad_xy[bi]; C = quad_xy[ci]; D = quad_xy[di]
+quad_field_id = {"A": quad_field_idx[ai], "B": quad_field_idx[bi],
+                 "C": quad_field_idx[ci], "D": quad_field_idx[di]}
+
+verif = trace["verification"]
+matched_field_idx = {m["field_idx"] for m in verif["matches"]}
+matched_xy_cat = np.array([(m["px"], y_flip(m["py"])) for m in verif["matches"]]) \
+    if verif["matches"] else np.zeros((0, 2))
+
+# --- figure ----------------------------------------------------------------
+fig, ax = plt.subplots(figsize=(11, 11))
+finite = img[np.isfinite(img)]
+lo, hi = np.percentile(finite, [10, 99.7])
+disp = np.arcsinh(np.clip(img, lo, hi) - lo)
+ax.imshow(disp, origin="lower", cmap="gray_r", interpolation="nearest")
+
+# Non-top-50 detections — cyan ×s underneath everything else.
+if rest_xy.size:
+    ax.scatter(rest_xy[:, 0], rest_xy[:, 1], s=18, marker="x",
+               color=COL_NONTOP, linewidths=0.9, alpha=0.7,
+               label=f"detected, not used for solve (ranks {args.top_n+1}-{len(all_xy)})")
+
+# Top-50 verification hits / misses (excluding the 4 quad vertices
+# themselves — those get their own bigger A/B/C/D markers below).
+hit_mask = np.array([i in matched_field_idx for i in range(min(args.top_n, len(top_xy)))])
+quad_field_set = set(quad_field_idx)
+miss_xy = []
+hit_xy_top = []
+for i in range(len(hit_mask)):
+    if i in quad_field_set:
+        continue  # drawn as A/B/C/D below
+    (hit_xy_top if hit_mask[i] else miss_xy).append(top_xy[i])
+miss_xy = np.array(miss_xy) if miss_xy else np.zeros((0, 2))
+hit_xy_top = np.array(hit_xy_top) if hit_xy_top else np.zeros((0, 2))
+
+ax.scatter(miss_xy[:, 0], miss_xy[:, 1], s=40, marker="x",
+           color=COL_MISS, linewidths=1.0, alpha=0.85,
+           label=f"top-{args.top_n} verification miss ({len(miss_xy)})")
+ax.scatter(hit_xy_top[:, 0], hit_xy_top[:, 1], s=120, marker="o",
+           facecolors="none", edgecolors=COL_HIT, linewidths=2.0,
+           label=f"top-{args.top_n} verification hit ({len(hit_xy_top)})")
+# Catalog projection for each verification match — open circles
+# (smaller than the detection hit circle) so the underlying source is
+# never covered. Drawn as data-space Circle patches for consistent
+# pixel-radius sizing.
+hit_r = max(20.0, np.hypot(nx, ny) * 0.005)
+for mxy in matched_xy_cat:
+    ax.add_patch(Circle(mxy, hit_r, fill=False, edgecolor=COL_HIT,
+                        lw=1.4, alpha=0.9, zorder=9))
+
+# --- AB-diameter validity circle (dashed grey) -----------------------------
+# Drawn as two arcs that stop where the circle crosses the A and B vertex
+# marker disks, so the dashed line never enters either vertex circle.
+ab_mid = 0.5 * (A + B)
+ab_radius = 0.5 * np.linalg.norm(B - A)
+# We'll need vertex_r below; compute the angular half-gap each vertex
+# carves out of the AB-diameter circle. The vertex disk has radius
+# vertex_r centred on A (or B), and the AB-circle passes through A; the
+# intersection half-angle (as seen from ab_mid) is arccos(1 - r²/(2R²)).
+def _ab_circle_arcs(M, R, A_pt, B_pt, vr):
+    ang_A = np.arctan2(A_pt[1] - M[1], A_pt[0] - M[0])
+    if vr >= R * np.sqrt(2):  # gap exceeds 180°, nothing to draw
+        return []
+    delta = np.arccos(1.0 - (vr * vr) / (2.0 * R * R))
+    # Arc 1: from A+δ to B-δ (= A+π-δ).
+    # Arc 2: from B+δ to A+2π-δ.
+    arc1 = (ang_A + delta, ang_A + np.pi - delta)
+    arc2 = (ang_A + np.pi + delta, ang_A + 2.0 * np.pi - delta)
+    return [arc1, arc2]
+
+# vertex_r is defined just below; compute it inline here to avoid a forward ref.
+_vertex_r_for_arc = max(35.0, np.hypot(nx, ny) * 0.012)
+for (a0, a1) in _ab_circle_arcs(ab_mid, ab_radius, A, B, _vertex_r_for_arc):
+    th = np.linspace(a0, a1, 256)
+    xs = ab_mid[0] + ab_radius * np.cos(th)
+    ys = ab_mid[1] + ab_radius * np.sin(th)
+    ax.plot(xs, ys, color=COL_VAL_CIRCLE, lw=1.4, linestyle="--",
+            alpha=0.85, zorder=8)
+
+# --- quad vertex circles (data-space, so we can clip lines exactly) ---------
+# Marker radius in image pixels — large enough to read at 4k, scaled to
+# the image diagonal so it adapts to plate scale.
+vertex_r = max(35.0, np.hypot(nx, ny) * 0.012)
+
+def add_vertex(p, label, colour):
+    ax.add_patch(Circle(p, vertex_r, fill=False, edgecolor=colour, lw=2.6,
+                        zorder=11))
+    # Annotation just outside the circle so it never covers the source.
+    ang = np.deg2rad({"A": 45, "B": 135, "C": 225, "D": 315}[label])
+    off = np.array([np.cos(ang), np.sin(ang)]) * vertex_r * 1.5
+    ax.annotate(f"{label}\nf{quad_field_id[label]}",
+                xy=p, xytext=p + off, textcoords="data",
+                ha="center", va="center", color=colour,
+                fontsize=11, fontweight="bold",
+                bbox=dict(boxstyle="round,pad=0.25", fc="white",
+                          ec=colour, lw=0.9, alpha=0.95),
+                zorder=12)
+
+add_vertex(A, "A", COL_A)
+add_vertex(B, "B", COL_B)
+add_vertex(C, "C", COL_C)
+add_vertex(D, "D", COL_D)
+
+
+def clipped_segment(p1, p2, r1, r2):
+    """Endpoints of the segment p1→p2 trimmed so it does not enter the
+    disks of radius r1/r2 around p1/p2."""
+    u = p2 - p1
+    L = np.linalg.norm(u)
+    if L <= r1 + r2:
+        return None  # circles touch or overlap; no segment to draw
+    u_hat = u / L
+    return (p1 + r1 * u_hat, p2 - r2 * u_hat)
+
+
+def draw_edge(p1, p2, colour, *, lw, alpha):
+    seg = clipped_segment(p1, p2, vertex_r, vertex_r)
+    if seg is None:
+        return
+    (q1, q2) = seg
+    ax.plot([q1[0], q2[0]], [q1[1], q2[1]], color=colour, lw=lw, alpha=alpha,
+            zorder=10)
+
+# AB backbone — yellow.
+draw_edge(A, B, COL_AB, lw=2.4, alpha=0.95)
+# AC, AD reference lines — semi-saturated cyan.
+draw_edge(A, C, COL_AC, lw=1.6, alpha=0.55)
+draw_edge(A, D, COL_AC, lw=1.6, alpha=0.55)
+
+inst = src_json.get("hst", {}).get("instrument_name", "?")
+target = src_json.get("hst", {}).get("target_name", "")
+err = ((trace["solved"]["ra_deg"]-trace["truth"]["ra_deg"])**2 +
+       (trace["solved"]["dec_deg"]-trace["truth"]["dec_deg"])**2)**0.5 * 3600
+
+ax.set_xlim(0, nx); ax.set_ylim(0, ny); ax.set_aspect("equal")
+ax.set_title(
+    f"{args.case} — {target} ({inst})  {nx}×{ny} px @ "
+    f"{src_json['plate_scale_arcsec']:.4f}\"/px\n"
+    f"quad band {quad['band_idx']} | log_odds={verif['log_odds']:.1f} | "
+    f"n_matched={verif['n_matched']} | n_distractor={verif['n_distractor']} | "
+    f"WCS error {err:.2f}\""
+)
+ax.legend(loc="lower right", fontsize=9)
+fig.tight_layout()
+fig.savefig(args.out, dpi=140, bbox_inches="tight")
+print(f"wrote {args.out}")

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -99,9 +99,14 @@ pub struct SolveStats {
 /// Information about the quad that produced the solution.
 #[derive(Debug, Clone)]
 pub struct QuadMatch {
+    /// Position of the matched index in the `&[&Index]` slice passed
+    /// to [`solve`]. With multi-band bundles each band is one Index,
+    /// so this also identifies the band.
+    pub index_id: usize,
     /// Indices into the field source list.
     pub field_indices: [usize; DIMQUADS],
-    /// Indices into the index star list.
+    /// Indices into the index star list (i.e. into
+    /// `indexes[index_id].stars`).
     pub index_indices: [usize; DIMQUADS],
 }
 
@@ -183,7 +188,7 @@ fn try_quad(
         let reordered_positions: [(f64, f64); DIMQUADS] =
             std::array::from_fn(|i| positions[reordered[i]]);
 
-        for index in indexes {
+        for (index_id, index) in indexes.iter().enumerate() {
             // Skip this index if the backbone angular scale can't overlap
             // with the index's quad scale band.
             if let Some((pix_lo_rad, pix_hi_rad)) = scale_rad {
@@ -271,6 +276,7 @@ fn try_quad(
                         wcs,
                         verify_result,
                         quad_match: QuadMatch {
+                            index_id,
                             field_indices: reordered_orig,
                             index_indices: quad.star_ids,
                         },

--- a/zodiacal-tools/src/bench_bundle.rs
+++ b/zodiacal-tools/src/bench_bundle.rs
@@ -8,17 +8,17 @@
 
 use std::fs;
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use starfield::Equatorial;
 
 use zodiacal::bundle::reader::ZdclBundle;
 use zodiacal::extraction::DetectedSource;
 use zodiacal::geom::sphere::{angular_distance, radec_to_xyz};
 use zodiacal::index::Index;
-use zodiacal::solver::{SkyRegion, SolverConfig, solve};
+use zodiacal::solver::{SkyRegion, Solution, SolverConfig, solve};
 use zodiacal::verify::VerifyConfig;
 
 #[derive(Debug, Deserialize)]
@@ -49,6 +49,12 @@ pub struct BenchBundleConfig {
     pub scale_hint: bool,
     /// Per-case solve timeout (seconds). 0 disables.
     pub timeout_secs: u64,
+    /// Optional directory for per-case `<case>.trace.json` sidecars.
+    /// When set and a case solves, the full solver trace is dumped:
+    /// solved WCS, the matched quad's 4 (field, catalog) pairs, and the
+    /// verification matched-pair list. Useful for visualising hits/
+    /// misses against the source image.
+    pub trace_out: Option<PathBuf>,
 }
 
 pub fn run(cfg: &BenchBundleConfig) -> io::Result<()> {
@@ -78,7 +84,7 @@ pub fn run(cfg: &BenchBundleConfig) -> io::Result<()> {
     );
 
     println!(
-        "case,solved,solve_ms,load_ms,error_arcsec,n_total_quads,n_total_stars,n_verified,best_rejected_log_odds,best_rejected_n_matched,best_rejected_error_arcsec,timed_out"
+        "case,solved,solve_ms,load_ms,error_arcsec,solved_ra_deg,solved_dec_deg,n_total_quads,n_total_stars,n_verified,best_rejected_log_odds,best_rejected_n_matched,best_rejected_error_arcsec,timed_out"
     );
 
     let mut n_solved = 0usize;
@@ -151,9 +157,17 @@ pub fn run(cfg: &BenchBundleConfig) -> io::Result<()> {
             angular_distance(truth_xyz, got_xyz).to_degrees() * 3600.0
         };
 
-        let (solved, error_arcsec) = match solution {
-            Some(sol) => (true, wcs_error_arcsec(&sol.wcs)),
-            None => (false, f64::NAN),
+        let (solved, error_arcsec, solved_ra_deg, solved_dec_deg) = match &solution {
+            Some(sol) => {
+                let (got_ra, got_dec) = sol.wcs.field_center();
+                (
+                    true,
+                    wcs_error_arcsec(&sol.wcs),
+                    got_ra.to_degrees(),
+                    got_dec.to_degrees(),
+                )
+            }
+            None => (false, f64::NAN, f64::NAN, f64::NAN),
         };
 
         let (best_rej_log_odds, best_rej_n_matched, best_rej_error) =
@@ -172,6 +186,15 @@ pub fn run(cfg: &BenchBundleConfig) -> io::Result<()> {
         total_solve_ms += solve_ms;
 
         let case_name = p.file_stem().unwrap().to_string_lossy();
+
+        // Optional per-case trace JSON sidecar. Dumped only on a
+        // successful solve; the renderer uses it to draw the matched
+        // quad and verification hits/misses.
+        if let (Some(out_dir), Some(sol)) = (cfg.trace_out.as_ref(), solution.as_ref()) {
+            std::fs::create_dir_all(out_dir)?;
+            let trace_path = out_dir.join(format!("{case_name}.trace.json"));
+            write_trace(&trace_path, &case_name, &tc, sol, &sources, &indexes)?;
+        }
         let fmt_f = |v: f64| -> String {
             if v.is_nan() {
                 String::new()
@@ -180,13 +203,22 @@ pub fn run(cfg: &BenchBundleConfig) -> io::Result<()> {
             }
         };
         let fmt_i = |v: i64| -> String { if v < 0 { String::new() } else { v.to_string() } };
+        let fmt_deg = |v: f64| -> String {
+            if v.is_nan() {
+                String::new()
+            } else {
+                format!("{:.6}", v)
+            }
+        };
         println!(
-            "{},{},{:.1},{:.1},{},{},{},{},{},{},{},{}",
+            "{},{},{:.1},{:.1},{},{},{},{},{},{},{},{},{},{}",
             case_name,
             solved as u8,
             solve_ms,
             load_ms,
             fmt_f(error_arcsec),
+            fmt_deg(solved_ra_deg),
+            fmt_deg(solved_dec_deg),
             total_quads,
             total_stars,
             stats.n_verified,
@@ -223,5 +255,156 @@ pub fn run(cfg: &BenchBundleConfig) -> io::Result<()> {
     eprintln!("Avg solve:    {:.1} ms", total_solve_ms / n);
     eprintln!("Wall-clock:   {:.1} s", total_elapsed);
 
+    Ok(())
+}
+
+/// Per-case solver trace dumped to `<trace_out>/<case>.trace.json`
+/// when `--trace-out` is passed and the case solves. The schema is
+/// stable enough for downstream renderers to consume directly.
+#[derive(Serialize)]
+struct TraceFile<'a> {
+    case: &'a str,
+    image_width: f64,
+    image_height: f64,
+    truth: TraceCenter,
+    solved: TraceWcs,
+    quad: TraceQuad,
+    verification: TraceVerification,
+}
+
+#[derive(Serialize)]
+struct TraceCenter {
+    ra_deg: f64,
+    dec_deg: f64,
+    plate_scale_arcsec: f64,
+}
+
+#[derive(Serialize)]
+struct TraceWcs {
+    ra_deg: f64,
+    dec_deg: f64,
+    crpix: [f64; 2],
+    cd: [[f64; 2]; 2],
+    image_size: [f64; 2],
+}
+
+#[derive(Serialize)]
+struct TraceQuad {
+    /// Position of the matched index in the band slice (= band index
+    /// for a multi-band bundle).
+    band_idx: usize,
+    /// 4 detected-source indices (into the test-case `sources` list,
+    /// 0-based, in the brightness order the bench passes to `solve`).
+    field_indices: [usize; 4],
+    /// 4 catalog-star pixel positions (post-fit) and sky positions.
+    catalog: [TraceCatalogStar; 4],
+}
+
+#[derive(Serialize)]
+struct TraceCatalogStar {
+    /// Pixel position of the catalog star projected through the
+    /// solver's WCS — what the matched quad's vertex looks like on
+    /// the image after the fit.
+    px: f64,
+    py: f64,
+    ra_deg: f64,
+    dec_deg: f64,
+}
+
+#[derive(Serialize)]
+struct TraceVerification {
+    log_odds: f64,
+    n_matched: usize,
+    n_distractor: usize,
+    /// One entry per accepted match during verification: the field
+    /// source index, the catalog star's projected pixel position, and
+    /// its sky position.
+    matches: Vec<TraceMatch>,
+}
+
+#[derive(Serialize)]
+struct TraceMatch {
+    field_idx: usize,
+    px: f64,
+    py: f64,
+    ra_deg: f64,
+    dec_deg: f64,
+}
+
+fn write_trace(
+    path: &Path,
+    case: &str,
+    tc: &TestCase,
+    sol: &Solution,
+    _sources: &[DetectedSource],
+    indexes: &[Index],
+) -> io::Result<()> {
+    let (got_ra, got_dec) = sol.wcs.field_center();
+    let band = &indexes[sol.quad_match.index_id];
+    let project = |ra: f64, dec: f64| -> (f64, f64) {
+        sol.wcs
+            .radec_to_pixel(ra, dec)
+            .unwrap_or((f64::NAN, f64::NAN))
+    };
+
+    let catalog: [TraceCatalogStar; 4] = std::array::from_fn(|i| {
+        let s = &band.stars[sol.quad_match.index_indices[i]];
+        let (px, py) = project(s.ra, s.dec);
+        TraceCatalogStar {
+            px,
+            py,
+            ra_deg: s.ra.to_degrees(),
+            dec_deg: s.dec.to_degrees(),
+        }
+    });
+
+    let matches: Vec<TraceMatch> = sol
+        .verify_result
+        .matched_pairs
+        .iter()
+        .map(|&(field_idx, ref_idx)| {
+            let s = &band.stars[ref_idx];
+            let (px, py) = project(s.ra, s.dec);
+            TraceMatch {
+                field_idx,
+                px,
+                py,
+                ra_deg: s.ra.to_degrees(),
+                dec_deg: s.dec.to_degrees(),
+            }
+        })
+        .collect();
+
+    let trace = TraceFile {
+        case,
+        image_width: tc.image_width,
+        image_height: tc.image_height,
+        truth: TraceCenter {
+            ra_deg: tc.ra_deg,
+            dec_deg: tc.dec_deg,
+            plate_scale_arcsec: tc.plate_scale_arcsec,
+        },
+        solved: TraceWcs {
+            ra_deg: got_ra.to_degrees(),
+            dec_deg: got_dec.to_degrees(),
+            crpix: sol.wcs.crpix,
+            cd: sol.wcs.cd,
+            image_size: sol.wcs.image_size,
+        },
+        quad: TraceQuad {
+            band_idx: sol.quad_match.index_id,
+            field_indices: sol.quad_match.field_indices,
+            catalog,
+        },
+        verification: TraceVerification {
+            log_odds: sol.verify_result.log_odds,
+            n_matched: sol.verify_result.n_matched,
+            n_distractor: sol.verify_result.n_distractor,
+            matches,
+        },
+    };
+
+    let json = serde_json::to_string_pretty(&trace).map_err(io::Error::other)?;
+    std::fs::write(path, json)?;
     Ok(())
 }

--- a/zodiacal-tools/src/main.rs
+++ b/zodiacal-tools/src/main.rs
@@ -162,6 +162,14 @@ enum Commands {
         /// Per-case solve timeout in seconds. 0 disables.
         #[arg(long, default_value_t = 0)]
         timeout_secs: u64,
+
+        /// Optional directory to write per-case trace JSON sidecars to.
+        /// On a successful solve, emits `<case>.trace.json` containing
+        /// the full WCS, the matched quad's 4 (field, catalog) pairs,
+        /// and the verification matched-pair list (for plotting hits/
+        /// misses against the image).
+        #[arg(long)]
+        trace_out: Option<PathBuf>,
     },
 
     /// Triage why specific bench cases failed. Projects bundle catalog
@@ -363,6 +371,7 @@ fn main() {
             limit,
             scale_hint,
             timeout_secs,
+            trace_out,
         } => {
             let cfg = BenchBundleConfig {
                 bundle_path: bundle_path.clone(),
@@ -371,6 +380,7 @@ fn main() {
                 limit: *limit,
                 scale_hint: *scale_hint,
                 timeout_secs: *timeout_secs,
+                trace_out: trace_out.clone(),
             };
             if let Err(e) = run_bench_bundle(&cfg) {
                 eprintln!("bench-bundle failed: {e}");


### PR DESCRIPTION
## Summary

- `bench-bundle --trace-out DIR` emits `<case>.trace.json` per successful solve, containing the full WCS, the matched quad's four (field, catalog) pairs, and every verification matched-pair.
- `scripts/render_solver_trace.py` overlays a trace on its FITS plate using the manim default palette (A=red, B=green, C=cyan, D=orange) with clipped edges and a dashed AB-diameter validity circle.
- `QuadMatch` now carries `index_id` so the trace can name the band that produced the match.

Built while investigating why bright detections fail verification on older HST imagery — uncovered the missing PM propagation tracked in #125 (M101's rank-4 star is a Gaia DR3 G=15.76 source whose catalog projection lands 9.4 px from the detection because of 13 yr of un-propagated proper motion).

## Test plan
- [x] `cargo fmt`, `cargo clippy --all-targets --workspace -- -D warnings`, `cargo test --lib` (299 pass)
- [x] Re-rendered M101 + 3 Hubble cases end-to-end against an existing depth-9 G≤20 bundle and confirmed the trace JSON / renderer produces sensible overlays
- [ ] Reviewer sanity-check the README walkthrough against a fresh test_cases checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)