### PR TITLE
PM propagation 2/2: apply at WCS fit + verification, wire bench-bundle --obs-epoch

### DIFF
--- a/src/solver.rs
+++ b/src/solver.rs
@@ -58,6 +58,19 @@ pub struct SolverConfig {
     pub timeout: Option<Duration>,
     /// Only accept solutions whose field center falls within this sky region.
     pub within: Option<SkyRegion>,
+    /// Observation epoch (Julian decimal year). When set, every catalog
+    /// star's `(ra, dec)` is propagated from its `ref_epoch` using its
+    /// `pmra`/`pmdec` via `crate::geom::sphere::propagate_pm` before
+    /// being fed into the WCS fit and the verification step. Stars
+    /// with NaN PM (Gaia 2-parameter solutions or legacy non-Gaia
+    /// indexes) pass through unchanged.
+    ///
+    /// Leave `None` for synthetic test corpora generated at Gaia epoch
+    /// and for legacy `.zdcl` v1/v2 indexes that don't carry PM. Set
+    /// to the plate's observation epoch (e.g. 2002.874 for HST data
+    /// from 2002-11-15) when solving real imagery against a Gaia DR3
+    /// bundle.
+    pub obs_epoch: Option<f64>,
 }
 
 impl Default for SolverConfig {
@@ -69,6 +82,7 @@ impl Default for SolverConfig {
             verify: VerifyConfig::default(),
             timeout: None,
             within: None,
+            obs_epoch: None,
         }
     }
 }
