### PR TITLE
deps: bump starfield 0.11 → 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,9 +2696,8 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "starfield"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b93ef240e0fc643093ef80412cae570bc46a0e802f39fc65b38f4322ece9e1"
+version = "0.12.0"
+source = "git+https://github.com/OrbitalCommons/starfield.git#41839fc85f1e13e68ffe8dd75b1f202fc8483d98"
 dependencies = [
  "base64",
  "byteorder",
@@ -2728,8 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "starfield"
-version = "0.12.0"
-source = "git+https://github.com/OrbitalCommons/starfield.git#41839fc85f1e13e68ffe8dd75b1f202fc8483d98"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5382835eb9ac044f278dba017dbbc6313061d3313948d42e630e13f051e4cb14"
 dependencies = [
  "base64",
  "byteorder",
@@ -3779,7 +3779,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "starfield 0.11.0",
+ "starfield 0.12.2",
  "tempfile",
  "zip",
 ]
@@ -3794,7 +3794,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "starfield 0.11.0",
+ "starfield 0.12.2",
  "starfield-gaia",
  "tempfile",
  "zodiacal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ nalgebra = "0.32"
 rayon = "1.11.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-starfield = "0.11"
+starfield = "0.12"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 lru = "0.18.0"
 

--- a/zodiacal-tools/Cargo.toml
+++ b/zodiacal-tools/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 [dependencies]
 zodiacal = { path = "..", version = "0.4" }
 cdshealpix = "0.9"
-starfield = "0.11"
+starfield = "0.12"
 starfield-gaia = { git = "https://github.com/OrbitalCommons/starfield-datasources" }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION
Pulls in starfield 0.12.2, which ships the \`Arc<Timescale>\` fix from [OrbitalCommons/starfield#134](https://github.com/OrbitalCommons/starfield/issues/134).

Effect: \`sizeof::<Time>\` drops from **528 bytes** to **~136 bytes**, and \`Time::clone\` becomes an O(1) refcount bump instead of an O(table-size) deep copy of the inner Timescale tables. This unblocks the typed PM/epoch refactor tracked in #125 — embedding \`Time\` directly inside row-like structs (e.g. \`IndexStar.ref_epoch\`) is now memory-safe.

## Changes

- \`Cargo.toml\`: \`starfield = "0.11"\` → \`"0.12"\`
- \`zodiacal-tools/Cargo.toml\`: same
- \`Cargo.lock\`: refreshed

Note: \`starfield-gaia\` still pins its own git rev of starfield (0.12.0); cargo resolves both side-by-side and the workspace builds clean.

## Test plan
- [x] \`cargo fmt\` clean
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` clean
- [x] \`cargo test --lib\` — 305/305 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)