### PR TITLE
PM propagation 1/2: IndexStar carries pmra/pmdec + propagate_pm helper

### DIFF
--- a/src/bundle/reader.rs
+++ b/src/bundle/reader.rs
@@ -632,7 +632,8 @@ fn arcsec_to_radians(arcsec: f64) -> f64 {
 /// Construct an `IndexStar` from a 104-byte Gaia record.
 ///
 /// The shard stores RA/Dec in degrees per the spec; the index uses
-/// radians.
+/// radians. Proper-motion fields pass through as-is (mas/yr, Gaia
+/// convention); the shard's NaN sentinel for missing PM is preserved.
 #[inline]
 fn gaia_record_to_index_star(g: &GaiaRecord) -> IndexStar {
     IndexStar {
@@ -640,6 +641,9 @@ fn gaia_record_to_index_star(g: &GaiaRecord) -> IndexStar {
         ra: g.ra.to_radians(),
         dec: g.dec.to_radians(),
         mag: g.phot_g_mean_mag,
+        pmra: g.pmra,
+        pmdec: g.pmdec,
+        ref_epoch: g.ref_epoch,
     }
 }
 

--- a/src/geom/sphere.rs
+++ b/src/geom/sphere.rs
@@ -79,6 +79,47 @@ pub fn star_coords(point: [f64; 3], reference: [f64; 3]) -> Option<(f64, f64)> {
     Some((x, y))
 }
 
+/// Linear proper-motion extrapolation of a catalog position from
+/// `ref_epoch` to `obs_epoch`.
+///
+/// Inputs:
+/// - `ra`, `dec` — sky position at `ref_epoch`, **radians**.
+/// - `pmra`, `pmdec` — Gaia DR3 proper motions in **mas/yr**. `pmra`
+///   carries the cos(dec) factor (Gaia convention), so a true-sky
+///   rate, not a coordinate rate. Either may be NaN; if so the
+///   position is returned unchanged.
+/// - `ref_epoch`, `obs_epoch` — Julian decimal years (e.g. 2016.0).
+///
+/// The math is the standard small-angle linear extrapolation. For
+/// fast-moving stars (~5000 mas/yr) and decade-scale gaps this is
+/// accurate to ~10 µas, far below any pixel tolerance we care about.
+/// Parallax, light-time, and stellar aberration are NOT applied
+/// here — those live in the apparent-place pipeline used by the
+/// `crate::refinement` module.
+pub fn propagate_pm(
+    ra: f64,
+    dec: f64,
+    pmra: f64,
+    pmdec: f64,
+    ref_epoch: f64,
+    obs_epoch: f64,
+) -> (f64, f64) {
+    if pmra.is_nan() || pmdec.is_nan() {
+        return (ra, dec);
+    }
+    let dt_yr = obs_epoch - ref_epoch;
+    // 1 mas = pi / (180 * 3600 * 1000) rad
+    const MAS_TO_RAD: f64 = std::f64::consts::PI / (180.0 * 3600.0 * 1000.0);
+    let cos_dec = dec.cos();
+    // pmra has cos(dec) baked in; divide it out to get the coordinate
+    // rate dRA/dt. cos(dec) is bounded away from zero everywhere except
+    // exactly at the poles; sources within a few arcsec of either pole
+    // are vanishingly rare in Gaia.
+    let dra = pmra * dt_yr * MAS_TO_RAD / cos_dec;
+    let ddec = pmdec * dt_yr * MAS_TO_RAD;
+    (ra + dra, dec + ddec)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -136,6 +177,88 @@ mod tests {
 
         let (_, dec) = xyz_to_radec([0.0, 0.0, -1.0]);
         assert_close(dec, -FRAC_PI_2, EPS);
+    }
+
+    #[test]
+    fn propagate_pm_zero_dt_is_identity() {
+        let ra = 1.234;
+        let dec = 0.567;
+        let (ra2, dec2) = propagate_pm(ra, dec, 12.34, -5.67, 2016.0, 2016.0);
+        assert_close(ra, ra2, EPS);
+        assert_close(dec, dec2, EPS);
+    }
+
+    #[test]
+    fn propagate_pm_nan_pm_is_identity() {
+        let ra = 0.5;
+        let dec = 0.3;
+        // Either NaN component must short-circuit to identity. Gaia
+        // 2-parameter solutions leave both NaN, but defending against
+        // a single NaN component is free.
+        for (pmra, pmdec) in [(f64::NAN, 0.0), (0.0, f64::NAN), (f64::NAN, f64::NAN)] {
+            let (ra2, dec2) = propagate_pm(ra, dec, pmra, pmdec, 2016.0, 2002.0);
+            assert_close(ra, ra2, EPS);
+            assert_close(dec, dec2, EPS);
+        }
+    }
+
+    #[test]
+    fn propagate_pm_known_drift_m101_rank4() {
+        // Gaia DR3 1609274703365302528 (the M101 rank-4 detection from
+        // PR #126's investigation). Verified against the user-space
+        // astropy calculation: 13.126 yr × pmra=-12.145 mas/yr (cos dec
+        // included) → -159.5 mas in true sky, -3.3 mas in declination.
+        let ra_deg: f64 = 210.826611;
+        let dec_deg: f64 = 54.347952;
+        let ra = ra_deg.to_radians();
+        let dec = dec_deg.to_radians();
+        let pmra = -12.14525611646663;
+        let pmdec = -0.25469925378605757;
+        // From Gaia 2016.0 backward to HST DATE-OBS 2002-11-15
+        // midpoint = MJD 52593.98 = decimal year 2002.87392.
+        let (ra2, dec2) = propagate_pm(ra, dec, pmra, pmdec, 2016.0, 2002.87392);
+        let dra_arcsec = (ra2 - ra).to_degrees() * 3600.0 * dec.cos();
+        let ddec_arcsec = (dec2 - dec).to_degrees() * 3600.0;
+        // Expected: -12.145 * (2002.874 - 2016.0) = +159.4 mas RA·cos
+        // (sign: -pmra × negative dt → +mas), +3.3 mas Dec.
+        assert!(
+            (dra_arcsec - 0.1594).abs() < 1e-3,
+            "RA drift mismatch: got {dra_arcsec} arcsec, want ~0.1594"
+        );
+        assert!(
+            (ddec_arcsec - 0.0033).abs() < 1e-3,
+            "Dec drift mismatch: got {ddec_arcsec} arcsec, want ~0.0033"
+        );
+    }
+
+    #[test]
+    fn propagate_pm_sign_convention() {
+        // Positive pmra at positive dt should increase RA (in radians);
+        // positive pmdec at positive dt should increase Dec.
+        let (ra2, dec2) = propagate_pm(1.0, 0.0, 100.0, 100.0, 2000.0, 2010.0);
+        assert!(ra2 > 1.0, "pmra>0, dt>0 should push ra up: got {ra2}");
+        assert!(dec2 > 0.0, "pmdec>0, dt>0 should push dec up: got {dec2}");
+        // And the converse.
+        let (ra2, dec2) = propagate_pm(1.0, 0.0, -100.0, -100.0, 2000.0, 2010.0);
+        assert!(ra2 < 1.0, "pmra<0, dt>0 should pull ra down: got {ra2}");
+        assert!(dec2 < 0.0, "pmdec<0, dt>0 should pull dec down: got {dec2}");
+    }
+
+    #[test]
+    fn propagate_pm_cos_dec_correction() {
+        // At dec = 60°, cos(dec) = 0.5, so a given pmra (which has
+        // cos(dec) baked in) should produce twice the RA-coordinate
+        // change as the same pmra at dec = 0.
+        let pmra = 100.0;
+        let dt = 10.0;
+        let (ra_eq, _) = propagate_pm(0.0, 0.0, pmra, 0.0, 0.0, dt);
+        let (ra_60, _) = propagate_pm(0.0, 60.0_f64.to_radians(), pmra, 0.0, 0.0, dt);
+        // ra change at 60° should be ra_eq / cos(60°) = ra_eq / 0.5
+        let ratio = ra_60 / ra_eq;
+        assert!(
+            (ratio - 2.0).abs() < 1e-9,
+            "ra change at dec=60 should be 2x equator: ratio={ratio}"
+        );
     }
 
     #[test]

--- a/src/index/builder.rs
+++ b/src/index/builder.rs
@@ -221,12 +221,7 @@ pub fn build_index(stars: &[(u64, f64, f64, f64)], config: &IndexBuilderConfig) 
 
     let index_stars: Vec<IndexStar> = sorted
         .iter()
-        .map(|&(id, ra, dec, mag)| IndexStar {
-            catalog_id: id,
-            ra,
-            dec,
-            mag,
-        })
+        .map(|&(id, ra, dec, mag)| IndexStar::without_pm(id, ra, dec, mag))
         .collect();
 
     finish_spinner(
@@ -530,12 +525,7 @@ pub fn build_index_from_catalog(
     let mut stars: Vec<IndexStar> = Vec::new();
     for (_, heap) in cell_heaps {
         for hs in heap {
-            stars.push(IndexStar {
-                catalog_id: hs.id,
-                ra: hs.ra,
-                dec: hs.dec,
-                mag: hs.mag,
-            });
+            stars.push(IndexStar::without_pm(hs.id, hs.ra, hs.dec, hs.mag));
         }
     }
     stars.sort_by(|a, b| {

--- a/src/index/cell_builder.rs
+++ b/src/index/cell_builder.rs
@@ -389,12 +389,7 @@ fn read_cell_artifact(path: &Path) -> io::Result<LoadedCellArtifact> {
         let ra = read_f64(&mut f)?;
         let dec = read_f64(&mut f)?;
         let mag = read_f64(&mut f)?;
-        stars.push(IndexStar {
-            catalog_id,
-            ra,
-            dec,
-            mag,
-        });
+        stars.push(IndexStar::without_pm(catalog_id, ra, dec, mag));
     }
     let mut quads_by_cid: Vec<[u64; DIMQUADS]> = Vec::with_capacity(n_quads);
     for _ in 0..n_quads {

--- a/src/index/live.rs
+++ b/src/index/live.rs
@@ -430,12 +430,12 @@ mod tests {
             let mut stars = Vec::new();
             for i in 0..6 {
                 let frac = i as f64 / 6.0;
-                stars.push(IndexStar {
-                    catalog_id: cell_id * 1000 + i as u64,
-                    ra: ra + frac * 0.005,
-                    dec: dec + frac * 0.005,
-                    mag: 5.0 + frac,
-                });
+                stars.push(IndexStar::without_pm(
+                    cell_id * 1000 + i as u64,
+                    ra + frac * 0.005,
+                    dec + frac * 0.005,
+                    5.0 + frac,
+                ));
             }
             cells.push(MockCell {
                 cell: HealpixCell {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -15,12 +15,44 @@ pub use source::{HealpixCell, IndexFragment, IndexSource, ZdclFile};
 pub use store::load_bundle_bands;
 
 /// Metadata for a star in the index.
+///
+/// `ra` / `dec` are stored in **radians** at `ref_epoch`. `pmra` /
+/// `pmdec` are Gaia DR3 proper motions in **mas/yr** (Gaia convention:
+/// `pmra` already includes the cos(dec) factor). Either PM component
+/// may be NaN to indicate "no proper motion available" (Gaia
+/// 2-parameter solutions, legacy v1/v2 `.zdcl` loads with no Gaia
+/// sidecar). The propagator in `crate::geom::sphere::propagate_pm`
+/// treats NaN PM as identity.
 #[derive(Debug, Clone)]
 pub struct IndexStar {
     pub catalog_id: u64,
     pub ra: f64,
     pub dec: f64,
     pub mag: f64,
+    /// Proper motion in RA, mas/yr (Gaia convention, includes cos(dec)).
+    /// NaN if not available.
+    pub pmra: f64,
+    /// Proper motion in Dec, mas/yr. NaN if not available.
+    pub pmdec: f64,
+    /// Catalog reference epoch, decimal Julian years (Gaia DR3 = 2016.0).
+    pub ref_epoch: f64,
+}
+
+impl IndexStar {
+    /// Build an `IndexStar` from a legacy or test source with no proper
+    /// motion data. `pmra` / `pmdec` are NaN and `ref_epoch` is the
+    /// Gaia DR3 default (2016.0).
+    pub fn without_pm(catalog_id: u64, ra: f64, dec: f64, mag: f64) -> Self {
+        Self {
+            catalog_id,
+            ra,
+            dec,
+            mag,
+            pmra: f64::NAN,
+            pmdec: f64::NAN,
+            ref_epoch: 2016.0,
+        }
+    }
 }
 
 /// Build metadata stored in a v2 index file.

--- a/src/index/source.rs
+++ b/src/index/source.rs
@@ -395,12 +395,7 @@ impl ZdclFile {
         let ra = f64::from_le_bytes(self.mmap[off + 8..off + 16].try_into().unwrap());
         let dec = f64::from_le_bytes(self.mmap[off + 16..off + 24].try_into().unwrap());
         let mag = f64::from_le_bytes(self.mmap[off + 24..off + 32].try_into().unwrap());
-        Ok(IndexStar {
-            catalog_id,
-            ra,
-            dec,
-            mag,
-        })
+        Ok(IndexStar::without_pm(catalog_id, ra, dec, mag))
     }
 
     fn read_quad(&self, idx: usize) -> io::Result<Quad> {
@@ -739,12 +734,12 @@ mod tests {
         let mut stars = Vec::with_capacity(n);
         for i in 0..n {
             let frac = i as f64 / n.max(1) as f64;
-            stars.push(IndexStar {
-                catalog_id: 100 + i as u64,
-                ra: 1.0 + frac * 0.5,
-                dec: 0.3 + frac * 0.4,
-                mag: 5.0 + frac * 5.0,
-            });
+            stars.push(IndexStar::without_pm(
+                100 + i as u64,
+                1.0 + frac * 0.5,
+                0.3 + frac * 0.4,
+                5.0 + frac * 5.0,
+            ));
         }
         let star_points: Vec<[f64; 3]> = stars.iter().map(|s| radec_to_xyz(s.ra, s.dec)).collect();
         let star_indices: Vec<usize> = (0..n).collect();

--- a/src/index/store.rs
+++ b/src/index/store.rs
@@ -234,12 +234,7 @@ fn load_filtered(path: &Path, region_filter: Option<(&SkyRegion, f64)>) -> io::R
             }
         }
         if keep {
-            stars.push(IndexStar {
-                catalog_id,
-                ra,
-                dec,
-                mag,
-            });
+            stars.push(IndexStar::without_pm(catalog_id, ra, dec, mag));
         }
     }
 
@@ -370,12 +365,12 @@ mod tests {
         let mut stars = Vec::with_capacity(num_stars);
         for i in 0..num_stars {
             let frac = i as f64 / num_stars.max(1) as f64;
-            stars.push(IndexStar {
-                catalog_id: (i as u64) * 100 + 1,
-                ra: base_ra + frac * 0.01,
-                dec: base_dec + frac * 0.01,
-                mag: 5.0 + frac * 10.0,
-            });
+            stars.push(IndexStar::without_pm(
+                (i as u64) * 100 + 1,
+                base_ra + frac * 0.01,
+                base_dec + frac * 0.01,
+                5.0 + frac * 10.0,
+            ));
         }
 
         let mut quads = Vec::with_capacity(num_quads);
@@ -582,21 +577,21 @@ mod tests {
         let mut stars = Vec::new();
         for i in 0..n_a {
             let frac = i as f64 / n_a as f64;
-            stars.push(IndexStar {
-                catalog_id: 1000 + i as u64,
-                ra: patch_a[0] + frac * 0.005,
-                dec: patch_a[1] + frac * 0.005,
-                mag: 5.0 + frac,
-            });
+            stars.push(IndexStar::without_pm(
+                1000 + i as u64,
+                patch_a[0] + frac * 0.005,
+                patch_a[1] + frac * 0.005,
+                5.0 + frac,
+            ));
         }
         for i in 0..n_b {
             let frac = i as f64 / n_b as f64;
-            stars.push(IndexStar {
-                catalog_id: 2000 + i as u64,
-                ra: patch_b[0] + frac * 0.005,
-                dec: patch_b[1] + frac * 0.005,
-                mag: 5.0 + frac,
-            });
+            stars.push(IndexStar::without_pm(
+                2000 + i as u64,
+                patch_b[0] + frac * 0.005,
+                patch_b[1] + frac * 0.005,
+                5.0 + frac,
+            ));
         }
 
         // Quads: some entirely within A, some entirely within B, some that

--- a/src/refinement/tests.rs
+++ b/src/refinement/tests.rs
@@ -97,12 +97,7 @@ fn make_scenario() -> (
         let ref_ra = apparent_ra - d_ra;
         let ref_dec = apparent_dec - d_dec;
 
-        index_stars.push(IndexStar {
-            catalog_id: i as u64,
-            ra: ref_ra,
-            dec: ref_dec,
-            mag: i as f64,
-        });
+        index_stars.push(IndexStar::without_pm(i as u64, ref_ra, ref_dec, i as f64));
 
         field_sources.push(DetectedSource {
             x: px,

--- a/src/tweak.rs
+++ b/src/tweak.rs
@@ -340,12 +340,7 @@ mod tests {
                 let py = h * 0.1 + h * 0.8 * (iy as f64) / (side as f64 - 1.0).max(1.0);
                 let (ra, dec) = wcs.pixel_to_radec(px, py);
 
-                stars.push(IndexStar {
-                    catalog_id: count as u64,
-                    ra,
-                    dec,
-                    mag: count as f64,
-                });
+                stars.push(IndexStar::without_pm(count as u64, ra, dec, count as f64));
                 sources.push(DetectedSource {
                     x: px,
                     y: py,
@@ -423,12 +418,12 @@ mod tests {
                 let py = h * 0.1 + h * 0.8 * (iy as f64) / (side as f64 - 1.0);
                 let (ra, dec) = wcs.pixel_to_radec(px, py);
 
-                stars.push(IndexStar {
-                    catalog_id: (iy * side + ix) as u64,
+                stars.push(IndexStar::without_pm(
+                    (iy * side + ix) as u64,
                     ra,
                     dec,
-                    mag: 10.0,
-                });
+                    10.0,
+                ));
 
                 // The field source is at a distorted position.
                 // If the TAN WCS predicts pixel (px, py) for this star,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -254,12 +254,7 @@ mod tests {
             .enumerate()
             .map(|(i, &(px, py))| {
                 let (ra, dec) = wcs.pixel_to_radec(px, py);
-                IndexStar {
-                    catalog_id: i as u64,
-                    ra,
-                    dec,
-                    mag: 10.0,
-                }
+                IndexStar::without_pm(i as u64, ra, dec, 10.0)
             })
             .collect()
     }
@@ -475,12 +470,7 @@ mod tests {
     fn empty_field() {
         let wcs = make_test_wcs();
 
-        let stars = vec![IndexStar {
-            catalog_id: 0,
-            ra: PI,
-            dec: 0.25,
-            mag: 10.0,
-        }];
+        let stars = vec![IndexStar::without_pm(0, PI, 0.25, 10.0)];
         let index = make_test_index(stars);
 
         let field_sources: Vec<DetectedSource> = vec![];


### PR DESCRIPTION
Part 1 of 2 for #125. Pure plumbing — **no solver/verifier behaviour change**.

## What's in

- **`propagate_pm(ra, dec, pmra, pmdec, ref_epoch, obs_epoch) -> (ra, dec)`** in `src/geom/sphere.rs`. Linear small-angle PM extrapolation with NaN-pm = identity. Inputs are radians for ra/dec and Gaia DR3 convention for pmra/pmdec (mas/yr, pmra carries cos(dec)).
- **`IndexStar`** grows from 4 to 7 fields: \`pmra\`, \`pmdec\`, \`ref_epoch\` added.
- **`IndexStar::without_pm(catalog_id, ra, dec, mag)`** convenience constructor for legacy and test sites.
- Bundle reader (`src/bundle/reader.rs`) now threads `pmra`/`pmdec`/`ref_epoch` from the `.zga` shard's `GaiaRecord` straight through to `IndexStar`. The data was already on disk — this is the first time it reaches the runtime struct.
- 13 other constructor sites (legacy `.zdcl` v1/v2 loads, refinement/tweak/verify test scaffolding) switch to `IndexStar::without_pm` and carry NaN PM.

## Next

Part 2 will add `SolverConfig::obs_epoch: Option<f64>` and apply `propagate_pm` at the two read sites (\`solver.rs:209\` quad → WCS fit, \`verify.rs:106\` catalog projection), plus auto-fill obs_epoch from FITS DATE-OBS in \`bench-bundle\`.

## Test plan
- [x] `cargo fmt`, `cargo clippy --all-targets --workspace -- -D warnings`, `cargo test --lib` (304 passing, +5 new propagator tests)
- [x] propagate_pm correctness validated against the M101 rank-4 case from #125 / #126 (verified against external astropy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)