@@ -208,7 +222,18 @@ fn try_quad(
 
                 let star_xyz: [[f64; 3]; DIMQUADS] = std::array::from_fn(|i| {
                     let s = &index.stars[quad.star_ids[i]];
-                    radec_to_xyz(s.ra, s.dec)
+                    let (ra, dec) = match config.obs_epoch {
+                        Some(obs) => crate::geom::sphere::propagate_pm(
+                            s.ra,
+                            s.dec,
+                            s.pmra,
+                            s.pmdec,
+                            s.ref_epoch,
+                            obs,
+                        ),
+                        None => (s.ra, s.dec),
+                    };
+                    radec_to_xyz(ra, dec)
                 });
 
                 // Pre-fit cheap rejection: see issue #48. The eventual fit's
@@ -267,7 +292,8 @@ fn try_quad(
                     continue;
                 }
 
-                let verify_result = verify_solution(&wcs, sources, index, &config.verify);
+                let verify_result =
+                    verify_solution(&wcs, sources, index, &config.verify, config.obs_epoch);
                 stats.n_verified += 1;
 
                 if verify_result.is_accepted(&config.verify) {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -77,6 +77,7 @@ pub fn verify_solution(
     field_sources: &[DetectedSource],
     index: &Index,
     config: &VerifyConfig,
+    obs_epoch: Option<f64>,
 ) -> VerifyResult {
     if field_sources.is_empty() {
         return VerifyResult {
@@ -103,7 +104,18 @@ pub fn verify_solution(
 
     for result in &nearby_results {
         let star = &index.stars[result.index];
-        if let Some((px, py)) = wcs.radec_to_pixel(star.ra, star.dec)
+        let (ra, dec) = match obs_epoch {
+            Some(obs) => crate::geom::sphere::propagate_pm(
+                star.ra,
+                star.dec,
+                star.pmra,
+                star.pmdec,
+                star.ref_epoch,
+                obs,
+            ),
+            None => (star.ra, star.dec),
+        };
+        if let Some((px, py)) = wcs.radec_to_pixel(ra, dec)
             && px >= -margin
             && px <= wcs.image_size[0] + margin
             && py >= -margin
@@ -280,7 +292,7 @@ mod tests {
             .collect();
 
         let config = VerifyConfig::default();
-        let result = verify_solution(&wcs, &field_sources, &index, &config);
+        let result = verify_solution(&wcs, &field_sources, &index, &config, None);
 
         assert!(
             result.log_odds > 0.0,
@@ -321,7 +333,7 @@ mod tests {
             log_odds_bail: f64::NEG_INFINITY,
             ..VerifyConfig::default()
         };
-        let result = verify_solution(&wcs, &field_sources, &index, &config);
+        let result = verify_solution(&wcs, &field_sources, &index, &config, None);
 
         assert_eq!(result.n_matched, 20);
         assert_eq!(result.n_distractor, 0);
@@ -354,7 +366,7 @@ mod tests {
             .collect();
 
         let config = VerifyConfig::default();
-        let result = verify_solution(&wrong_wcs, &field_sources, &index, &config);
+        let result = verify_solution(&wrong_wcs, &field_sources, &index, &config, None);
 
         assert!(
             result.log_odds <= 0.0,
@@ -405,7 +417,7 @@ mod tests {
             min_matches: 3,
             ..VerifyConfig::default()
         };
-        let result = verify_solution(&wcs, &field_sources, &index, &config);
+        let result = verify_solution(&wcs, &field_sources, &index, &config, None);
 
         assert!(
             result.n_matched >= 3,
@@ -457,7 +469,7 @@ mod tests {
             .collect();
 
         let config = VerifyConfig::default();
-        let result = verify_solution(&wrong_wcs, &field_sources, &index, &config);
+        let result = verify_solution(&wrong_wcs, &field_sources, &index, &config, None);
 
         assert!(
             result.log_odds <= 0.0 || result.n_matched == 0,
@@ -476,7 +488,7 @@ mod tests {
         let field_sources: Vec<DetectedSource> = vec![];
 
         let config = VerifyConfig::default();
-        let result = verify_solution(&wcs, &field_sources, &index, &config);
+        let result = verify_solution(&wcs, &field_sources, &index, &config, None);
 
         assert_eq!(result.log_odds, 0.0);
         assert_eq!(result.n_matched, 0);
@@ -571,7 +583,7 @@ mod tests {
             ..VerifyConfig::default()
         };
 
-        let result = verify_solution(&wrong_wcs, &field_sources, &index, &config);
+        let result = verify_solution(&wrong_wcs, &field_sources, &index, &config, None);
 
         let total_examined = result.n_matched + result.n_distractor;
         assert!(
@@ -583,5 +595,89 @@ mod tests {
             "Expected early bail or all sources examined"
         );
         assert!(!result.is_accepted(&config));
+    }
+
+    /// Regression for #125: a catalog star with non-trivial proper motion
+    /// must match its detection only when `obs_epoch` is set and
+    /// `propagate_pm` is applied.
+    ///
+    /// Scenario: detection sits at pixel (300, 400). The catalog star's
+    /// position at the *observation* epoch projects to that pixel. We
+    /// then back-extrapolate the catalog position to a Gaia 2016
+    /// reference epoch by applying the *negative* of the proper motion;
+    /// that's the (ra, dec) we store in the index. Without
+    /// `obs_epoch`, the verifier projects the index's 2016 position and
+    /// misses. With `obs_epoch = obs`, it forward-propagates back to
+    /// the obs position and matches.
+    #[test]
+    fn obs_epoch_recovers_high_pm_star() {
+        let wcs = make_test_wcs();
+
+        // Detection at pixel (300, 400).
+        let det_px = (300.0_f64, 400.0_f64);
+        let (det_ra, det_dec) = wcs.pixel_to_radec(det_px.0, det_px.1);
+        let field_sources = vec![DetectedSource {
+            x: det_px.0,
+            y: det_px.1,
+            flux: 100.0,
+        }];
+
+        // PM in mas/yr. 50 mas/yr × 14 yr = 700 mas drift in RA. At the
+        // synthetic 1″/px plate scale, that's 0.7 px — comfortably
+        // inside the default 5 px match radius, so the test must fail
+        // for the right reason (PM not applied), not because the index
+        // is way off-image.
+        //
+        // Push it harder: 500 mas/yr × 14 yr = 7000 mas = 7″ = 7 px,
+        // outside the default tolerance.
+        let pmra_mas_per_yr = 500.0;
+        let pmdec_mas_per_yr = 200.0;
+        let ref_epoch = 2016.0;
+        let obs_epoch = 2002.0;
+        let dt = obs_epoch - ref_epoch; // negative
+
+        const MAS_TO_RAD: f64 = std::f64::consts::PI / (180.0 * 3600.0 * 1000.0);
+        // Reverse the PM extrapolation: where the star was at ref_epoch
+        // such that at obs_epoch (with the recorded PM) it ends up at
+        // (det_ra, det_dec).
+        let cos_dec = det_dec.cos();
+        let dra = pmra_mas_per_yr * dt * MAS_TO_RAD / cos_dec;
+        let ddec = pmdec_mas_per_yr * dt * MAS_TO_RAD;
+        // Store position at ref_epoch = det position - PM*dt (rearranged
+        // from propagate_pm).
+        let ra_2016 = det_ra - dra;
+        let dec_2016 = det_dec - ddec;
+
+        let star_with_pm = IndexStar {
+            catalog_id: 1,
+            ra: ra_2016,
+            dec: dec_2016,
+            mag: 10.0,
+            pmra: pmra_mas_per_yr,
+            pmdec: pmdec_mas_per_yr,
+            ref_epoch,
+        };
+        let index = make_test_index(vec![star_with_pm]);
+
+        let config = VerifyConfig::default();
+
+        // Without obs_epoch: the catalog projects to its 2016 position,
+        // ~7 px away from the detection — outside the default 5 px
+        // match radius. So this should be a miss.
+        let r_no_pm = verify_solution(&wcs, &field_sources, &index, &config, None);
+        assert_eq!(
+            r_no_pm.n_matched, 0,
+            "Without obs_epoch the high-PM star should miss; got {} matches",
+            r_no_pm.n_matched
+        );
+
+        // With obs_epoch: propagate_pm forwards the catalog position to
+        // 2002, landing on the detection. Now it's a hit.
+        let r_with_pm = verify_solution(&wcs, &field_sources, &index, &config, Some(obs_epoch));
+        assert_eq!(
+            r_with_pm.n_matched, 1,
+            "With obs_epoch the high-PM star should match; got {} matches",
+            r_with_pm.n_matched
+        );
     }
 }

--- a/zodiacal-tools/src/bench_bundle.rs
+++ b/zodiacal-tools/src/bench_bundle.rs
@@ -29,6 +29,18 @@ struct TestCase {
     dec_deg: f64,
     plate_scale_arcsec: f64,
     sources: Vec<TestCaseSource>,
+    #[serde(default)]
+    hst: Option<HstBlock>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HstBlock {
+    /// Exposure start in MJD (Modified Julian Date).
+    #[serde(default)]
+    t_min_mjd: Option<f64>,
+    /// Exposure end in MJD.
+    #[serde(default)]
+    t_max_mjd: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -36,6 +48,27 @@ struct TestCaseSource {
     x: f64,
     y: f64,
     flux: f64,
+}
+
+/// Convert a Modified Julian Date to decimal year (Julian).
+///
+/// MJD 51544.5 = J2000.0 = 2000.0 decimal year. One Julian year is
+/// exactly 365.25 days, so `dy = 2000.0 + (mjd - 51544.5) / 365.25`.
+fn mjd_to_decimal_year(mjd: f64) -> f64 {
+    2000.0 + (mjd - 51544.5) / 365.25
+}
+
+/// If the test case carries an `hst` block with MJD timestamps, return
+/// the exposure midpoint as a decimal-year `obs_epoch` suitable for
+/// PM propagation. Returns `None` for synthetic test corpora.
+fn obs_epoch_from_test_case(tc: &TestCase) -> Option<f64> {
+    let hst = tc.hst.as_ref()?;
+    let mid = match (hst.t_min_mjd, hst.t_max_mjd) {
+        (Some(a), Some(b)) => 0.5 * (a + b),
+        (Some(a), None) | (None, Some(a)) => a,
+        (None, None) => return None,
+    };
+    Some(mjd_to_decimal_year(mid))
 }
 
 pub struct BenchBundleConfig {
@@ -55,6 +88,10 @@ pub struct BenchBundleConfig {
     /// verification matched-pair list. Useful for visualising hits/
     /// misses against the source image.
     pub trace_out: Option<PathBuf>,
+    /// Observation epoch override. When `None`, the harness auto-fills
+    /// from the test case's `hst.t_min_mjd`/`t_max_mjd` midpoint (HST
+    /// cases) and leaves it as `None` for synthetic corpora.
+    pub obs_epoch: Option<f64>,
 }
 
 pub fn run(cfg: &BenchBundleConfig) -> io::Result<()> {
@@ -130,6 +167,10 @@ pub fn run(cfg: &BenchBundleConfig) -> io::Result<()> {
             },
             ..SolverConfig::default()
         };
+        // PM propagation: explicit --obs-epoch wins, otherwise auto-fill
+        // from the HST exposure midpoint when the case carries one.
+        // Synthetic cases at Gaia epoch leave obs_epoch = None (identity).
+        solver_cfg.obs_epoch = cfg.obs_epoch.or_else(|| obs_epoch_from_test_case(&tc));
         if cfg.scale_hint {
             // ±25% tolerance — wide enough to absorb sub-pixel residuals
             // and the scale-vs-band-edge interaction without destroying

--- a/zodiacal-tools/src/main.rs
+++ b/zodiacal-tools/src/main.rs
@@ -170,6 +170,14 @@ enum Commands {
         /// misses against the image).
         #[arg(long)]
         trace_out: Option<PathBuf>,
+
+        /// Observation epoch (Julian decimal year, e.g. 2002.874)
+        /// used to propagate catalog proper motions before the WCS fit
+        /// and verification step. When omitted, HST cases auto-fill
+        /// from `hst.t_min_mjd`/`t_max_mjd` and synthetic Gaia-epoch
+        /// cases default to no propagation.
+        #[arg(long)]
+        obs_epoch: Option<f64>,
     },
 
     /// Triage why specific bench cases failed. Projects bundle catalog
@@ -372,6 +380,7 @@ fn main() {
             scale_hint,
             timeout_secs,
             trace_out,
+            obs_epoch,
         } => {
             let cfg = BenchBundleConfig {
                 bundle_path: bundle_path.clone(),
@@ -381,6 +390,7 @@ fn main() {
                 scale_hint: *scale_hint,
                 timeout_secs: *timeout_secs,
                 trace_out: trace_out.clone(),
+                obs_epoch: *obs_epoch,
             };
             if let Err(e) = run_bench_bundle(&cfg) {
                 eprintln!("bench-bundle failed: {e}");


### PR DESCRIPTION
Part 2 of 2 for #125. Builds on top of #127 (the PM struct plumbing).

## What's in

- **`SolverConfig::obs_epoch: Option<f64>`** — observation epoch as a Julian decimal year. Defaults to None (today's behaviour).
- **\`verify_solution\` signature** grows an \`obs_epoch: Option<f64>\` argument. When \`Some\`, catalog (ra, dec) is forwarded through \`propagate_pm\` before being fed into either the quad-based WCS fit or the verification projection.
- **\`bench-bundle --obs-epoch DECIMAL_YEAR\`** CLI flag. When omitted, the harness auto-fills from the test case's \`hst.t_min_mjd\`/\`t_max_mjd\` midpoint (Hubble cases) and leaves \`obs_epoch = None\` for synthetic Gaia-epoch corpora.
- **Regression test in verify.rs** (\`obs_epoch_recovers_high_pm_star\`): a 500 mas/yr star whose 2016 catalog position projects 7 px from its 2002 detection misses without \`obs_epoch\` and hits with it. This is the exact failure mode the M101 investigation surfaced — see #125 / #126.

## What stays the same

- \`obs_epoch = None\` is a no-op; the synthetic 1000-case bench and every existing test pass unchanged.
- Stars with NaN PM (Gaia 2-parameter solutions, legacy \`.zdcl\` v1/v2 loads) pass through \`propagate_pm\` as identity.
- The bundle on-disk format doesn't change (PR #127 only changed the runtime struct; the data was already in \`.zga\`).

## Stack note

This branch's first commit depends on PR #127 (\`feat/pm-propagation-1-struct\`). Merge order: #127 first, then rebase this one onto main and squash-merge.

## Test plan
- [x] \`cargo fmt\`, \`cargo clippy --all-targets --workspace -- -D warnings\`, \`cargo test --lib\` — **305 pass** (+1 new regression test on top of #127's +5 propagator tests).
- [ ] After both PRs land: run \`bench-bundle --bundle-path <d9 G≤20> --test-cases-dir ../zodiacal-test-cases/hubble-f606w\` and capture the before/after solve count + per-case n_matched delta.
- [ ] Manual sanity: re-render M101 with \`scripts/render_solver_trace.py\` and confirm the rank-4 star turns from a verification miss into a hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)